### PR TITLE
Allow --stdin for nbconvert (alternative command line interface)

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,8 @@
 Changes in nbconvert
 ====================
 
+- allow nbconvert reading from stdin with "--stdin" option (write into "notebook" basename)
+
 4.1
 ---
 

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -71,7 +71,11 @@ nbconvert_flags.update({
          "is only relevant if '--execute' was specified, too.")
         ),
     'stdin' : (
-        {'NbConvertApp' : {'from_stdin' : True}},
+        {'NbConvertApp' : {
+            'from_stdin' : True,
+            'writer_class':'StdoutWriter'
+            }
+        },
         "read a single notebook file from stdin, and write the converted result to stdout. Implies `--stdout`"
         ),
     'stdout' : (
@@ -192,9 +196,6 @@ class NbConvertApp(JupyterApp):
             new = self.writer_aliases[new.lower()]
         self.writer_factory = import_item(new)
 
-    def _from_stdin_changed(self, name, old, new):
-        if new == True:
-            self.writer_class = "StdoutWriter"
 
     # Post-processor specific variables
     postprocessor = Instance('nbconvert.postprocessors.base.PostProcessorBase',

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -25,6 +25,7 @@ from .exporters.export import get_export_names, exporter_map
 from nbconvert import exporters, preprocessors, writers, postprocessors, __version__
 from .utils.base import NbConvertBase
 from .utils.exceptions import ConversionException
+from .utils.io import unicode_stdin_stream
 
 #-----------------------------------------------------------------------------
 #Classes and functions
@@ -430,8 +431,9 @@ class NbConvertApp(JupyterApp):
             for notebook_filename in self.notebooks:
                 self.convert_single_notebook(notebook_filename)
         else:
+            input_buffer = unicode_stdin_stream()
             # default name when conversion from stdin
-            self.convert_single_notebook("notebook.ipynb", input_buffer=sys.stdin)
+            self.convert_single_notebook("notebook.ipynb", input_buffer=input_buffer)
             
 #-----------------------------------------------------------------------------
 # Main entry point

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -72,7 +72,6 @@ nbconvert_flags.update({
     'stdin' : (
         {'NbConvertApp' : {
             'from_stdin' : True,
-            'writer_class':'StdoutWriter'
             }
         },
         "read a single notebook file from stdin, and write the converted result to stdout. Implies `--stdout`"

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -360,7 +360,7 @@ class NbConvertApp(JupyterApp):
         resources from the exporter.
 
         notebook_filename: a filename
-        input_buffer: a containing notebook buffer, if not None notebook_filename is ignored
+        input_buffer: a readable file like object returning unicode, if not None notebook_filename is ignored
         """
         try:
             if input_buffer is not None:

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -431,7 +431,7 @@ class NbConvertApp(JupyterApp):
                 self.convert_single_notebook(notebook_filename)
         else:
             # default name when conversion from stdin
-            self.convert_single_notebook("notebook", input_buffer=sys.stdin)
+            self.convert_single_notebook("notebook.ipynb", input_buffer=sys.stdin)
             
 #-----------------------------------------------------------------------------
 # Main entry point

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -316,7 +316,7 @@ class NbConvertApp(JupyterApp):
 
         # Get a unique key for the notebook and set it in the resources object.
         if not notebook_filename:
-            notebook_name = '%s' % uuid.uuid(4)
+            notebook_name = '%s' % uuid.uuid4()
 
         else:
             basename = os.path.basename(notebook_filename)
@@ -349,7 +349,7 @@ class NbConvertApp(JupyterApp):
         shell_input: a filename or buffer from stdin depending on the '--stdin' option
         """
         try:
-            if stdin_input:
+            if self.from_stdin:
                 output, resources = self.exporter.from_file(shell_input, resources=resources)
             else:
                 output, resources = self.exporter.from_filename(shell_input, resources=resources)
@@ -398,11 +398,12 @@ class NbConvertApp(JupyterApp):
             4. (Maybe) postprocess the written file
 
         """
-        if stdin_option:
+        if self.from_stdin:
             self.log.info("Converting notebook from stdin to stdout", shell_input, self.export_format)
+            resources = self.init_single_notebook_resources(None)
         else:
             self.log.info("Converting notebook %s to %s", shell_input, self.export_format)
-        resources = self.init_single_notebook_resources(shell_input)
+            resources = self.init_single_notebook_resources(shell_input)
         output, resources = self.export_single_notebook(shell_input, resources)
         write_results = self.write_single_notebook(output, resources)
         self.postprocess_single_notebook(write_results)

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -310,8 +310,6 @@ class NbConvertApp(JupyterApp):
             - output_files_dir: a directory where output files (not including
               the notebook itself) should be saved
 
-        If filename is None (converting notebook from in memory), fill in the required
-        parameters with UUID.
         """
 
         # Get a unique key for the notebook and set it in the resources object.

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -429,7 +429,7 @@ class NbConvertApp(JupyterApp):
             sys.exit(-1)
 
         # convert each notebook
-        if not self.from_stdin:
+        if not self.writer_class == 'StdoutWriter': #if stdout there is no file
             for notebook_filename in self.notebooks:
                 self.convert_single_notebook(notebook_filename)
         else:

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -336,20 +336,20 @@ class NbConvertApp(JupyterApp):
 
         return resources
 
-    def export_single_notebook(self, shell_input, resources):
+    def export_single_notebook(self, notebook_filename, resources):
         """Step 2: Export the notebook
 
         Exports the notebook to a particular format according to the specified
         exporter. This function returns the output and (possibly modified)
         resources from the exporter.
 
-        shell_input: a filename or buffer (for instance from stdin using '--stdin' option)
+        notebook_filename: a filename or buffer (for instance from stdin using '--stdin' option)
         """
         try:
             if self.from_stdin:
-                output, resources = self.exporter.from_file(shell_input, resources=resources)
+                output, resources = self.exporter.from_file(notebook_filename, resources=resources)
             else:
-                output, resources = self.exporter.from_filename(shell_input, resources=resources)
+                output, resources = self.exporter.from_filename(notebook_filename, resources=resources)
         except ConversionException:
             self.log.error("Error while converting notebook", exc_info=True)
             self.exit('Could not convert notebook.')
@@ -386,7 +386,7 @@ class NbConvertApp(JupyterApp):
         if hasattr(self, 'postprocessor') and self.postprocessor:
             self.postprocessor(write_results)
 
-    def convert_single_notebook(self, shell_input):
+    def convert_single_notebook(self, notebook_filename):
         """Convert a single notebook. Performs the following steps:
 
             1. Initialize notebook resources
@@ -399,9 +399,9 @@ class NbConvertApp(JupyterApp):
             self.log.info("Converting notebook from stdin into %s", self.export_format)
             resources = self.init_single_notebook_resources(None)
         else:
-            self.log.info("Converting notebook %s to %s", shell_input, self.export_format)
-            resources = self.init_single_notebook_resources(shell_input)
-        output, resources = self.export_single_notebook(shell_input, resources)
+            self.log.info("Converting notebook %s to %s", notebook_filename, self.export_format)
+            resources = self.init_single_notebook_resources(notebook_filename)
+        output, resources = self.export_single_notebook(notebook_filename, resources)
         write_results = self.write_single_notebook(output, resources)
         self.postprocess_single_notebook(write_results)
 

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -427,7 +427,7 @@ class NbConvertApp(JupyterApp):
         self.exporter = exporter_map[self.export_format](config=self.config)
 
         # no notebooks to convert!
-        if len(self.notebooks) == 0:
+        if len(self.notebooks) == 0 and not self.from_stdin:
             self.print_help()
             sys.exit(-1)
 
@@ -436,7 +436,7 @@ class NbConvertApp(JupyterApp):
             for notebook_filename in self.notebooks:
                 self.convert_single_notebook(notebook_filename)
         else:
-            self.convert_single_notebook(stream=sys.stdin)
+            self.convert_single_notebook(sys.stdin)
             
 #-----------------------------------------------------------------------------
 # Main entry point

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -34,7 +34,7 @@ class DottedOrNone(DottedObjectName):
     """
     A string holding a valid dotted object name in Python, such as A.b3._c
     Also allows for None type."""
-
+    
     default_value = u''
 
     def validate(self, obj, value):
@@ -42,7 +42,7 @@ class DottedOrNone(DottedObjectName):
             return super(DottedOrNone, self).validate(obj, value)
         else:
             return value
-
+            
 nbconvert_aliases = {}
 nbconvert_aliases.update(base_aliases)
 nbconvert_aliases.update({
@@ -88,7 +88,7 @@ nbconvert_flags.update({
             },
             'FilesWriter': {'build_directory': ''},
         },
-        """Run nbconvert in place, overwriting the existing notebook (only
+        """Run nbconvert in place, overwriting the existing notebook (only 
         relevant when converting to notebook format)"""
         )
 })
@@ -165,7 +165,7 @@ class NbConvertApp(JupyterApp):
         
         Multiple notebooks can be given at the command line in a couple of 
         different ways:
-        
+  
         > jupyter nbconvert notebook*.ipynb
         > jupyter nbconvert notebook1.ipynb notebook2.ipynb
         
@@ -177,13 +177,12 @@ class NbConvertApp(JupyterApp):
         """.format(get_export_names()))
 
     # Writer specific variables
-    writer = Instance('nbconvert.writers.base.WriterBase',
-                      help="""Instance of the writer class used to write the
+    writer = Instance('nbconvert.writers.base.WriterBase',  
+                      help="""Instance of the writer class used to write the 
                       results of the conversion.""", allow_none=True)
-    writer_class = DottedObjectName('FilesWriter', config=True,
-                                    help="""Writer class used to write the
+    writer_class = DottedObjectName('FilesWriter', config=True, 
+                                    help="""Writer class used to write the 
                                     results of the conversion""")
-    from_stdin   = Bool(False, config=True, help="read a single notebook from stdin.")
     writer_aliases = {'fileswriter': 'nbconvert.writers.files.FilesWriter',
                       'debugwriter': 'nbconvert.writers.debug.DebugWriter',
                       'stdoutwriter': 'nbconvert.writers.stdout.StdoutWriter'}
@@ -194,13 +193,12 @@ class NbConvertApp(JupyterApp):
             new = self.writer_aliases[new.lower()]
         self.writer_factory = import_item(new)
 
-
     # Post-processor specific variables
     postprocessor = Instance('nbconvert.postprocessors.base.PostProcessorBase',
                       help="""Instance of the PostProcessor class used to write the
                       results of the conversion.""", allow_none=True)
 
-    postprocessor_class = DottedOrNone(config=True,
+    postprocessor_class = DottedOrNone(config=True, 
                                     help="""PostProcessor class used to write the
                                     results of the conversion""")
     postprocessor_aliases = {'serve': 'nbconvert.postprocessors.serve.ServePostProcessor'}
@@ -224,6 +222,7 @@ class NbConvertApp(JupyterApp):
                      Wildcards are supported.
                      Filenames passed positionally will be added to the list.
                      """)
+    from_stdin   = Bool(False, config=True, help="read a single notebook from stdin.")
 
     @catch_config_error
     def initialize(self, argv=None):
@@ -240,7 +239,7 @@ class NbConvertApp(JupyterApp):
         Add the cwd to the sys.path ($PYTHONPATH)
         """
         sys.path.insert(0, os.getcwd())
-
+        
 
     def init_notebooks(self):
         """Construct the list of notebooks.
@@ -259,8 +258,8 @@ class NbConvertApp(JupyterApp):
         # Use glob to replace all the notebook patterns with filenames.
         filenames = []
         for pattern in patterns:
-
-            # Use glob to find matching filenames.  Allow the user to convert
+            
+            # Use glob to find matching filenames.  Allow the user to convert 
             # notebooks without having to type the extension.
             globbed_files = glob.glob(pattern)
             globbed_files.extend(glob.glob(pattern + '.ipynb'))
@@ -285,7 +284,7 @@ class NbConvertApp(JupyterApp):
         """
         Initialize the postprocessor (which is stateless)
         """
-        self._postprocessor_class_changed(None, self.postprocessor_class,
+        self._postprocessor_class_changed(None, self.postprocessor_class, 
             self.postprocessor_class)
         if self.postprocessor_factory:
             self.postprocessor = self.postprocessor_factory(parent=self)
@@ -311,19 +310,15 @@ class NbConvertApp(JupyterApp):
 
         """
 
-        # Get a unique key for the notebook and set it in the resources object.
-        if not notebook_filename:
-            notebook_name = 'notebook'
-        else:
-            basename = os.path.basename(notebook_filename)
-            notebook_name = basename[:basename.rfind('.')]
-            if self.output_base:
-                # strip duplicate extension from output_base, to avoid Basname.ext.ext
-                if getattr(self.exporter, 'file_extension', False):
-                    base, ext = os.path.splitext(self.output_base)
-                    if ext == self.exporter.file_extension:
-                        self.output_base = base
-                notebook_name = self.output_base
+        basename = os.path.basename(notebook_filename)
+        notebook_name = basename[:basename.rfind('.')]
+        if self.output_base:
+            # strip duplicate extension from output_base, to avoid Basname.ext.ext
+            if getattr(self.exporter, 'file_extension', False):
+                base, ext = os.path.splitext(self.output_base)
+                if ext == self.exporter.file_extension:
+                    self.output_base = base
+            notebook_name = self.output_base
 
         self.log.debug("Notebook name is '%s'", notebook_name)
 
@@ -342,7 +337,8 @@ class NbConvertApp(JupyterApp):
         exporter. This function returns the output and (possibly modified)
         resources from the exporter.
 
-        notebook_filename: a filename or buffer (for instance from stdin using '--stdin' option)
+        notebook_filename: a filename
+        input_buffer: a containing notebook buffer, if not None notebook_filename is ignored
         """
         try:
             if input_buffer is not None:
@@ -350,8 +346,8 @@ class NbConvertApp(JupyterApp):
             else:
                 output, resources = self.exporter.from_filename(notebook_filename, resources=resources)
         except ConversionException:
-            self.log.error("Error while converting notebook", exc_info=True)
-            self.exit('Could not convert notebook.')
+            self.log.error("Error while converting '%s'", notebook_filename, exc_info=True)
+            self.exit(1)
 
         return output, resources
 
@@ -393,19 +389,16 @@ class NbConvertApp(JupyterApp):
             3. Write the exported notebook to file
             4. (Maybe) postprocess the written file
             
-            If input_buffer is not None, convertion is done using buffer as source ignoring
-            the notebook_filename argument.
+            If input_buffer is not None, convertion is done using buffer as source into
+            a file basenamed by the notebook_filename argument.
         """
-        if not input_buffer:
+        if input_buffer is None:
             self.log.info("Converting notebook %s to %s", notebook_filename, self.export_format)
-            resources = self.init_single_notebook_resources(notebook_filename)
-            output, resources = self.export_single_notebook(notebook_filename, resources)
         else:
-            notebook_filename = "notebook"
             self.log.info("Converting notebook into %s", self.export_format)
-            resources = self.init_single_notebook_resources(None) #init_single_notebook_resources need to know there is no file
-            output, resources = self.export_single_notebook(notebook_filename, resources, input_buffer=input_buffer)
-
+        
+        resources = self.init_single_notebook_resources(notebook_filename)
+        output, resources = self.export_single_notebook(notebook_filename, resources, input_buffer=input_buffer)
         write_results = self.write_single_notebook(output, resources)
         self.postprocess_single_notebook(write_results)
 
@@ -423,7 +416,7 @@ class NbConvertApp(JupyterApp):
                 """
             )
             self.exit(1)
-
+        
         # initialize the exporter
         self.exporter = exporter_map[self.export_format](config=self.config)
 
@@ -437,7 +430,8 @@ class NbConvertApp(JupyterApp):
             for notebook_filename in self.notebooks:
                 self.convert_single_notebook(notebook_filename)
         else:
-            self.convert_single_notebook(None, input_buffer=sys.stdin)
+            # default name when conversion from stdin
+            self.convert_single_notebook("notebook", input_buffer=sys.stdin)
             
 #-----------------------------------------------------------------------------
 # Main entry point

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -74,7 +74,7 @@ nbconvert_flags.update({
             'from_stdin' : True,
             }
         },
-        "read a single notebook file from stdin, and write the converted result to stdout. Implies `--stdout`"
+        "read a single notebook file from stdin. Write the resulting notebook with default basename 'notebook.*'"
         ),
     'stdout' : (
         {'NbConvertApp' : {'writer_class' : "StdoutWriter"}},
@@ -345,7 +345,7 @@ class NbConvertApp(JupyterApp):
         notebook_filename: a filename or buffer (for instance from stdin using '--stdin' option)
         """
         try:
-            if input_buffer:
+            if input_buffer is not None:
                 output, resources = self.exporter.from_file(input_buffer, resources=resources)
             else:
                 output, resources = self.exporter.from_filename(notebook_filename, resources=resources)

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -310,14 +310,13 @@ class NbConvertApp(JupyterApp):
             - output_files_dir: a directory where output files (not including
               the notebook itself) should be saved
 
-        If filename is none (converting notebook from in memory), fill in the required
+        If filename is None (converting notebook from in memory), fill in the required
         parameters with UUID.
         """
 
         # Get a unique key for the notebook and set it in the resources object.
         if not notebook_filename:
             notebook_name = '%s' % uuid.uuid4()
-
         else:
             basename = os.path.basename(notebook_filename)
             notebook_name = basename[:basename.rfind('.')]
@@ -346,7 +345,7 @@ class NbConvertApp(JupyterApp):
         exporter. This function returns the output and (possibly modified)
         resources from the exporter.
 
-        shell_input: a filename or buffer from stdin depending on the '--stdin' option
+        shell_input: a filename or buffer (for instance from stdin using '--stdin' option)
         """
         try:
             if self.from_stdin:
@@ -399,7 +398,7 @@ class NbConvertApp(JupyterApp):
 
         """
         if self.from_stdin:
-            self.log.info("Converting notebook from stdin to stdout", shell_input, self.export_format)
+            self.log.info("Converting notebook from stdin into %s", self.export_format)
             resources = self.init_single_notebook_resources(None)
         else:
             self.log.info("Converting notebook %s to %s", shell_input, self.export_format)

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -324,9 +324,12 @@ class TestNbConvertApp(TestsBase):
         with self.create_temp_cwd(["notebook1.ipynb"]):
             with io.open('notebook1.ipynb') as f:
                 notebook = f.read().encode()
-                output1, _ = self.nbconvert('--to markdown --stdin', stdin=notebook)
-            assert_not_in('```python', output1) # shouldn't have language
-            assert_in("```", output1) # but should have fenced blocks
+                self.nbconvert('--to markdown --stdin', stdin=notebook)
+            assert os.path.isfile("notebook.md") #default name for stdin input
+            with io.open('notebook.md') as f:
+                output1 = f.read()
+                assert_not_in('```python', output1) # shouldn't have language
+                assert_in("```", output1) # but should have fenced blocks
 
     @dec.onlyif_cmds_exist('pdflatex')
     @dec.onlyif_cmds_exist('pandoc')

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -304,6 +304,18 @@ class TestNbConvertApp(TestsBase):
             assert '```julia' in output2  # shouldn't have language
             assert "```" in output2  # but should also plain ``` to close cell
     
+    def test_convert_from_stdin_to_stdout(self):
+        """
+        Verify that conversion can be done via stdin, and that 
+        --stdin  implies --stdout. 
+        """
+        with self.create_temp_cwd(["notebook1.ipynb"]):
+            with io.open('notebook1.ipynb') as f:
+                notebook = f.read().encode()
+                output1, _ = self.nbconvert('--to markdown --stdin --stdout', stdin=notebook)
+            assert_not_in('```python', output1) # shouldn't have language
+            assert_in("```", output1) # but should have fenced blocks
+
     def test_convert_from_stdin(self):
         """
         Verify that conversion can be done via stdin, and that 
@@ -315,7 +327,6 @@ class TestNbConvertApp(TestsBase):
                 output1, _ = self.nbconvert('--to markdown --stdin', stdin=notebook)
             assert_not_in('```python', output1) # shouldn't have language
             assert_in("```", output1) # but should have fenced blocks
-
 
     @dec.onlyif_cmds_exist('pdflatex')
     @dec.onlyif_cmds_exist('pandoc')

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -319,8 +319,7 @@ class TestNbConvertApp(TestsBase):
     
     def test_convert_from_stdin_to_stdout(self):
         """
-        Verify that conversion can be done via stdin, and that 
-        --stdin  implies --stdout. 
+        Verify that conversion can be done via stdin to stdout
         """
         with self.create_temp_cwd(["notebook1.ipynb"]):
             with io.open('notebook1.ipynb') as f:
@@ -331,8 +330,7 @@ class TestNbConvertApp(TestsBase):
 
     def test_convert_from_stdin(self):
         """
-        Verify that conversion can be done via stdin, and that 
-        --stdin  implies --stdout. 
+        Verify that conversion can be done via stdin.
         """
         with self.create_temp_cwd(["notebook1.ipynb"]):
             with io.open('notebook1.ipynb') as f:

--- a/nbconvert/utils/io.py
+++ b/nbconvert/utils/io.py
@@ -43,7 +43,10 @@ def unicode_stdin_stream():
     """
     stream  = sys.stdin
     if PY3:
-        stream_b = stream.buffer
+        try:
+            stream_b = stream.buffer
+        except AttributeError:
+            return stream
     else:
         stream_b = stream
 

--- a/nbconvert/utils/io.py
+++ b/nbconvert/utils/io.py
@@ -31,3 +31,20 @@ def unicode_std_stream(stream='stdout'):
         stream_b = stream
 
     return codecs.getwriter('utf-8')(stream_b)
+
+def unicode_stdin_stream():
+    u"""Get a wrapper to read unicode from stdin as UTF-8.
+
+    This ignores environment variables and default encodings, to reliably read unicode from stdin.
+
+    ::
+
+        totreat = unicode_stdin_stream().read()
+    """
+    stream  = sys.stdin
+    if PY3:
+        stream_b = stream.buffer
+    else:
+        stream_b = stream
+
+    return codecs.getreader('utf-8')(stream_b)


### PR DESCRIPTION
Follow #166 and #164, @akhmerov @Carreau @minrk 
Here the command line interface is:

| nbconvert --stdin --to html 
write in "notebook.html" by default
| nbconvert --stdin --to html --stdout
write to stdout

The corner in this API is default basename I am forced to introduce. Public APIs are changed but not broken, just extended. Right now help, and docstring havn't been double cheked (coming ...).