### PR TITLE
Fix Coverage report submission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ install:
     - python -m ipykernel.kernelspec --user
 script:
     - # need to cd or coverage report broken.
-    - DIR=$(pwd) ; cd /tmp/
-    - nosetests --with-coverage --cover-package nbconvert --cover-inclusive --cover-xml nbconvert --cover-xml-file=$DIR/coverage.xml
+    - cd /tmp/
+    - nosetests --with-coverage --cover-package nbconvert --cover-inclusive --cover-xml nbconvert --cover-xml-file=$TRAVIS_BUILD_DIR/coverage.xml
     - cd -
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,13 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
     - wget http://c90cb902a90d6a506ab3-a24171cbeaa42ce11788f0df3362e902.r46.cf5.rackcdn.com/pandoc-1.15.0.6.tar.gz && tar -xzf pandoc-1.15.0.6.tar.gz
-    - pip install -f travis-wheels/wheelhouse . coveralls codecov
+    - pip install -f travis-wheels/wheelhouse . codecov coverage
     - pip install nbconvert[execute,serve,test]
     - python -m ipykernel.kernelspec --user
 script:
-    - nosetests -w /tmp --with-coverage --cover-package nbconvert nbconvert
+    - # need to cd or coverage report broken.
+    - DIR=$(pwd) ; cd /tmp/
+    - nosetests --with-coverage --cover-package nbconvert --cover-inclusive --cover-xml nbconvert --cover-xml-file=$DIR/coverage.xml
+    - cd -
 after_success:
-    - coveralls
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 script:
     - # need to cd or coverage report broken.
     - cd /tmp/
-    - nosetests --with-coverage --cover-package nbconvert --cover-inclusive --cover-xml nbconvert --cover-xml-file=$TRAVIS_BUILD_DIR/coverage.xml
+    - nosetests nbconvert --with-coverage --cover-package nbconvert --cover-inclusive --cover-xml --cover-xml-file=$TRAVIS_BUILD_DIR/coverage.xml
     - cd -
 after_success:
     - codecov


### PR DESCRIPTION
Nose + temp-dir does not behave well with coverage report.
We have to cd in the tmp dir manually and set up the covergge file by
hand.