### PR TITLE
[Fixes using reveal.js>3] Wait for reveal.js to load before using it.

### DIFF
--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -164,24 +164,31 @@ div.output_prompt {
 
 <script src="{{resources.reveal.url_prefix}}/lib/js/head.min.js"></script>
 
-<script src="{{resources.reveal.url_prefix}}/js/reveal.js"></script>
-
 <script>
+requirejs(["{{resources.reveal.url_prefix}}/js/reveal.js"], function() {
 
-// Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
-Reveal.initialize({
-controls: true,
-progress: true,
-history: true,
+    // Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
+    Reveal.initialize({
+    controls: true,
+    progress: true,
+    history: true,
 
-theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
-transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/concave/zoom/linear/none
+    theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
+    transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/concave/zoom/linear/none
 
-// Optional libraries used to extend on reveal.js
-dependencies: [
-{ src: "{{resources.reveal.url_prefix}}/lib/js/classList.js", condition: function() { return !document.body.classList; } },
-{ src: "{{resources.reveal.url_prefix}}/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
-]
+    // Optional libraries used to extend on reveal.js
+    dependencies: [
+        { src: "{{resources.reveal.url_prefix}}/lib/js/classList.js",
+          condition: function() { return !document.body.classList; } },
+        { src: "{{resources.reveal.url_prefix}}/plugin/notes/notes.js",
+          async: true, condition: function() { return !!document.body.classList; } }
+    ]
+    });
+
+    Reveal.addEventListener( 'slidechanged', function( event ) {
+        window.scrollTo(0,0);
+        MathJax.Hub.Rerender(event.currentSlide);
+    });
 });
 </script>
 
@@ -189,10 +196,6 @@ dependencies: [
 {{ mathjax() }}
 
 <script>
-Reveal.addEventListener( 'slidechanged', function( event ) {
-  window.scrollTo(0,0);
-  MathJax.Hub.Rerender(event.currentSlide);
-});
 </script>
 
 </body>


### PR DESCRIPTION
This issue is described in these places:

http://stackoverflow.com/a/30128179/170656

The solution is described here:

https://github.com/hakimel/reveal.js/issues/389

It turns out that since requirejs is already in the template,
all we have to do is defer the use of Reveal till after
the reveal.js script has loaded.