### PR TITLE
Simplify TemplateExporter

### DIFF
--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -48,14 +48,6 @@ class LatexExporter(TemplateExporter):
 
     def _template_skeleton_path_default(self):
         return os.path.join("..", "templates", "latex", "skeleton")
-
-    #Special Jinja2 syntax that will not conflict when exporting latex.
-    jinja_comment_block_start = Unicode("((=", config=True)
-    jinja_comment_block_end = Unicode("=))", config=True)
-    jinja_variable_block_start = Unicode("(((", config=True)
-    jinja_variable_block_end = Unicode(")))", config=True)
-    jinja_logic_block_start = Unicode("((*", config=True)
-    jinja_logic_block_end = Unicode("*))", config=True)
     
     #Extension that the template files use.    
     template_extension = Unicode(".tplx", config=True)
@@ -94,3 +86,16 @@ class LatexExporter(TemplateExporter):
         self.register_filter('highlight_code',
                              Highlight2Latex(pygments_lexer=lexer, parent=self))
         return super(LatexExporter, self).from_notebook_node(nb, resources, **kw)
+
+    def _create_environment(self):
+        environment = super(LatexExporter, self)._create_environment()
+
+        # Set special Jinja2 syntax that will not conflict with latex.
+        environment.block_start_string = "((*"
+        environment.block_end_string = "*))"
+        environment.variable_start_string = "((("
+        environment.variable_end_string = ")))"
+        environment.comment_start_string = "((="
+        environment.comment_end_string = "=))"
+
+        return environment

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -2,17 +2,8 @@
 that uses Jinja2 to export notebook files into different formats.
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
+# Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
 
 from __future__ import print_function, absolute_import
 
@@ -23,16 +14,12 @@ import os
 # to move ImportErrors to runtime when the requirement is actually needed
 
 # IPython imports
-from traitlets import MetaHasTraits, Unicode, List, Dict, Any
+from traitlets import MetaHasTraits, Unicode, List, Dict
 from ipython_genutils.importstring import import_item
 from ipython_genutils import py3compat
 
 from nbconvert import filters
 from .exporter import Exporter
-
-#-----------------------------------------------------------------------------
-# Globals and constants
-#-----------------------------------------------------------------------------
 
 #Jinja2 extensions to load.
 JINJA_EXTENSIONS = ['jinja2.ext.loopcontrols']
@@ -65,9 +52,6 @@ default_filters = {
         'prevent_list_blocks': filters.prevent_list_blocks,
 }
 
-#-----------------------------------------------------------------------------
-# Class
-#-----------------------------------------------------------------------------
 
 class TemplateExporter(Exporter):
     """
@@ -85,47 +69,69 @@ class TemplateExporter(Exporter):
     __doc__ = __doc__.format(filters = '- '+'\n    - '.join(sorted(default_filters.keys())))
 
 
-    template_file = Unicode(u'default',
-            config=True,
-            help="Name of the template file to use")
+    _template_cached = None
+    def _invalidate_template_cache(self):
+        self._template_cached = None
+
+    @property
+    def template(self):
+        if self._template_cached is None:
+            self._template_cached = self._load_template()
+        return self._template_cached
+
+    _environment_cached = None
+    def _invalidate_environment_cache(self):
+        self._environment_cached = None
+        self._invalidate_template_cache()
+
+    @property
+    def environment(self):
+        if self._environment_cached is None:
+            self._environment_cached = self._create_environment()
+        return self._environment_cached
+
+    template_file = Unicode(config=True,
+            help="Name of the template file to use", affects_template=True)
     def _template_file_changed(self, name, old, new):
         if new == 'default':
             self.template_file = self.default_template
-        else:
-            self.template_file = new
-        self.template = None
-        self._load_template()
-    
-    default_template = Unicode(u'')
-    template = Any()
-    environment = Any()
 
-    template_path = List(['.'], config=True)
-    def _template_path_changed(self, name, old, new):
-        self._load_template()
+    def _template_file_default(self):
+        return self.default_template
+
+    default_template = Unicode(u'', affects_template=True)
+
+    template_path = List(['.'], config=True, affects_template=True)
 
     default_template_path = Unicode(
         os.path.join("..", "templates"), 
-        help="Path where the template files are located.")
+        help="Path where the template files are located.", affects_template=True)
 
     template_skeleton_path = Unicode(
         os.path.join("..", "templates", "skeleton"), 
-        help="Path where the template skeleton files are located.") 
+        help="Path where the template skeleton files are located.",
+        affects_template=True)
 
     #Jinja block definitions
-    jinja_comment_block_start = Unicode("", config=True)
-    jinja_comment_block_end = Unicode("", config=True)
-    jinja_variable_block_start = Unicode("", config=True)
-    jinja_variable_block_end = Unicode("", config=True)
-    jinja_logic_block_start = Unicode("", config=True)
-    jinja_logic_block_end = Unicode("", config=True)
+    jinja_comment_block_start = Unicode("", config=True, affects_environment=True)
+    jinja_comment_block_end = Unicode("", config=True, affects_environment=True)
+    jinja_variable_block_start = Unicode("", config=True, affects_environment=True)
+    jinja_variable_block_end = Unicode("", config=True, affects_environment=True)
+    jinja_logic_block_start = Unicode("", config=True, affects_environment=True)
+    jinja_logic_block_end = Unicode("", config=True, affects_environment=True)
     
     #Extension that the template files use.    
-    template_extension = Unicode(".tpl", config=True)
+    template_extension = Unicode(".tpl", config=True, affects_template=True)
+
+    extra_loaders = List(
+        help="Jinja loaders to find templates. Will be tried in order "
+             "before the default FileSystem ones.",
+        affects_environment=True,
+    )
 
     filters = Dict(config=True,
         help="""Dictionary of filters, by name and namespace, to add to the Jinja
-        environment.""")
+        environment.""", affects_environment=True)
 
     raw_mimetypes = List(config=True,
         help="""formats of raw cells to be included in this Exporter's output."""
@@ -134,7 +140,7 @@ class TemplateExporter(Exporter):
         return [self.output_mimetype, '']
 
 
-    def __init__(self, config=None, extra_loaders=None, **kw):
+    def __init__(self, config=None, **kw):
         """
         Public constructor
     
@@ -150,27 +156,19 @@ class TemplateExporter(Exporter):
         """
         super(TemplateExporter, self).__init__(config=config, **kw)
 
-        #Init
-        self._init_template()
-        self._init_environment(extra_loaders=extra_loaders)
-        self._init_filters()
+        self.on_trait_change(self._invalidate_environment_cache,
+                     list(self.traits(affects_environment=True)))
+        self.on_trait_change(self._invalidate_template_cache,
+                     list(self.traits(affects_template=True)))
 
 
     def _load_template(self):
         """Load the Jinja template object from the template file
         
-        This is a no-op if the template attribute is already defined,
-        or the Jinja environment is not setup yet.
-        
         This is triggered by various trait changes that would change the template.
         """
         from jinja2 import TemplateNotFound
-        
-        if self.template is not None:
-            return
-        # called too early, do nothing
-        if self.environment is None:
-            return
+
         # Try different template names during conversion.  First try to load the
         # template by name with extension added, then try loading the template
         # as if the name is explicitly specified, then try the name as a 
@@ -184,19 +182,19 @@ class TemplateExporter(Exporter):
         for try_name in try_names:
             self.log.debug("Attempting to load template %s", try_name)
             try:
-                self.template = self.environment.get_template(try_name)
+                template = self.environment.get_template(try_name)
             except (TemplateNotFound, IOError):
                 pass
             except Exception as e:
                 self.log.warn("Unexpected exception loading template: %s", try_name, exc_info=True)
             else:
                 self.log.debug("Loaded template %s", try_name)
-                break
+                return template
 
     def from_notebook_node(self, nb, resources=None, **kw):
         """
         Convert a notebook from a notebook node instance.
-    
+
         Parameters
         ----------
         nb : :class:`~nbformat.NotebookNode`
@@ -216,13 +214,12 @@ class TemplateExporter(Exporter):
             raise IOError('template file "%s" could not be found' % self.template_file)
         return output, resources
 
-
-    def register_filter(self, name, jinja_filter):
+    def _register_filter(self, environ, name, jinja_filter):
         """
         Register a filter.
-        A filter is a function that accepts and acts on one string.  
-        The filters are accesible within the Jinja templating engine.
-    
+        A filter is a function that accepts and acts on one string.
+        The filters are accessible within the Jinja templating engine.
+
         Parameters
         ----------
         name : str
@@ -239,83 +236,83 @@ class TemplateExporter(Exporter):
             #filter is a string, import the namespace and recursively call
             #this register_filter method
             filter_cls = import_item(jinja_filter)
-            return self.register_filter(name, filter_cls)
-        
+            return self._register_filter(environ, name, filter_cls)
+
         if constructed and hasattr(jinja_filter, '__call__'):
             #filter is a function, no need to construct it.
-            self.environment.filters[name] = jinja_filter
+            environ.filters[name] = jinja_filter
             return jinja_filter
 
         elif isclass and isinstance(jinja_filter, MetaHasTraits):
-            #filter is configurable.  Make sure to pass in new default for 
+            #filter is configurable.  Make sure to pass in new default for
             #the enabled flag if one was specified.
             filter_instance = jinja_filter(parent=self)
-            self.register_filter(name, filter_instance )
+            self._register_filter(environ, name, filter_instance)
 
         elif isclass:
             #filter is not configurable, construct it
             filter_instance = jinja_filter()
-            self.register_filter(name, filter_instance)
+            self._register_filter(environ, name, filter_instance)
 
         else:
-            #filter is an instance of something without a __call__ 
-            #attribute.  
+            #filter is an instance of something without a __call__
+            #attribute.
             raise TypeError('filter')
 
-        
-    def _init_template(self):
-        """
-        Make sure a template name is specified.  If one isn't specified, try to
-        build one from the information we know.
-        """
-        self._template_file_changed('template_file', self.template_file, self.template_file)
-        
 
-    def _init_environment(self, extra_loaders=None):
+    def register_filter(self, name, jinja_filter):
+        """
+        Register a filter.
+        A filter is a function that accepts and acts on one string.  
+        The filters are accessible within the Jinja templating engine.
+    
+        Parameters
+        ----------
+        name : str
+            name to give the filter in the Jinja engine
+        filter : filter
+        """
+        return self._register_filter(self.environment, name, jinja_filter)
+
+    def _create_environment(self):
         """
         Create the Jinja templating environment.
         """
         from jinja2 import Environment, ChoiceLoader, FileSystemLoader
         here = os.path.dirname(os.path.realpath(__file__))
-        loaders = []
-        if extra_loaders:
-            loaders.extend(extra_loaders)
+        loaders = self.extra_loaders[:]
 
-        paths = self.template_path
-        paths.extend([os.path.join(here, self.default_template_path),
-                      os.path.join(here, self.template_skeleton_path)])
-        loaders.append(FileSystemLoader(paths))
+        paths = self.template_path + \
+            [os.path.join(here, self.default_template_path),
+             os.path.join(here, self.template_skeleton_path)]
+        loaders = self.extra_loaders + [FileSystemLoader(paths)]
 
-        self.environment = Environment(
+        environment = Environment(
             loader= ChoiceLoader(loaders),
             extensions=JINJA_EXTENSIONS
             )
         
         #Set special Jinja2 syntax that will not conflict with latex.
         if self.jinja_logic_block_start:
-            self.environment.block_start_string = self.jinja_logic_block_start
+            environment.block_start_string = self.jinja_logic_block_start
         if self.jinja_logic_block_end:
-            self.environment.block_end_string = self.jinja_logic_block_end
+            environment.block_end_string = self.jinja_logic_block_end
         if self.jinja_variable_block_start:
-            self.environment.variable_start_string = self.jinja_variable_block_start
+            environment.variable_start_string = self.jinja_variable_block_start
         if self.jinja_variable_block_end:
-            self.environment.variable_end_string = self.jinja_variable_block_end
+            environment.variable_end_string = self.jinja_variable_block_end
         if self.jinja_comment_block_start:
-            self.environment.comment_start_string = self.jinja_comment_block_start
+            environment.comment_start_string = self.jinja_comment_block_start
         if self.jinja_comment_block_end:
-            self.environment.comment_end_string = self.jinja_comment_block_end
+            environment.comment_end_string = self.jinja_comment_block_end
 
-    
-    def _init_filters(self):
-        """
-        Register all of the filters required for the exporter.
-        """
-        
         #Add default filters to the Jinja2 environment
         for key, value in default_filters.items():
-            self.register_filter(key, value)
+            self._register_filter(environment, key, value)
 
         #Load user filters.  Overwrite existing filters if need be.
         if self.filters:
             for key, user_filter in self.filters.items():
-                self.register_filter(key, user_filter)
+                self._register_filter(environment, key, user_filter)
+
+        return environment

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -272,7 +272,6 @@ class TemplateExporter(Exporter):
         """
         from jinja2 import Environment, ChoiceLoader, FileSystemLoader
         here = os.path.dirname(os.path.realpath(__file__))
-        loaders = self.extra_loaders[:]
 
         paths = self.template_path + \
             [os.path.join(here, self.default_template_path),

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -111,14 +111,6 @@ class TemplateExporter(Exporter):
         os.path.join("..", "templates", "skeleton"), 
         help="Path where the template skeleton files are located.",
         affects_template=True)
-
-    #Jinja block definitions
-    jinja_comment_block_start = Unicode("", config=True, affects_environment=True)
-    jinja_comment_block_end = Unicode("", config=True, affects_environment=True)
-    jinja_variable_block_start = Unicode("", config=True, affects_environment=True)
-    jinja_variable_block_end = Unicode("", config=True, affects_environment=True)
-    jinja_logic_block_start = Unicode("", config=True, affects_environment=True)
-    jinja_logic_block_end = Unicode("", config=True, affects_environment=True)
     
     #Extension that the template files use.    
     template_extension = Unicode(".tpl", config=True, affects_template=True)
@@ -291,20 +283,6 @@ class TemplateExporter(Exporter):
             loader= ChoiceLoader(loaders),
             extensions=JINJA_EXTENSIONS
             )
-        
-        #Set special Jinja2 syntax that will not conflict with latex.
-        if self.jinja_logic_block_start:
-            environment.block_start_string = self.jinja_logic_block_start
-        if self.jinja_logic_block_end:
-            environment.block_end_string = self.jinja_logic_block_end
-        if self.jinja_variable_block_start:
-            environment.variable_start_string = self.jinja_variable_block_start
-        if self.jinja_variable_block_end:
-            environment.variable_end_string = self.jinja_variable_block_end
-        if self.jinja_comment_block_start:
-            environment.comment_start_string = self.jinja_comment_block_start
-        if self.jinja_comment_block_end:
-            environment.comment_end_string = self.jinja_comment_block_end
 
         #Add default filters to the Jinja2 environment
         for key, value in default_filters.items():


### PR DESCRIPTION
I was finding the code in TemplateExporter hard to follow because it had quite a bit of state, particularly around loading templates.

Because the class stores all the information needed to load the template at any time, storing the loaded template is really a cache. These changes make this explicit.

This has a few functional consequences:

1. Previously you could load a template separately and pass it in to TemplateExporter, at least in principle (I'm not sure if it would actually have worked). This is not possible at present, because the template attribute is considered a cache. However, since most of the logic in TemplateExporter is to set up the environment and load the template, code that wants to load a template itself may be better off not using TemplateExporter.
2. If there's an error in a template (e.g. invalid syntax), with this PR it will escape to the caller. I was confused while trying to make custom templates for Fernando, because it was logging the template error, then continuing and raising a "template file ... could not be found" error instead, which is not really accurate.
3. The template syntax is no longer configurable, instead the Latex overrides are hardcoded. As we're encouraging people to inherit from our templates, it doesn't really make sense to reconfigure the template syntax. If people really need custom syntax, they can still make that work by subclassing `TemplateExporter` in their own code and overriding `_create_environment()`, like `LatexExporter` does here.