### PR TITLE
Make sure outputs are cleared immediately before execution rather than immediately after

### DIFF
--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -66,8 +66,8 @@ class Exporter(LoggingConfigurable):
     _preprocessors = List()
 
     default_preprocessors = List([
-                                  'nbconvert.preprocessors.ExecutePreprocessor',
                                   'nbconvert.preprocessors.ClearOutputPreprocessor',
+                                  'nbconvert.preprocessors.ExecutePreprocessor',
                                   'nbconvert.preprocessors.coalesce_streams',
                                   'nbconvert.preprocessors.SVG2PDFPreprocessor',
                                   'nbconvert.preprocessors.CSSHTMLHeaderPreprocessor',


### PR DESCRIPTION
The current ordering or preprocessors clears the output fields after executing cells rather than before, so --to notebook no longer leaves results. This affects 3.2 as well.