### PR TITLE
Make sure env value is always str

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -80,7 +80,7 @@ class PDFExporter(LatexExporter):
         if shell:
             command = subprocess.list2cmdline(command)
         env = os.environ.copy()
-        env['TEXINPUTS'] = os.pathsep.join([self.texinputs, env.get('TEXINPUTS', '')])
+        env['TEXINPUTS'] = str(os.pathsep.join([self.texinputs, env.get('TEXINPUTS', '')]))
         with open(os.devnull, 'rb') as null:
             stdout = subprocess.PIPE if not self.verbose else None
             for index in range(count):


### PR DESCRIPTION
 subprocess.Popen will fail if env contains anything other than str, including unicode