### PR TITLE
Add html_head block

### DIFF
--- a/docs/source/customizing.ipynb
+++ b/docs/source/customizing.ipynb
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -118,6 +118,11 @@
        "    padding: 5px;\n",
        "    border: 1px solid hsla(120, 60%, 70%, 0.5);\n",
        "    border-left: 2px solid black;\n",
+       "}\n",
+       "\n",
+       ".template_block pre {\n",
+       "    background: transparent;\n",
+       "    padding: 0;\n",
        "}\n",
        "\n",
        ".big_vertical_ellipsis {\n",
@@ -185,7 +190,39 @@
        "        </div>\n",
        "    </div>\n",
        "    <div class=\"big_vertical_ellipsis\">⋮</div>\n",
-       "</div>\n"
+       "</div>\n",
+       "\n",
+       "<h3>Extra HTML blocks (full.tpl)</h3>\n",
+       "<div class=\"template_block\">header\n",
+       "    <pre>&lt;head&gt;</pre>\n",
+       "    <div class=\"template_block\">html_head</div>\n",
+       "    <pre>&lt;/head&gt;</pre>\n",
+       "</div>\n",
+       "\n",
+       "<h3>Extra Latex blocks</h3>\n",
+       "<div class=\"template_block\">header\n",
+       "    <div class=\"template_block\">docclass</div>\n",
+       "    <div class=\"template_block\">packages</div>\n",
+       "    <div class=\"template_block\">definitions\n",
+       "        <div class=\"template_block\">title</div>\n",
+       "        <div class=\"template_block\">date</div>\n",
+       "        <div class=\"template_block\">author</div>\n",
+       "    </div>\n",
+       "    <div class=\"template_block\">commands\n",
+       "        <div class=\"template_block\">margins</div>\n",
+       "    </div>\n",
+       "</div>\n",
+       "<div class=\"template_block\">body\n",
+       "    <div class=\"template_block\">predoc\n",
+       "        <div class=\"template_block\">maketitle</div>\n",
+       "        <div class=\"template_block\">abstract</div>\n",
+       "    </div>\n",
+       "    ... other fields as above ...\n",
+       "    <div class=\"template_block\">postdoc\n",
+       "        <div class=\"template_block\">bibliography</div>\n",
+       "    </div>\n",
+       "</div>\n",
+       "\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -265,7 +302,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "IPython (Python 3)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -279,7 +316,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3+"
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/docs/source/customizing.rst
+++ b/docs/source/customizing.rst
@@ -90,6 +90,11 @@ described here, though some may define additional blocks.
         border-left: 2px solid black;
     }
     
+    .template_block pre {
+        background: transparent;
+        padding: 0;
+    }
+    
     .big_vertical_ellipsis {
         font-size: 24pt;
     }
@@ -156,6 +161,38 @@ described here, though some may define additional blocks.
         </div>
         <div class="big_vertical_ellipsis">⋮</div>
     </div>
+    
+    <h3>Extra HTML blocks (full.tpl)</h3>
+    <div class="template_block">header
+        <pre>&lt;head&gt;</pre>
+        <div class="template_block">html_head</div>
+        <pre>&lt;/head&gt;</pre>
+    </div>
+    
+    <h3>Extra Latex blocks</h3>
+    <div class="template_block">header
+        <div class="template_block">docclass</div>
+        <div class="template_block">packages</div>
+        <div class="template_block">definitions
+            <div class="template_block">title</div>
+            <div class="template_block">date</div>
+            <div class="template_block">author</div>
+        </div>
+        <div class="template_block">commands
+            <div class="template_block">margins</div>
+        </div>
+    </div>
+    <div class="template_block">body
+        <div class="template_block">predoc
+            <div class="template_block">maketitle</div>
+            <div class="template_block">abstract</div>
+        </div>
+        ... other fields as above ...
+        <div class="template_block">postdoc
+            <div class="template_block">bibliography</div>
+        </div>
+    </div>
+    
 
 
 
@@ -163,7 +200,7 @@ A few gotchas
 ~~~~~~~~~~~~~
 
 Jinja blocks use ``{% %}`` by default which does not play nicely with
-LaTeX, hence thoses are replaced by ``((* *))`` in LaTeX templates.
+LaTeX, so those are replaced by ``((* *))`` in LaTeX templates.
 
 Templates that use cell metadata
 --------------------------------

--- a/docs/source/template_structure.html
+++ b/docs/source/template_structure.html
@@ -15,6 +15,11 @@ body {
     border-left: 2px solid black;
 }
 
+.template_block pre {
+    background: transparent;
+    padding: 0;
+}
+
 .big_vertical_ellipsis {
     font-size: 24pt;
 }
@@ -81,3 +86,35 @@ body {
     </div>
     <div class="big_vertical_ellipsis">⋮</div>
 </div>
+
+<h3>Extra HTML blocks (full.tpl)</h3>
+<div class="template_block">header
+    <pre>&lt;head&gt;</pre>
+    <div class="template_block">html_head</div>
+    <pre>&lt;/head&gt;</pre>
+</div>
+
+<h3>Extra Latex blocks</h3>
+<div class="template_block">header
+    <div class="template_block">docclass</div>
+    <div class="template_block">packages</div>
+    <div class="template_block">definitions
+        <div class="template_block">title</div>
+        <div class="template_block">date</div>
+        <div class="template_block">author</div>
+    </div>
+    <div class="template_block">commands
+        <div class="template_block">margins</div>
+    </div>
+</div>
+<div class="template_block">body
+    <div class="template_block">predoc
+        <div class="template_block">maketitle</div>
+        <div class="template_block">abstract</div>
+    </div>
+    ... other fields as above ...
+    <div class="template_block">postdoc
+        <div class="template_block">bibliography</div>
+    </div>
+</div>
+

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -52,7 +52,7 @@ div#notebook {
 
 <!-- Loading mathjax macro -->
 {{ mathjax() }}
-{%- endblock html_head %-}
+{%- endblock html_head -%}
 </head>
 {%- endblock header -%}
 

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -6,7 +6,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-
+{%- block html_head -%}
 <meta charset="utf-8" />
 <title>{{resources['metadata']['name']}}</title>
 
@@ -52,7 +52,7 @@ div#notebook {
 
 <!-- Loading mathjax macro -->
 {{ mathjax() }}
-
+{%- endblock html_head %-}
 </head>
 {%- endblock header -%}
 


### PR DESCRIPTION
By overriding this, you can add things in the `<head>` tag without having to maintain a copy of the default content that goes there.

Closes #39

I've also documented the extra blocks that are overridable in the HTML and Latex templates. There are quite a few for Latex - do we want to publicly document all of these, or leave some out so we have more flexibility to rearrange them later?