### PR TITLE
render markdown output in rst

### DIFF
--- a/nbconvert/templates/rst.tpl
+++ b/nbconvert/templates/rst.tpl
@@ -49,6 +49,10 @@
 .. image:: {{ output.metadata.filenames['image/jpeg'] | urlencode }}
 {% endblock data_jpg %}
 
+{% block data_markdown %}
+{{ output.data['text/markdown'] | markdown2rst }}
+{% endblock data_markdown %}
+
 {% block data_latex %}
 .. math::
 

--- a/nbconvert/utils/base.py
+++ b/nbconvert/utils/base.py
@@ -13,7 +13,7 @@ class NbConvertBase(LoggingConfigurable):
     Useful for display data priority that might be use by many transformers
     """
 
-    display_data_priority = List(['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain'],
+    display_data_priority = List(['text/html', 'application/pdf', 'text/latex', 'text/markdown', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain'],
             config=True,
               help= """
                     An ordered list of preferred output type, the first

--- a/nbconvert/utils/base.py
+++ b/nbconvert/utils/base.py
@@ -13,7 +13,7 @@ class NbConvertBase(LoggingConfigurable):
     Useful for display data priority that might be use by many transformers
     """
 
-    display_data_priority = List(['text/html', 'application/pdf', 'text/latex', 'text/markdown', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain'],
+    display_data_priority = List(['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/markdown', 'text/plain'],
             config=True,
               help= """
                     An ordered list of preferred output type, the first


### PR DESCRIPTION
Currently `text/markdown` output is ignored and only `text/plain` is used in conversion to rst.