### PR TITLE
Misc TemplateExporter enhancements

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -264,15 +264,17 @@ class TemplateExporter(Exporter):
         """
         return self._register_filter(self.environment, name, jinja_filter)
 
-    def _extra_filters(self):
+    def default_filters(self):
         """Override in subclasses to provide extra filters.
 
-        This should return an iterable of 2-tuples: (name, class-or-function)
+        This should return an iterable of 2-tuples: (name, class-or-function).
+        You should call the method on the parent class and include the filters
+        it provides.
 
-        This is deliberately distinct from config, so that subclasses and user
-        config don't interfere.
+        If a name is repeated, the last filter provided wins. Filters from
+        user-supplied config win over filters provided by classes.
         """
-        return []
+        return default_filters.items()
 
     def _create_environment(self):
         """
@@ -292,11 +294,7 @@ class TemplateExporter(Exporter):
             )
 
         # Add default filters to the Jinja2 environment
-        for key, value in default_filters.items():
-            self._register_filter(environment, key, value)
-
-        # Add filters specified by subclasses
-        for key, value in self._extra_filters():
+        for key, value in self.default_filters():
             self._register_filter(environment, key, value)
 
         # Load user filters.  Overwrite existing filters if need be.

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -264,6 +264,16 @@ class TemplateExporter(Exporter):
         """
         return self._register_filter(self.environment, name, jinja_filter)
 
+    def _extra_filters(self):
+        """Override in subclasses to provide extra filters.
+
+        This should return an iterable of 2-tuples: (name, class-or-function)
+
+        This is deliberately distinct from config, so that subclasses and user
+        config don't interfere.
+        """
+        return []
+
     def _create_environment(self):
         """
         Create the Jinja templating environment.
@@ -281,11 +291,15 @@ class TemplateExporter(Exporter):
             extensions=JINJA_EXTENSIONS
             )
 
-        #Add default filters to the Jinja2 environment
+        # Add default filters to the Jinja2 environment
         for key, value in default_filters.items():
             self._register_filter(environment, key, value)
 
-        #Load user filters.  Overwrite existing filters if need be.
+        # Add filters specified by subclasses
+        for key, value in self._extra_filters():
+            self._register_filter(environment, key, value)
+
+        # Load user filters.  Overwrite existing filters if need be.
         if self.filters:
             for key, user_filter in self.filters.items():
                 self._register_filter(environment, key, user_filter)

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -177,8 +177,6 @@ class TemplateExporter(Exporter):
                 template = self.environment.get_template(try_name)
             except (TemplateNotFound, IOError):
                 pass
-            except Exception as e:
-                self.log.warn("Unexpected exception loading template: %s", try_name, exc_info=True)
             else:
                 self.log.debug("Loaded template %s", try_name)
                 return template


### PR DESCRIPTION
1. When loading a template fails, e.g. because the template syntax is invalid, let the exception raise rather than logging it and carrying on. I claimed that I had made this change in #44, but apparently I lost it somewhere, because I just ran into it again.

2. Add a method for a TemplateExporter subclass to provide extra filters for the template. Before this, there's a fixed set of default templates, and a configurable traitlet for user config to provide filters, but no clear way for a subclass to provide filters. I wanted this at one point while working on #69; I ended up not using it, but it seems like a useful thing to have.