### PR TITLE
add get_metadata filter

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -51,6 +51,7 @@ default_filters = {
         'add_prompts': filters.add_prompts,
         'ascii_only': filters.ascii_only,
         'prevent_list_blocks': filters.prevent_list_blocks,
+        'get_metadata': filters.get_metadata,
 }
 
 

--- a/nbconvert/filters/__init__.py
+++ b/nbconvert/filters/__init__.py
@@ -5,5 +5,6 @@ from .highlight import *
 from .latex import *
 from .markdown import *
 from .strings import *
+from .metadata import *
 
 from ipython_genutils.text import indent

--- a/nbconvert/filters/metadata.py
+++ b/nbconvert/filters/metadata.py
@@ -1,0 +1,16 @@
+"""filters for metadata"""
+
+def get_metadata(output, key, mimetype=None):
+    """Resolve an output metadata key
+    
+    If mimetype given, resolve at mimetype level first,
+    then fallback to top-level.
+    Otherwise, just resolve at top-level.
+    Returns None if no data found.
+    """
+    md = output.get('metadata') or {}
+    if mimetype and mimetype in md:
+        value = md[mimetype].get(key)
+        if value is not None:
+            return value
+    return md.get(key)

--- a/nbconvert/filters/tests/test_metadata.py
+++ b/nbconvert/filters/tests/test_metadata.py
@@ -1,0 +1,21 @@
+import nose.tools as nt
+
+from nbconvert.filters import get_metadata
+
+def test_get_metadata():
+    output = {
+        'metadata': {
+            'width': 1,
+            'height': 2,
+            'image/png': {
+                'unconfined': True,
+                'height': 3,
+            }
+        }
+    }
+    nt.assert_is(get_metadata(output, 'nowhere'), None)
+    nt.assert_equal(get_metadata(output, 'height'), 2)
+    nt.assert_equal(get_metadata(output, 'unconfined'), None)
+    nt.assert_equal(get_metadata(output, 'unconfined', 'image/png'), True)
+    nt.assert_equal(get_metadata(output, 'width', 'image/png'), 1)
+    nt.assert_equal(get_metadata(output, 'height', 'image/png'), 3)

--- a/nbconvert/templates/html/basic.tpl
+++ b/nbconvert/templates/html/basic.tpl
@@ -136,13 +136,15 @@ unknown type  {{ cell.type }}
 {%- else %}
 <img src="data:image/png;base64,{{ output.data['image/png'] }}"
 {%- endif %}
-{%- if 'width' in output.metadata.get('image/png', {}) %}
-width={{output.metadata['image/png']['width']}}
+{%- set width=output | get_metadata('width', 'image/png') -%}
+{%- if width is not none %}
+width={{width}}
 {%- endif %}
-{%- if 'height' in output.metadata.get('image/png', {}) %}
-height={{output.metadata['image/png']['height']}}
+{%- set height=output | get_metadata('height', 'image/png') -%}
+{%- if height is not none %}
+height={{height}}
 {%- endif %}
-{%- if output.metadata.get('image/png', {}).get('unconfined') %}
+{%- if output | get_metadata('unconfined', 'image/png') -%}
 class="unconfined"
 {%- endif %}
 >
@@ -156,11 +158,16 @@ class="unconfined"
 {%- else %}
 <img src="data:image/jpeg;base64,{{ output.data['image/jpeg'] }}"
 {%- endif %}
-{%- if 'width' in output.metadata.get('image/jpeg', {}) %}
-width={{output.metadata['image/jpeg']['width']}}
+{%- set width=output | get_metadata('width', 'image/jpeg') -%}
+{%- if width is not none %}
+width={{width}}
 {%- endif %}
-{%- if 'height' in output.metadata.get('image/jpeg', {}) %}
-height={{output.metadata['image/jpeg']['height']}}
+{%- set height=output | get_metadata('height', 'image/jpeg') -%}
+{%- if height is not none %}
+height={{height}}
+{%- endif %}
+{%- if output | get_metadata('unconfined', 'image/jpeg') -%}
+class="unconfined"
 {%- endif %}
 >
 </div>


### PR DESCRIPTION
for extracting output metadata properly

output may be in the top-level, or specified for a particular mimetype

closes #75