### PR TITLE
[slides] updating uninitialized resources in from_notebook_node

### DIFF
--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -102,7 +102,7 @@ class SlidesExporter(HTMLExporter):
     output_mimetype = 'text/html'
 
     def from_notebook_node(self, nb, resources=None, **kw):
-        self._init_resources(resources)
+        resources = self._init_resources(resources)
         if 'reveal' not in resources:
             resources['reveal'] = {}
         resources['reveal']['url_prefix'] = self.reveal_url_prefix


### PR DESCRIPTION
Was having a look at options for #43... not sure how we haven't been bitten by this on nbviewer, as we call `from_notebook_node` without `resources`. In some local testing, however, I am seeing `The error was: argument of type 'NoneType' is not iterable`. This fixes it!