### PR TITLE
Handle cell execution error in preprocess_cell() not in run_cell()

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -134,11 +134,11 @@ class ExecutePreprocessor(Preprocessor):
                     raise exception("Cell execution timed out, see log"
                                     " for details.")
 
-        if msg['parent_header'].get('msg_id') == msg_id:
-            break
-        else:
-            # not our reply
-            continue
+            if msg['parent_header'].get('msg_id') == msg_id:
+                break
+            else:
+                # not our reply
+                continue
         
         outs = []
 

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -34,7 +34,7 @@ class ExecutePreprocessor(Preprocessor):
     """
     Executes all the cells in a notebook
     """
-    
+
     timeout = Integer(30, config=True,
         help="The time to wait (in seconds) for output from executions."
     )
@@ -43,8 +43,8 @@ class ExecutePreprocessor(Preprocessor):
         False, config=True,
         help=dedent(
             """
-            If execution of a cell times out, interrupt the kernel and 
-            continue executing other cells rather than throwing an error and 
+            If execution of a cell times out, interrupt the kernel and
+            continue executing other cells rather than throwing an error and
             stopping.
             """
         )
@@ -61,7 +61,7 @@ class ExecutePreprocessor(Preprocessor):
             """
         )
     )
-    
+
     extra_arguments = List(Unicode())
 
     def preprocess(self, nb, resources):
@@ -93,10 +93,10 @@ class ExecutePreprocessor(Preprocessor):
         """
         if cell.cell_type != 'code':
             return cell, resources
-        
+
         outputs = self.run_cell(cell)
         cell.outputs = outputs
-    
+
         if not self.allow_errors:
             for out in outputs:
                 if out.output_type == 'error':
@@ -123,9 +123,9 @@ class ExecutePreprocessor(Preprocessor):
             except Empty:
                 self.log.error("""Timeout waiting for execute reply (%is).
                 If your cell should take longer than this, you can increase the timeout with:
-                
+
                     c.ExecutePreprocessor.timeout = SECONDS
-                
+
                 in jupyter_nbconvert_config.py
                 """ % self.timeout)
                 if self.interrupt_on_timeout:
@@ -145,7 +145,7 @@ class ExecutePreprocessor(Preprocessor):
             else:
                 # not our reply
                 continue
-        
+
         outs = []
 
         while True:

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -100,10 +100,16 @@ class ExecutePreprocessor(Preprocessor):
         if not self.allow_errors:
             for out in outputs:
                 if out.output_type == 'error':
-                    msg = 'Error executing the following the notebook cell:\n'
-                    msg += str(cell.source)
-                    raise CellExecutionError(msg)            
-    
+                    pattern = """\
+                        An error occurred while executing the following cell:
+                        ------------------
+                        {cell.source}
+                        ------------------
+
+                        {out.ename}: {out.evalue}
+                        """
+                    msg = dedent(pattern).format(out=out, cell=cell)
+                    raise CellExecutionError(msg)
         return cell, resources
 
 


### PR DESCRIPTION
Delay raising CellExecutionError until the cell output is saved.
In this way, when an execution error occurs, the stack trace is stored in 
the cell output. Also, CellExecutionError is raised with a message showing
the source of the cell causing the error.