### PR TITLE
two passes through cells

### DIFF
--- a/nbconvert/preprocessors/revealhelp.py
+++ b/nbconvert/preprocessors/revealhelp.py
@@ -36,6 +36,8 @@ class RevealHelpPreprocessor(Preprocessor):
             #Make sure the cell has slideshow metadata.
             cell.metadata.slide_type = cell.get('metadata', {}).get('slideshow', {}).get('slide_type', '-')
 
+        for index, cell in enumerate(nb.cells):
+
             # Get the slide type. If type is start, subslide, or slide,
             # end the last subslide/slide.
             if cell.metadata.slide_type in ['slide']:


### PR DESCRIPTION
This loops through the cells twice to ensure the appropriate metadata exists for all cells before trying to use them.