### PR TITLE
Latex conversion of Latex and Markdown in cell output

### DIFF
--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -59,7 +59,7 @@ class LatexExporter(TemplateExporter):
     def default_config(self):
         c = Config({
             'NbConvertBase': {
-                'display_data_priority' : ['text/latex', 'application/pdf', 'image/png', 'image/jpeg', 'image/svg+xml', 'text/plain']
+                'display_data_priority' : ['text/latex', 'application/pdf', 'image/png', 'image/jpeg', 'image/svg+xml', 'text/markdown', 'text/plain']
                 },
              'ExtractOutputPreprocessor': {
                     'enabled':True

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -181,23 +181,13 @@ This template does not define a docclass, the inheriting class must define this.
 
 % Display latex
 ((* block data_latex -*))
-    ((*- set Data = output.data['text/latex'].split('$$') -*))      
-    ((*- for eq in Data: -*)) 
-        ((*- set eqs = eq.strip() -*)) 
-        ((*- if eqs | length >0: -*)) 
-            ((*- if eqs.startswith('$'): -*)) 
-                ((= In line equation, not a block =))
-                ((( eqs )))
-            ((*- else: -*)) 
-                ((= Replace $ symbols with more explicit, equation block. =))
-                ((*- set Eq = '$$' + eqs + '$$' -*)) 
-                \begin{equation*}\adjustbox{max width=\hsize}{$
-                ((( Eq | strip_dollars )))
-                $}\end{equation*}
-            ((*- endif -*)) 
-       ((*-  endif -*)) 
-    ((*- endfor -*)) 
+    ((( output.data['text/latex'] | citation2latex | strip_files_prefix | markdown2latex )))
 ((* endblock data_latex *))
+
+% Display markdown
+((* block data_markdown -*))
+    ((( output.data['text/markdown'] | citation2latex | strip_files_prefix | markdown2latex )))
+((* endblock data_markdown *))
 
 % Default mechanism for rendering figures
 ((*- block data_png -*))((( draw_figure(output.metadata.filenames['image/png']) )))((*- endblock -*))


### PR DESCRIPTION
Trying to add markdown support for cell output. Also changed the latex output part of the template based on this testcase using `jupyter nbconvert --to pdf testcase.ipynb` :
```Python
from IPython.display import Markdown, Math, Latex
Markdown("Markdown output $a=1$ and $\\varphi = 2$ in the middle of a **sentence**.")

Latex("Latex output $b=1$ and $\\varphi = \\int 2$ in the middle of a sentence.")

Math("Pure Math \\text{ Text }\\varphi")
```
