### PR TITLE
nbconvert --inplace implies --to notebook

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -75,8 +75,11 @@ nbconvert_flags.update({
         ),
     'inplace' : (
         {
-            'NbConvertApp' : {'use_output_suffix' : False},
-            'FilesWriter': {'build_directory': ''}
+            'NbConvertApp' : {
+                'use_output_suffix' : False,
+                'export_format': 'notebook',
+            },
+            'FilesWriter': {'build_directory': ''},
         },
         """Run nbconvert in place, overwriting the existing notebook (only 
         relevant when converting to notebook format)"""

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -240,9 +240,10 @@ class TestNbConvertApp(TestsBase):
         """
         with self.create_temp_cwd():
             self.create_empty_notebook('empty.ipynb')
-            self.nbconvert('empty.ipynb --to notebook --inplace')
+            self.nbconvert('empty.ipynb --inplace')
             assert os.path.isfile('empty.ipynb')
             assert not os.path.isfile('empty.nbconvert.ipynb')
+            assert not os.path.isfile('empty.html')
 
     def test_allow_errors(self):
         """


### PR DESCRIPTION
Since --inplace only makes sense if using `--to notebook`, it should be implied.