### PR TITLE
Add install docs

### DIFF
--- a/docs/source/api/preprocessors.rst
+++ b/docs/source/api/preprocessors.rst
@@ -25,8 +25,6 @@ Specialized preprocessors
 
 .. autoclass:: ExtractOutputPreprocessor
 
-.. autoclass:: RevealHelpPreprocessor
-
 .. autoclass:: LatexPreprocessor
 
 .. autoclass:: CSSHTMLHeaderPreprocessor

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   install
    usage
    config_options
    latex_citations

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,0 +1,29 @@
+Installing nbconvert
+====================
+
+.. seealso::
+
+   `Installing Jupyter <http://jupyter.readthedocs.org/en/latest/install.html>`__
+     Nbconvert is part of the Jupyter ecosystem.
+
+Nbconvert is packaged for both pip and conda, so you can install it with::
+
+    pip install nbconvert
+    # OR
+    conda install nbconvert
+
+If you're new to Python, we recommend installing `Anaconda <http://continuum.io/downloads#py34>`__,
+a Python distribution which includes nbconvert and the other Jupyter components.
+
+Pandoc
+------
+
+For converting markdown to formats other than HTML, nbconvert uses Pandoc_
+(1.12.1 or later).
+
+To install pandoc on Linux, you can generally use your package manager::
+
+    sudo apt-get install pandoc
+
+On other platforms, you can get pandoc from
+`their website <http://johnmacfarlane.net/pandoc/installing.html>`_.


### PR DESCRIPTION
Moving information out of the IPython docs. I think it's worth having brief install documentation on nbconvert to mention the dependency on pandoc.