### PR TITLE
--inplace should actually run in-place

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -72,6 +72,7 @@ nbconvert_aliases.update({
     'writer' : 'NbConvertApp.writer_class',
     'post': 'NbConvertApp.postprocessor_class',
     'output': 'NbConvertApp.output_base',
+    'output-dir': 'FilesWriter.build_directory',
     'reveal-prefix': 'SlidesExporter.reveal_url_prefix',
     'nbformat': 'NotebookExporter.nbformat_version',
 })

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -53,9 +53,17 @@ class TestNbConvertApp(TestsBase):
             self.copy_files_to(['notebook*.ipynb'], 'subdir/')
             self.nbconvert('--to python --log-level 0 ' +
                       os.path.join('subdir', '*.ipynb'))
+            assert os.path.isfile(os.path.join('subdir', 'notebook1.py'))
+            assert os.path.isfile(os.path.join('subdir', 'notebook2.py'))
+
+    def test_build_dir(self):
+        """build_directory affects export location"""
+        with self.create_temp_cwd():
+            self.copy_files_to(['notebook*.ipynb'], 'subdir/')
+            self.nbconvert('--to python --log-level 0 --output-dir . ' +
+                      os.path.join('subdir', '*.ipynb'))
             assert os.path.isfile('notebook1.py')
             assert os.path.isfile('notebook2.py')
-
 
     def test_convert_full_qualified_name(self):
         """
@@ -63,12 +71,11 @@ class TestNbConvertApp(TestsBase):
         package, import and use it.
         """
         with self.create_temp_cwd():
-            self.copy_files_to(['notebook*.ipynb'], 'subdir/')
+            self.copy_files_to(['notebook*.ipynb'], 'subdir')
             self.nbconvert('--to nbconvert.tests.fake_exporters.MyExporter --log-level 0 ' +
                       os.path.join('subdir', '*.ipynb'))
-            assert os.path.isfile('notebook1.test_ext')
-            assert os.path.isfile('notebook2.test_ext')
-
+            assert os.path.isfile(os.path.join('subdir', 'notebook1.test_ext'))
+            assert os.path.isfile(os.path.join('subdir', 'notebook2.test_ext'))
 
     def test_explicit(self):
         """

--- a/nbconvert/writers/files.py
+++ b/nbconvert/writers/files.py
@@ -68,10 +68,9 @@ class FilesWriter(WriterBase):
             output_extension = resources.get('output_extension', None)
 
             # Get the relative path for copying files
-            if self.relpath == '':
-                relpath = resources.get('metadata', {}).get('path', '')
-            else:
-                relpath = self.relpath
+            resource_path = resources.get('metadata', {}).get('path', '')
+            relpath = self.relpath or resource_path
+            build_directory = self.build_directory or resource_path
 
             # Write all of the extracted resources to the destination directory.
             # NOTE: WE WRITE EVERYTHING AS-IF IT'S BINARY.  THE EXTRACT FIG
@@ -83,7 +82,7 @@ class FilesWriter(WriterBase):
             for filename, data in items:
 
                 # Determine where to write the file to
-                dest = os.path.join(self.build_directory, filename)
+                dest = os.path.join(build_directory, filename)
                 path = os.path.dirname(dest)
                 self._makedir(path)
 
@@ -93,7 +92,7 @@ class FilesWriter(WriterBase):
                     f.write(data)
 
             # Copy referenced files to output directory
-            if self.build_directory:
+            if build_directory:
                 for filename in self.files:
 
                     # Copy files that match search pattern
@@ -106,13 +105,13 @@ class FilesWriter(WriterBase):
                             dest_filename = matching_filename
 
                         # Make sure folder exists.
-                        dest = os.path.join(self.build_directory, dest_filename)
+                        dest = os.path.join(build_directory, dest_filename)
                         path = os.path.dirname(dest)
                         self._makedir(path)
 
                         # Copy if destination is different.
                         if not os.path.normpath(dest) == os.path.normpath(matching_filename):
-                            self.log.info("Linking %s -> %s", matching_filename, dest)
+                            self.log.info("Copying %s -> %s", matching_filename, dest)
                             link_or_copy(matching_filename, dest)
 
             # Determine where to write conversion results.
@@ -120,8 +119,7 @@ class FilesWriter(WriterBase):
                 dest = notebook_name + output_extension
             else:
                 dest = notebook_name
-            if self.build_directory:
-                dest = os.path.join(self.build_directory, dest)
+            dest = os.path.join(build_directory, dest)
 
             # Write conversion results.
             self.log.info("Writing %i bytes to %s", len(output), dest)

--- a/nbconvert/writers/tests/test_files.py
+++ b/nbconvert/writers/tests/test_files.py
@@ -98,7 +98,7 @@ class Testfiles(TestsBase):
                 self.assertEqual(output, 'b')
 
 
-    def test_builddir(self):
+    def test_build_dir(self):
         """Can FilesWriter write to a build dir correctly?"""
 
         # Work in a temporary directory.
@@ -125,6 +125,20 @@ class Testfiles(TestsBase):
             with open(extracted_file_dest, 'r') as f:
                 output = f.read()
                 self.assertEqual(output, 'b')
+
+    def test_build_dir_default(self):
+        """FilesWriter defaults to input path"""
+        with self.create_temp_cwd():
+            os.mkdir('sub')
+            resources = {
+                'metadata': {'path': 'sub'}
+            }
+            writer = FilesWriter()
+            writer.write(u'content', resources, notebook_name="out")
+            dest = os.path.join('sub', 'out')
+            assert os.path.isfile(dest)
+            with open(dest) as f:
+                self.assertEqual(f.read().strip(), 'content')
 
 
     def test_links(self):


### PR DESCRIPTION
empty build_directory is meant to indicate that exported files are in the same directory as their source.

Use path resource if build_directory is unspecified.