### PR TITLE
Make 'element' available for JS output to add to document

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -9,6 +9,7 @@ from __future__ import print_function, absolute_import
 
 # Stdlib imports
 import os
+import uuid
 
 # other libs/dependencies are imported at runtime
 # to move ImportErrors to runtime when the requirement is actually needed
@@ -282,6 +283,8 @@ class TemplateExporter(Exporter):
             loader= ChoiceLoader(loaders),
             extensions=JINJA_EXTENSIONS
             )
+
+        environment.globals['uuid4'] = uuid.uuid4
 
         #Add default filters to the Jinja2 environment
         for key, value in default_filters.items():

--- a/nbconvert/templates/html/basic.tpl
+++ b/nbconvert/templates/html/basic.tpl
@@ -193,8 +193,11 @@ height={{output.metadata['image/jpeg']['height']}}
 {%- endblock -%}
 
 {%- block data_javascript scoped %}
+{% set div_id = uuid4() %}
+<div id="{{ div_id }}"></div>
 <div class="output_subarea output_javascript {{extra_class}}">
 <script type="text/javascript">
+var element = $('#{{ div_id }}');
 {{ output.data['application/javascript'] }}
 </script>
 </div>


### PR DESCRIPTION
From discussion with Min. JS output in the notebook can add to 'element' to put things on the page in that output area. This adds the same variable for use by JS output in nbconverted HTML.

I'm playing with this in altwidgets-prototype, and it seems to work. I haven't thought through all the possible scoping issues, though.