### PR TITLE
Update documentation and add a readme for building docs

### DIFF
--- a/docs/README-DOCS.md
+++ b/docs/README-DOCS.md
@@ -1,0 +1,42 @@
+# Documenting nbconvert
+
+[Documentation for `nbconvert`](https://nbconvert.readthedocs.org/en/latest/)
+is hosted on ReadTheDocs.
+
+## Build Documentation locally
+
+0. Change directory to documentation root:
+
+    $ cd docs
+
+1. Install requirements:
+
+    $ pip install -r requirements.txt
+
+2. Build documentation using Makefile for Linux and OS X:
+
+    $ make html
+
+or for Windows:
+
+    $ make.bat html
+
+3. Display the documentation locally:
+
+    $ open build/html/index.html
+
+Or alternatively you may run a local server to display the docs. In Python 3:
+
+    $ python -m http.server 8000
+
+In your browser, go to `http://localhost:8000`
+
+## Developing Documentation
+
+### Helpful files and directories
+
+* conf.py - Sphinx build configuration file
+* source directory - source for documentation
+* source/api - source files for generated API documentation
+* autogen_config.py - Generates configuration of ipynb source files to rst
+* index.rst - Main landing page of the Sphinx documentation

--- a/docs/README-DOCS.md
+++ b/docs/README-DOCS.md
@@ -5,38 +5,40 @@ is hosted on ReadTheDocs.
 
 ## Build Documentation locally
 
-0. Change directory to documentation root:
+1. Change directory to documentation root:
 
-    $ cd docs
+       $ cd docs
 
-1. Install requirements:
+2. Install requirements:
 
-    $ pip install -r requirements.txt
+       $ pip install -r requirements.txt
 
-2. Build documentation using Makefile for Linux and OS X:
+3. Build documentation using Makefile for Linux and OS X:
 
-    $ make html
+       $ make html
 
-or for Windows:
+   or for Windows:
 
-    $ make.bat html
+       $ make.bat html
 
-3. Display the documentation locally:
+4. Display the documentation locally:
 
-    $ open build/html/index.html
+       $ open build/html/index.html
 
-Or alternatively you may run a local server to display the docs. In Python 3:
+   This command will open a window in your browser.
 
-    $ python -m http.server 8000
+   Or alternatively you may run a local server to display the docs. In Python 3:
 
-In your browser, go to `http://localhost:8000`
+       $ python -m http.server 8000
+
+   In your browser, go to `http://localhost:8000`.
 
 ## Developing Documentation
 
 ### Helpful files and directories
 
-* conf.py - Sphinx build configuration file
-* source directory - source for documentation
-* source/api - source files for generated API documentation
-* autogen_config.py - Generates configuration of ipynb source files to rst
-* index.rst - Main landing page of the Sphinx documentation
+* `conf.py` - Sphinx build configuration file
+* `source` directory - source for documentation
+* `source/api` directory - source files for generated API documentation
+* `autogen_config.py` - Generates configuration of ipynb source files to rst
+* `index.rst` - Main landing page of the Sphinx documentation

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,29 +7,27 @@ is hosted on ReadTheDocs.
 
 1. Change directory to documentation root:
 
-       $ cd docs
+           $ cd docs
 
 2. Install requirements:
 
-       $ pip install -r requirements.txt
+           $ pip install -r requirements.txt
 
 3. Build documentation using Makefile for Linux and OS X:
 
-       $ make html
+           $ make html
 
-   or for Windows:
+  or on Windows:
 
-       $ make.bat html
+           $ make.bat html
 
-4. Display the documentation locally:
+4. Display the documentation locally by navigating to
+   ``build/html/index.html`` in your browser:
 
-       $ open build/html/index.html
+   Or alternatively you may run a local server to display
+   the docs. In Python 3:
 
-   This command will open a window in your browser.
-
-   Or alternatively you may run a local server to display the docs. In Python 3:
-
-       $ python -m http.server 8000
+           $ python -m http.server 8000
 
    In your browser, go to `http://localhost:8000`.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,6 @@ traitlets
 jupyter_core
 jupyter_client
 nbformat
+sphinx_rtd_theme
 -e git+https://github.com/ipython/ipython.git#egg=ipython
 -e git+https://github.com/ipython/ipykernel.git#egg=ipykernel

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,4 @@ jupyter_core
 jupyter_client
 nbformat
 sphinx_rtd_theme
--e git+https://github.com/ipython/ipython.git#egg=ipython
 -e git+https://github.com/ipython/ipykernel.git#egg=ipykernel

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,8 +23,9 @@ import shlex
 #sys.path.insert(0, os.path.abspath('.'))
 
 if os.environ.get('READTHEDOCS', ''):
-    # RTD doesn't use the repo's Makefile to build docs. Run autogen_config.py
-    # here to generate rst files from ipynb files.
+    # RTD doesn't use the repo's Makefile to build docs. We run
+    # autogen_config.py to create the config docs (i.e. Configuration Options
+    # page).
 
     with open('../autogen_config.py') as f:
         exec(compile(f.read(), 'autogen_config.py', 'exec'), {})

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,8 @@ import shlex
 #sys.path.insert(0, os.path.abspath('.'))
 
 if os.environ.get('READTHEDOCS', ''):
-    # RTD doesn't use the Makefile, so re-run autogen_config.py here.
+    # RTD doesn't use the repo's Makefile to build docs. Run autogen_config.py
+    # here to generate rst files from ipynb files.
 
     with open('../autogen_config.py') as f:
         exec(compile(f.read(), 'autogen_config.py', 'exec'), {})
@@ -65,6 +66,7 @@ author = 'Jupyter Development Team'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
+# Get information from _version.py and use it to generate version and release
 _version_py = '../../nbconvert/_version.py'
 version_ns = {}
 exec(compile(open(_version_py).read(), _version_py, 'exec'), version_ns)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -122,9 +122,21 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
+# Set on_rtd to whether we are building on readthedocs.org. We get this line of
+# code grabbed from docs.readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# otherwise, readthedocs.org uses their default theme, so no need to specify it
+
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#html_theme = 'alabaster'
+#html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -132,7 +144,7 @@ todo_include_todos = False
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+#html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -298,7 +310,6 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
-
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,7 +12,7 @@ Nbconvert is packaged for both pip and conda, so you can install it with::
     # OR
     conda install nbconvert
 
-If you're new to Python, we recommend installing `Anaconda <https://continuum.io/downloads>`__,
+If you're new to Python, we recommend installing `Anaconda <https://www.continuum.io/downloads>`__,
 a Python distribution which includes nbconvert and the other Jupyter components.
 
 Pandoc

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,7 +12,7 @@ Nbconvert is packaged for both pip and conda, so you can install it with::
     # OR
     conda install nbconvert
 
-If you're new to Python, we recommend installing `Anaconda <http://continuum.io/downloads#py34>`__,
+If you're new to Python, we recommend installing `Anaconda <https://continuum.io/downloads>`__,
 a Python distribution which includes nbconvert and the other Jupyter components.
 
 Pandoc
@@ -26,4 +26,4 @@ To install pandoc on Linux, you can generally use your package manager::
     sudo apt-get install pandoc
 
 On other platforms, you can get pandoc from
-`their website <http://johnmacfarlane.net/pandoc/installing.html>`_.
+`their website <http://pandoc.org/installing.html>`_.

--- a/docs/source/nbconvert_library.ipynb
+++ b/docs/source/nbconvert_library.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "In this notebook, you will be introduced to the programmatic API of nbconvert and how it can be used in various contexts. \n",
     "\n",
-    "One of [@jakevdp](https://github.com/jakevdp)'s great [blog posts](http://jakevdp.github.io/blog/2013/04/15/code-golf-in-python-sudoku/) will be used to demonstrate.  This notebook will not focus on using the command line tool. The attentive reader will point-out that no data is read from or written to disk during the conversion process. This is because nbconvert has been designed to work in memory so that it works well in a database or web-based environement too."
+    "A great [blog post](http://jakevdp.github.io/blog/2013/04/15/code-golf-in-python-sudoku/) by [@jakevdp](https://github.com/jakevdp) will be used to demonstrate.  This notebook will not focus on using the command line tool. The attentive reader will point-out that no data is read from or written to disk during the conversion process. This is because nbconvert has been designed to work in memory so that it works well in a database or web-based environement too."
    ]
   },
   {
@@ -463,7 +463,25 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -113,7 +113,7 @@ The currently supported export formats are:
   nbconvert uses pandoc_ to convert between various markup languages,
   so pandoc is a dependency when converting to latex or reStructuredText.
 
-.. _pandoc: http://johnmacfarlane.net/pandoc/
+.. _pandoc: http://pandoc.org/
 
 The output file created by ``nbconvert`` will have the same base name as
 the notebook and will be placed in the current working directory. Any


### PR DESCRIPTION
- Add a `README_DOCS.md` to aid developers in docs development and local builds
- Expanded existing comments in `conf.py` to be more understandable to less frequent users of Sphinx configuration settings and RTD settings
- Added code to enable local builds of documentation with `sphinx_rtd_theme` instead of the default alabaster theme
- Added a `_static` directory with an empty text file to suppress warning during `make html`. This could have been achieved by editing the `conf.py` file to comment out the static file directory setting. Since we will likely have some screenshots in the near future, it seemed prudent to add it now. I'm happy to remove it if that is preferred.
- Edited notebook markdown to correct bad link to JVP's blog post