### PR TITLE
Remove Mathjax render on fragments-related events.

### DIFF
--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -207,8 +207,6 @@ require(
         };
 
         Reveal.addEventListener('slidechanged', update);
-        Reveal.addEventListener('fragmentshown', update);
-        Reveal.addEventListener('fragmenthidden', update);
 
         var update_scroll = function(event){
           $(".reveal").scrollTop(0);


### PR DESCRIPTION
Closes #79

Just what title said... I also PR this against nbviewer here: https://github.com/jupyter/nbviewer/pull/487