### PR TITLE
get notebook css from cdn.jupyter.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ docs/source/api/generated
 docs/source/config/options
 docs/source/interactive/magics-generated.txt
 docs/gh-pages
-jupyter_notebook/notebook/static/mathjax
-jupyter_notebook/static/style/*.map
+nbconvert/resources/style.min.css
 *.py[co]
 __pycache__
 *.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ install:
     - pip install nbconvert[execute,serve,test]
     - python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 script:
-    - nosetests --with-coverage --cover-package nbconvert nbconvert
+    - nosetests -w /tmp --with-coverage --cover-package nbconvert nbconvert
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
     # temporary while renaming propagates
-    - pip install --no-deps -e git+https://github.com/jupyter/jupyter_notebook#egg=jupyter_notebook
     - pip install -f travis-wheels/wheelhouse . coveralls -r requirements.txt
     - pip install nbconvert[execute,serve,test]
     - python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'

--- a/nbconvert/preprocessors/csshtmlheader.py
+++ b/nbconvert/preprocessors/csshtmlheader.py
@@ -50,10 +50,12 @@ class CSSHTMLHeaderPreprocessor(Preprocessor):
         from pygments.formatters import HtmlFormatter
         header = []
         
-        # Construct path to IPy CSS
-        from jupyter_notebook import DEFAULT_STATIC_FILES_PATH
-        sheet_filename = os.path.join(DEFAULT_STATIC_FILES_PATH,
-            'style', 'style.min.css')
+        # Construct path to Jupyter CSS
+        import nbconvert.resources
+        sheet_filename = os.path.join(
+            os.path.dirname(nbconvert.resources.__file__),
+            'style.min.css',
+        )
         
         # Load style CSS file.
         with io.open(sheet_filename, encoding='utf-8') as f:

--- a/nbconvert/preprocessors/csshtmlheader.py
+++ b/nbconvert/preprocessors/csshtmlheader.py
@@ -69,10 +69,15 @@ class CSSHTMLHeaderPreprocessor(Preprocessor):
         # Load the user's custom CSS and IPython's default custom CSS.  If they
         # differ, assume the user has made modifications to his/her custom CSS
         # and that we should inline it in the nbconvert output.
+        try:
+            from notebook import DEFAULT_STATIC_FILES_PATH
+        except ImportError:
+            DEFAULT_STATIC_FILES_PATH = None
+        
         config_dir = resources['config_dir']
         custom_css_filename = os.path.join(config_dir, 'custom', 'custom.css')
         if os.path.isfile(custom_css_filename):
-            if self._default_css_hash is None:
+            if DEFAULT_STATIC_FILES_PATH and self._default_css_hash is None:
                 self._default_css_hash = self._hash(os.path.join(DEFAULT_STATIC_FILES_PATH, 'custom', 'custom.css'))
             if self._hash(custom_css_filename) != self._default_css_hash:
                 with io.open(custom_css_filename, encoding='utf-8') as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@
 -e git+https://github.com/jupyter/jupyter_client.git#egg=jupyter_client
 -e git+https://github.com/ipython/ipython.git#egg=ipython
 -e git+https://github.com/ipython/ipykernel.git#egg=ipykernel
-# -e git+https://github.com/jupyter/jupyter_notebook.git#egg=jupyter_notebook


### PR DESCRIPTION
removes dependency on the notebook package

This will only be 4.0.0-dev while notebook is unreleased, after which point it will be pinned to a stable release, even for dev versions of nbconvert.