### PR TITLE
adding minimal change to allow just slides sections, etc.

### DIFF
--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -159,13 +159,16 @@ a.anchor-link {
 
 
 {% block body %}
+{% block pre_slides %}
 <body>
+{% endblock pre_slides %}
+
 <div class="reveal">
 <div class="slides">
 {{ super() }}
 </div>
 </div>
-
+{% block post_slides %}
 <script>
 
 require(
@@ -216,10 +219,10 @@ require(
 
     }
 );
-
 </script>
 
 </body>
+{% endblock post_slides %}
 {% endblock body %}
 
 {% block footer %}


### PR DESCRIPTION
This adds two new blocks, `pre_slides` and `post_slides` which allows for `slides_reveal` to be used in a situation where an inheriting template will provide the `<html>` and `<body>`, and all the reveal stuff, basically, just `any_cell`.

nbviewer would like to be the first user of this: jupyter/nbviewer#546!