### PR TITLE
prepare for mistune changes

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -116,4 +116,4 @@ class IPythonRenderer(mistune.Renderer):
 
 def markdown2html_mistune(source):
     """Convert a markdown string to HTML using mistune"""
-    return MarkdownWithMath(renderer=IPythonRenderer()).render(source)
+    return MarkdownWithMath(renderer=IPythonRenderer(escape=False)).render(source)

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
-    'mistune',
+    'mistune!=0.6',
     'jinja2',
     'pygments',
     'traitlets',


### PR DESCRIPTION
- blacklist mistune 0.6, which has some buggy behavior escaping *some* raw html.
- mistune 0.7 will start escaping html by default, so prepare for this with explicit `escape=False`.