### PR TITLE
ENH: add option to specify (and possibly override) the kernel name.

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -65,7 +65,7 @@ class ExecutePreprocessor(Preprocessor):
     extra_arguments = List(Unicode())
 
     kernel_name = Unicode(
-        "python", config=True,
+        '', config=True,
         help=dedent(
             """
             Name of kernel to use to execute the cells.

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -81,9 +81,8 @@ class ExecutePreprocessor(Preprocessor):
             path = None
 
         from jupyter_client.manager import start_new_kernel
-        if not self.kernel_name:
-            kernel_name = nb.metadata.get('kernelspec', {}).get('name', 'python')
-        else:
+        kernel_name = nb.metadata.get('kernelspec', {}).get('name', 'python')
+        if self.kernel_name:
             kernel_name = self.kernel_name
         self.log.info("Executing notebook with kernel: %s" % kernel_name)
         self.km, self.kc = start_new_kernel(

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -64,13 +64,27 @@ class ExecutePreprocessor(Preprocessor):
 
     extra_arguments = List(Unicode())
 
+    kernel_name = Unicode(
+        "python", config=True,
+        help=dedent(
+            """
+            Name of kernel to use to execute the cells.
+            If not set, use the kernel_spec embedded in the notebook.
+            """
+        )
+    )
+
+
     def preprocess(self, nb, resources):
         path = resources.get('metadata', {}).get('path', '')
         if path == '':
             path = None
 
         from jupyter_client.manager import start_new_kernel
-        kernel_name = nb.metadata.get('kernelspec', {}).get('name', 'python')
+        if not self.kernel_name:
+            kernel_name = nb.metadata.get('kernelspec', {}).get('name', 'python')
+        else:
+            kernel_name = self.kernel_name
         self.log.info("Executing notebook with kernel: %s" % kernel_name)
         self.km, self.kc = start_new_kernel(
             kernel_name=kernel_name,


### PR DESCRIPTION
Add trailet `kernel_name` to `ExecutePreprocessor` to allow specifying a kernel for the notebook execution. When no `kernel_name` is set, the kernel name is taken from the notebook metadata.

When running notebooks on python 2/3 projects, it is convenient to run the same notebook under both python 2 and python 3. Before this patch, it was not possible to directly run a notebook with a different kernel form the one saved in the notebook metadata. With this patch is possible, for example, to use a python2 kernel to run a notebook that specifies python3.