### PR TITLE
Ensure notebooks with strikethroughs compile to pdf

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -32,6 +32,7 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{hyperref}
     \usepackage{longtable} % longtable support required by pandoc >1.10
     \usepackage{booktabs}  % table support for pandoc > 1.12.2
+    \usepackage{ulem} % ulem is needed to support strikethroughs (\sout)
     ((* endblock packages *))
 
     ((* block definitions *))

--- a/nbconvert/tests/files/notebook2.ipynb
+++ b/nbconvert/tests/files/notebook2.ipynb
@@ -1574,6 +1574,13 @@
     "    raise Exception(\"message\")\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This string contains a ~~strikethrough~~, struckthrough. "
+   ]
   }
  ],
  "metadata": {

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -85,6 +85,21 @@ class TestNbConvertApp(TestsBase):
             )
             assert os.path.isfile('notebook with spaces.pdf')
 
+
+    @dec.onlyif_cmds_exist('pdflatex')
+    @dec.onlyif_cmds_exist('pandoc')
+    def test_pdf(self):
+        """
+        Check to see if pdfs compile, even if strikethroughs are included. 
+        """
+        with self.create_temp_cwd(['notebook2.ipynb']):
+            self.nbconvert('--log-level 0 --to pdf'
+                    ' "notebook2"'
+                    ' --PDFExporter.latex_count=1'
+                    ' --PDFExporter.verbose=True'
+            )
+            assert os.path.isfile('notebook2.pdf')
+
     def test_post_processor(self):
         """Do post processors work?"""
         with self.create_temp_cwd(['notebook1.ipynb']):


### PR DESCRIPTION
Added `ulem` dependency to the LaTeX base template to ensure that strikethroughs are properly handled.

Added a test to ensure that pdfs compile and a cell to the  `tests/files/notebook2.ipynb` so that a strikethrough is tested.

Fixes #99 