### PR TITLE
Make slides to work with latest Reveal

### DIFF
--- a/nbconvert/postprocessors/serve.py
+++ b/nbconvert/postprocessors/serve.py
@@ -46,8 +46,8 @@ class ServePostProcessor(PostProcessorBase):
     open_in_browser = Bool(True, config=True,
         help="""Should the browser be opened automatically?"""
     )
-    reveal_cdn = Unicode("https://cdn.jsdelivr.net/reveal.js/2.6.2", config=True,
-        help="""URL for reveal.js CDN."""
+    reveal_cdn = Unicode("https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.1.0",
+        config=True, help="""URL for reveal.js CDN."""
     )
     reveal_prefix = Unicode("reveal.js", config=True, help="URL prefix for reveal.js")
     ip = Unicode("127.0.0.1", config=True, help="The IP address to listen on.")

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -144,9 +144,11 @@ div.output_prompt {
   margin: 5px 5px 0 0;
 }
 div.text_cell.rendered .rendered_html {
+  /* The H1 height seems miscalculated, we are just hidding the scrollbar */
   overflow-y: hidden;
 }
 a.anchor-link {
+  /* There is still an anchor, we are only hidding it */
   display: none;
 }
 .rendered_html p {

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -74,6 +74,9 @@ if( window.location.search.match( /print-pdf/gi ) ) {
 <script src="{{resources.reveal.url_prefix}}/lib/js/html5shiv.js"></script>
 <![endif]-->
 
+<!-- Loading the mathjax macro -->
+{{ mathjax() }}
+
 <!-- Get Font-awesome from cdn -->
 <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
 
@@ -155,9 +158,6 @@ a.anchor-link {
 
 <!-- Custom stylesheet, it must be in the same directory as the html file -->
 <link rel="stylesheet" href="custom.css">
-
-<!-- Loading the mathjax macro -->
-{{ mathjax() }}
 
 </head>
 {% endblock header%}

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -156,6 +156,9 @@ a.anchor-link {
 <!-- Custom stylesheet, it must be in the same directory as the html file -->
 <link rel="stylesheet" href="custom.css">
 
+<!-- Loading the mathjax macro -->
+{{ mathjax() }}
+
 </head>
 {% endblock header%}
 
@@ -168,37 +171,50 @@ a.anchor-link {
 </div>
 </div>
 
-<script src="{{resources.reveal.url_prefix}}/lib/js/head.min.js"></script>
-
-<script src="{{resources.reveal.url_prefix}}/js/reveal.js"></script>
-
 <script>
 
-// Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
-Reveal.initialize({
-controls: true,
-progress: true,
-history: true,
+require(
+    {
+      // for really large notebook this probably makes sense
+      waitSeconds: 30
+    },
+    [
+      "{{resources.reveal.url_prefix}}/lib/js/head.min.js",
+      "{{resources.reveal.url_prefix}}/js/reveal.js"
+    ],
 
-theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
-transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/concave/zoom/linear/none
+    function(head, Reveal){
 
-// Optional libraries used to extend on reveal.js
-dependencies: [
-{ src: "{{resources.reveal.url_prefix}}/lib/js/classList.js", condition: function() { return !document.body.classList; } },
-{ src: "{{resources.reveal.url_prefix}}/plugin/notes/notes.js", async: true, condition: function() { return !!document.body.classList; } }
-]
-});
-</script>
+        // Full list of configuration options available here: https://github.com/hakimel/reveal.js#configuration
+        Reveal.initialize({
+            controls: true,
+            progress: true,
+            history: true,
 
-<!-- Loading mathjax macro -->
-{{ mathjax() }}
+            theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
+            transition: Reveal.getQueryHash().transition || 'linear', // default/cube/page/concave/zoom/linear/none
 
-<script>
-Reveal.addEventListener( 'slidechanged', function( event ) {
-  window.scrollTo(0,0);
-  MathJax.Hub.Rerender(event.currentSlide);
-});
+            // Optional libraries used to extend on reveal.js
+            dependencies: [
+                { src: "{{resources.reveal.url_prefix}}/lib/js/classList.js",
+                  condition: function() { return !document.body.classList; } },
+                { src: "{{resources.reveal.url_prefix}}/plugin/notes/notes.js",
+                  async: true,
+                  condition: function() { return !!document.body.classList; } }
+            ]
+        });
+
+        var update = function(event){
+          window.scrollTo(0,0);
+          if(MathJax.Hub.getAllJax(Reveal.getCurrentSlide())){
+            MathJax.Hub.Rerender(Reveal.getCurrentSlide());
+          }
+        };
+
+        Reveal.addEventListener('slidechanged', update);
+    }
+);
+
 </script>
 
 </body>

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -175,8 +175,9 @@ a.anchor-link {
 
 require(
     {
-      // for really large notebook this probably makes sense
-      waitSeconds: 30
+      // it makes sense to wait a little bit when you are loading
+      // reveal from a cdn in a slow connection environment
+      waitSeconds: 15
     },
     [
       "{{resources.reveal.url_prefix}}/lib/js/head.min.js",
@@ -205,7 +206,6 @@ require(
         });
 
         var update = function(event){
-          window.scrollTo(0,0);
           if(MathJax.Hub.getAllJax(Reveal.getCurrentSlide())){
             MathJax.Hub.Rerender(Reveal.getCurrentSlide());
           }
@@ -214,6 +214,13 @@ require(
         Reveal.addEventListener('slidechanged', update);
         Reveal.addEventListener('fragmentshown', update);
         Reveal.addEventListener('fragmenthidden', update);
+
+        var update_scroll = function(event){
+          $(".reveal").scrollTop(0);
+        };
+
+        Reveal.addEventListener('slidechanged', update_scroll);
+
     }
 );
 

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -88,11 +88,9 @@ if( window.location.search.match( /print-pdf/gi ) ) {
 
 <style type="text/css">
 /* Overrides of notebook CSS for static HTML export */
-html {
-  overflow-y: auto;
-}
 .reveal {
   font-size: 160%;
+  overflow-y: scroll;
 }
 .reveal pre {
   width: inherit;
@@ -212,6 +210,8 @@ require(
         };
 
         Reveal.addEventListener('slidechanged', update);
+        Reveal.addEventListener('fragmentshown', update);
+        Reveal.addEventListener('fragmenthidden', update);
     }
 );
 


### PR DESCRIPTION
Closes #34 

* [x] Change how to load latest reveal
* [x] Update CDN to get the latest `reveal.js`
* [x] Load the mathjax macro in a proper place at `head`