### PR TITLE
Pdflatex figurefixes

### DIFF
--- a/nbconvert/templates/latex/article.tplx
+++ b/nbconvert/templates/latex/article.tplx
@@ -13,5 +13,5 @@
 %===============================================================================
 
 ((* block docclass *))
-\documentclass{article}
+\documentclass[11pt]{article}
 ((* endblock docclass *))

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -16,7 +16,26 @@ This template does not define a docclass, the inheriting class must define this.
     % Nicer default font than Computer Modern for most use cases
     \usepackage{palatino}
 
-    \usepackage{graphicx} % Used to insert images
+    % Basic figure setup, for now with no caption control since it's done
+    % automatically by Pandoc (which extracts ![](path) syntax from Markdown).
+    \usepackage{graphicx}
+    % We will generate all images so they have a width \maxwidth. This means
+    % that they will get their normal width if they fit onto the page, but
+    % are scaled down if they would overflow the margins.
+    \makeatletter
+    \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth
+    \else\Gin@nat@width\fi}
+    \makeatother
+    \let\Oldincludegraphics\includegraphics
+    % Set max figure width to be 80% of text width, for now hardcoded.
+    \renewcommand{\includegraphics}[1]{\Oldincludegraphics[width=.8\maxwidth]{#1}}
+    % Ensure that by default, figures have no caption (until we provide a
+    % proper Figure object with a Caption API and a way to capture that
+    % in the conversion process - todo).
+    \usepackage{caption}
+    \DeclareCaptionLabelFormat{nolabel}{}
+    \captionsetup{labelformat=nolabel}
+
     \usepackage{adjustbox} % Used to constrain images to a maximum size 
     \usepackage{color} % Allow colors to be defined
     \usepackage{enumerate} % Needed for markdown enumerations to work

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -13,6 +13,9 @@ This template does not define a docclass, the inheriting class must define this.
     ((* block docclass *))((* endblock docclass *))
     
     ((* block packages *))
+    % Nicer default font than Computer Modern for most use cases
+    \usepackage{palatino}
+
     \usepackage{graphicx} % Used to insert images
     \usepackage{adjustbox} % Used to constrain images to a maximum size 
     \usepackage{color} % Allow colors to be defined


### PR DESCRIPTION
Mostly improvements to figure handling, but a few extra fixes as well, to improve the quality of PDF output out of the box.

With these fixes, I was able to generate the final Sloan report with the command `jupyter nbconvert --to pdf <notebook-filename>`, without any further manual modification.

Note to whoever does final merge: merge commit message should list credit to https://gist.github.com/rwst/1366514 by @rwst, which is the main logic of this PR, the rest are small tweaks.