### PR TITLE
add import line to test notebook

### DIFF
--- a/nbconvert/tests/files/notebook2.ipynb
+++ b/nbconvert/tests/files/notebook2.ipynb
@@ -1569,6 +1569,8 @@
    "metadata": {},
    "source": [
     "```python\n",
+    "import math, numpy\n",
+    "def matrix_calc(L):\n",
     "def foo(bar=1):\n",
     "    \"\"\"docstring\"\"\"\n",
     "    raise Exception(\"message\")\n",
@@ -1579,7 +1581,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This string contains a ~~strikethrough~~, struckthrough. "
+    "This string contains a ~~strikethrough~~, struckthrough. ",
    ]
   }
  ],

--- a/nbconvert/tests/files/notebook2.ipynb
+++ b/nbconvert/tests/files/notebook2.ipynb
@@ -1581,7 +1581,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This string contains a ~~strikethrough~~, struckthrough. ",
+    "This string contains a ~~strikethrough~~, struckthrough. "
    ]
   }
  ],

--- a/nbconvert/tests/files/notebook2.ipynb
+++ b/nbconvert/tests/files/notebook2.ipynb
@@ -1570,9 +1570,11 @@
    "source": [
     "```python\n",
     "import math \n",
-    "import numpy as np\n",",
-    "def matrix_calc(L=np.random.random(size=(1,1))):\n",
+    "import numpy as np\n",
+    "def matrix_calc(L=None):\n",
     "    \"\"\"docstring\"\"\"\n",
+    "    if L is None:",
+    "       L = np.random.random(size=(1,1))",
     "    raise Exception(\"message\")\n",
     "```"
    ]

--- a/nbconvert/tests/files/notebook2.ipynb
+++ b/nbconvert/tests/files/notebook2.ipynb
@@ -1571,7 +1571,6 @@
     "```python\n",
     "import math, numpy\n",
     "def matrix_calc(L):\n",
-    "def foo(bar=1):\n",
     "    \"\"\"docstring\"\"\"\n",
     "    raise Exception(\"message\")\n",
     "```"

--- a/nbconvert/tests/files/notebook2.ipynb
+++ b/nbconvert/tests/files/notebook2.ipynb
@@ -1569,8 +1569,9 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "import math, numpy\n",
-    "def matrix_calc(L):\n",
+    "import math \n",
+    "import numpy as np\n",",
+    "def matrix_calc(L=np.random.random(size=(1,1))):\n",
     "    \"\"\"docstring\"\"\"\n",
     "    raise Exception(\"message\")\n",
     "```"


### PR DESCRIPTION
Adds a line to the notebook2 test notebook to see import and base class token types. The test itself is already incorporated in the `test_pdf` test in `test_nbconvertapp.py` (i.e., it will fail to build if it cannot find token command names).

Closes #111