### PR TITLE
scrub temporary outputs from PDF export

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -157,6 +157,9 @@ class PDFExporter(LatexExporter):
         # convert output extension to pdf
         # the writer above required it to be tex
         resources['output_extension'] = '.pdf'
+        # clear figure outputs, extracted by latex export,
+        # so we don't claim to be a multi-file export.
+        resources.pop('outputs', None)
         
         return pdf_data, resources
     


### PR DESCRIPTION
avoids downstream writers from thinking PDF is a multi-file export that should be zipped up.

closes #148