### PR TITLE
Add command line switch --abort-on-error to abort conversion if execution fails

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -89,11 +89,10 @@ The currently supported export formats are:
       jupyter nbconvert --to notebook --execute mynotebook.ipynb
 
   will open the notebook, execute it, capture new output, and save the result in
-  :file:`mynotebook.nbconvert.ipynb`. Any exceptions occurring during execution
-  of a cell will not result in an error, but the output from the exception will
-  simply be included in the cell output. If you specify ``--abort-on-error``
-  in addition to the ``--execute`` flag then ``nbconvert`` will abort if an
-  exception occurs during execution.
+  :file:`mynotebook.nbconvert.ipynb`. By default, ``nbconvert`` will abort conversion
+  if any exceptions occur during execution of a cell. If you specify ``--allow-errors``
+  (in addition to the ``--execute`` flag) then conversion will continue and the output
+  from any exception will be included in the cell output.
 
   ::
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -89,7 +89,11 @@ The currently supported export formats are:
       jupyter nbconvert --to notebook --execute mynotebook.ipynb
 
   will open the notebook, execute it, capture new output, and save the result in
-  :file:`mynotebook.nbconvert.ipynb`.
+  :file:`mynotebook.nbconvert.ipynb`. Any exceptions occurring during execution
+  of a cell will not result in an error, but the output from the exception will
+  simply be included in the cell output. If you specify ``--abort-on-error``
+  in addition to the ``--execute`` flag then ``nbconvert`` will abort if an
+  exception occurs during execution.
 
   ::
 

--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -280,7 +280,9 @@ class Exporter(LoggingConfigurable):
     def _preprocess(self, nb, resources):
         """
         Preprocess the notebook before passing it into the Jinja engine.
-        To preprocess the notebook is to apply all of the
+        To preprocess the notebook is to successively apply all the
+        enabled preprocessors. Output from each preprocessor is passed
+        along to the next one.
 
         Parameters
         ----------

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -62,11 +62,12 @@ nbconvert_flags.update({
         {'ExecutePreprocessor' : {'enabled' : True}},
         "Execute the notebook prior to export."
         ),
-    'abort-on-error' : (
-        {'ExecutePreprocessor' : {'abort_on_error' : True}},
-        ("Abort (by raising CellExecutionError) if an error was encountered "
-         "during notebook execution. This flag is only relevant if "
-         "'--execute' was specified, too.")
+    'allow-errors' : (
+        {'ExecutePreprocessor' : {'allow_errors' : True}},
+        ("Continue notebook execution even if one of the cells throws "
+         "an error and include the error message in the cell output "
+         "(the default behaviour is to abort conversion). This flag "
+         "is only relevant if '--execute' was specified, too.")
         ),
     'stdout' : (
         {'NbConvertApp' : {'writer_class' : "StdoutWriter"}},

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -62,6 +62,12 @@ nbconvert_flags.update({
         {'ExecutePreprocessor' : {'enabled' : True}},
         "Execute the notebook prior to export."
         ),
+    'abort-on-error' : (
+        {'ExecutePreprocessor' : {'abort_on_error' : True}},
+        ("Abort (by raising CellExecutionError) if an error was encountered "
+         "during notebook execution. This flag is only relevant if "
+         "'--execute' was specified, too.")
+        ),
     'stdout' : (
         {'NbConvertApp' : {'writer_class' : "StdoutWriter"}},
         "Write notebook output to stdout instead of files."

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -50,7 +50,7 @@ class ExecutePreprocessor(Preprocessor):
         )
     )
 
-    abort_on_error = Bool(
+    allow_errors = Bool(
         False, config=True,
         help=dedent(
             """
@@ -170,7 +170,7 @@ class ExecutePreprocessor(Preprocessor):
             else:
                 outs.append(out)
 
-            if out.output_type == 'error' and self.abort_on_error:
+            if out.output_type == 'error' and not self.allow_errors:
                 raise CellExecutionError(outs)
 
         return outs

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -26,8 +26,8 @@ class CellExecutionError(ConversionException):
     using nbconvert as a library, since it allows to deal with
     failures gracefully.
     """
-    def __init__(self, outputs):
-        self.outputs = outputs
+    def __init__(self, traceback):
+        self.traceback = traceback
 
 
 class ExecutePreprocessor(Preprocessor):
@@ -124,6 +124,9 @@ class ExecutePreprocessor(Preprocessor):
                 else:
                     raise
 
+            if msg['msg_type'] == 'execute_reply' and msg['metadata']['status'] == 'error' and not self.allow_errors:
+                raise CellExecutionError(msg['content']['traceback'])
+
             if msg['parent_header'].get('msg_id') == msg_id:
                 break
             else:
@@ -162,8 +165,6 @@ class ExecutePreprocessor(Preprocessor):
                 continue
             elif msg_type.startswith('comm'):
                 continue
-            elif msg_type == 'error' and not self.allow_errors:
-                raise CellExecutionError(outs)
 
             try:
                 out = output_from_msg(msg)

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -124,11 +124,11 @@ class ExecutePreprocessor(Preprocessor):
                 else:
                     raise
 
-            if msg['msg_type'] == 'execute_reply' and msg['metadata']['status'] == 'error' and not self.allow_errors:
-                raise CellExecutionError(msg['content']['traceback'])
-
             if msg['parent_header'].get('msg_id') == msg_id:
-                break
+                if msg['metadata']['status'] == 'error' and not self.allow_errors:
+                    raise CellExecutionError(msg['content']['traceback'])
+                else:
+                    break
             else:
                 # not our reply
                 continue

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -162,6 +162,8 @@ class ExecutePreprocessor(Preprocessor):
                 continue
             elif msg_type.startswith('comm'):
                 continue
+            elif msg_type == 'error' and not self.allow_errors:
+                raise CellExecutionError(outs)
 
             try:
                 out = output_from_msg(msg)
@@ -169,8 +171,5 @@ class ExecutePreprocessor(Preprocessor):
                 self.log.error("unhandled iopub msg: " + msg_type)
             else:
                 outs.append(out)
-
-            if out.output_type == 'error' and not self.allow_errors:
-                raise CellExecutionError(outs)
 
         return outs

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -129,7 +129,7 @@ class TestExecute(PreprocessorTestsBase):
         filename = os.path.join(current_dir, 'files', 'Disable Stdin.ipynb')
         res = self.build_resources()
         res['metadata']['path'] = os.path.dirname(filename)
-        input_nb, output_nb = self.run_notebook(filename, {}, res)
+        input_nb, output_nb = self.run_notebook(filename, dict(allow_errors=True), res)
 
         # We need to special-case this particular notebook, because the
         # traceback contains machine-specific stuff like where IPython

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -19,7 +19,7 @@ except ImportError:
 import nbformat
 
 from .base import PreprocessorTestsBase
-from ..execute import ExecutePreprocessor
+from ..execute import ExecutePreprocessor, CellExecutionError
 
 from nbconvert.filters import strip_ansi
 from nose.tools import assert_raises
@@ -149,3 +149,13 @@ class TestExecute(PreprocessorTestsBase):
         res = self.build_resources()
         res['metadata']['path'] = os.path.dirname(filename)
         assert_raises(Empty, self.run_notebook, filename, dict(timeout=1), res)
+
+    def test_abort_on_error(self):
+        """
+        Check that conversion is aborted if `abort_on_error` is True.
+        """
+        current_dir = os.path.dirname(__file__)
+        filename = os.path.join(current_dir, 'files', 'Skip Exceptions.ipynb')
+        res = self.build_resources()
+        res['metadata']['path'] = os.path.dirname(filename)
+        assert_raises(CellExecutionError, self.run_notebook, filename, dict(abort_on_error=True), res)

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -150,12 +150,12 @@ class TestExecute(PreprocessorTestsBase):
         res['metadata']['path'] = os.path.dirname(filename)
         assert_raises(Empty, self.run_notebook, filename, dict(timeout=1), res)
 
-    def test_abort_on_error(self):
+    def test_allow_errors(self):
         """
-        Check that conversion is aborted if `abort_on_error` is True.
+        Check that conversion continues if ``allow_errors`` is False.
         """
         current_dir = os.path.dirname(__file__)
         filename = os.path.join(current_dir, 'files', 'Skip Exceptions.ipynb')
         res = self.build_resources()
         res['metadata']['path'] = os.path.dirname(filename)
-        assert_raises(CellExecutionError, self.run_notebook, filename, dict(abort_on_error=True), res)
+        assert_raises(CellExecutionError, self.run_notebook, filename, dict(allow_errors=False), res)

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -106,9 +106,11 @@ class TestExecute(PreprocessorTestsBase):
             if os.path.basename(filename) == "Disable Stdin.ipynb":
                 continue
             elif os.path.basename(filename) == "Interrupt.ipynb":
-                opts = dict(timeout=1, interrupt_on_timeout=True)
+                opts = dict(timeout=1, interrupt_on_timeout=True, allow_errors=True)
+            elif os.path.basename(filename) == "Skip Exceptions.ipynb":
+                opts = dict(allow_errors=True)
             else:
-                opts = {}
+                opts = dict()
             res = self.build_resources()
             res['metadata']['path'] = os.path.dirname(filename)
             input_nb, output_nb = self.run_notebook(filename, opts, res)

--- a/nbconvert/tests/base.py
+++ b/nbconvert/tests/base.py
@@ -131,8 +131,9 @@ class TestsBase(unittest.TestCase):
 
     def nbconvert(self, parameters, ignore_return_code=False):
         """
-        Run nbconvert a, IPython shell command, listening for both Errors and non-zero
-        return codes.
+        Run nbconvert as a shell command, listening for both Errors and
+        non-zero return codes. Returns the tuple (stdout, stderr) of
+        output produced during the nbconvert run.
 
         Parameters
         ----------

--- a/nbconvert/tests/files/notebook3_with_errors.ipynb
+++ b/nbconvert/tests/files/notebook3_with_errors.ipynb
@@ -49,25 +49,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/nbconvert/tests/files/notebook3_with_errors.ipynb
+++ b/nbconvert/tests/files/notebook3_with_errors.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook contains a cell which deliberately throws an exception. This is to test if `nbconvert` stops conversion if both the `--execute` and `--abort-on-error` flags were provided. In the cells before and after the one which raises the exception we compute a couple of numbers. If they exist in the output we know that the respective cells were executed."
+    "This notebook contains a cell which deliberately throws an exception. This is to test if `nbconvert` stops conversion if the flag `--execute` is given without `--allow-errors`. In the cells before and after the one which raises the exception we compute a couple of numbers. If they exist in the output we know that the respective cells were executed."
    ]
   },
   {

--- a/nbconvert/tests/files/notebook3_with_errors.ipynb
+++ b/nbconvert/tests/files/notebook3_with_errors.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Notebook with errors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook contains a cell which deliberately throws an exception. This is to test if `nbconvert` stops conversion if both the `--execute` and `--abort-on-error` flags were provided. In the cells before and after the one which raises the exception we compute a couple of numbers. If they exist in the output we know that the respective cells were executed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Hello world, my number is {}\".format(24 - 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Some text before the error\")\n",
+    "raise RuntimeError(\"This is a deliberate exception\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"The answer to the question about life, the universe and everything is: {}\".format(43 - 1))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -251,17 +251,20 @@ class TestNbConvertApp(TestsBase):
         used in addition.
         """
         with self.create_temp_cwd(['notebook3*.ipynb']):
+            # Convert notebook containing a cell that raises an error,
+            # both without and with cell execution enabled.
             output1, _ = self.nbconvert('--to markdown --stdout notebook3*.ipynb')  # no cell execution
             output2, _ = self.nbconvert('--to markdown --allow-errors --stdout notebook3*.ipynb')  # no cell execution; --allow-errors should have no effect
             output3, _ = self.nbconvert('--execute --allow-errors --to markdown --stdout notebook3*.ipynb')  # with cell execution; errors are allowed
 
-            # Un-executed outputs should have neither of the results
+            # Un-executed outputs should not contain either
+            # of the two numbers computed in the notebook.
             assert '23' not in output1
             assert '42' not in output1
             assert '23' not in output2
             assert '42' not in output2
 
-            # Executed output should have both results
+            # Executed output should contain both numbers.
             assert '23' in output3
             assert '42' in output3
 

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -244,14 +244,16 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile('empty.ipynb')
             assert not os.path.isfile('empty.nbconvert.ipynb')
 
-    def test_abort_on_error(self):
+    def test_allow_errors(self):
         """
-        Verify that conversion is aborted if both '--execute' and '--abort-on-error' are used.
+        Verify that conversion is aborted with '--execute' if an error is
+        encountered, but that conversion continues if '--allow-errors' is
+        used in addition.
         """
         with self.create_temp_cwd(['notebook3*.ipynb']):
-            output1, _ = self.nbconvert('--to markdown --stdout notebook3*.ipynb')
-            output2, _ = self.nbconvert('--abort-on-error --to markdown --stdout notebook3*.ipynb')
-            output3, _ = self.nbconvert('--execute --to markdown --stdout notebook3*.ipynb')
+            output1, _ = self.nbconvert('--to markdown --stdout notebook3*.ipynb')  # no cell execution
+            output2, _ = self.nbconvert('--to markdown --allow-errors --stdout notebook3*.ipynb')  # no cell execution; --allow-errors should have no effect
+            output3, _ = self.nbconvert('--execute --allow-errors --to markdown --stdout notebook3*.ipynb')  # with cell execution; errors are allowed
 
             # Un-executed outputs should have neither of the results
             assert '23' not in output1
@@ -263,6 +265,6 @@ class TestNbConvertApp(TestsBase):
             assert '23' in output3
             assert '42' in output3
 
-            # Executing the notebook with --abort-on-error should raise an exception
+            # Executing the notebook should raise an exception if --allow-errors is not specified
             with assert_raises(OSError):
-                self.nbconvert('--execute --abort-on-error --to markdown --stdout notebook3*.ipynb')
+                self.nbconvert('--execute --to markdown --stdout notebook3*.ipynb')


### PR DESCRIPTION
This PR adds a command line switch `--abort-on-error`. When used in conjunction with `--execute` this will make `nbconvert` abort in case any of the cells raises an exception during execution.

I have added a custom exception which captures the output of the notebook execution until the failure because we have a use case in our group where we need to be able to inspect this. The downside is that it makes the output somewhat noisy when `nbconvert` is used from the command line. Let me know your thoughts and whether you have any suggestions how this can be handled differently in case you think it is a problem. Thanks!