### PR TITLE
DOC: Add section on executing notebooks

### DIFF
--- a/docs/source/api/preprocessors.rst
+++ b/docs/source/api/preprocessors.rst
@@ -34,5 +34,6 @@ Specialized preprocessors
 .. autoclass:: ClearOutputPreprocessor
 
 .. autoclass:: ExecutePreprocessor
+    :members:
 
 .. autofunction:: coalesce_streams

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -1,17 +1,19 @@
 Executing notebooks
 ===================
 
+.. module:: nbconvert.preprocessors
+
 In this section we show how to execute a ``.ipynb`` notebook
 document saving the result in notebook format.
 To export the notebook to other formats see section
-:ref:`Using nbconvert as a library <nbconvert_library>`.
+:doc:`nbconvert_library`.
 
 Executing notebooks programmatically is useful, for example, as a test layer
 in python libraries that include example notebooks, or as a way to
 automate the data analysis in projects involving more than one notebook.
 
 The same functionality of executing notebooks is exposed through a
-:ref:`command line interface <commandline_usage>` or a python API interface.
+:doc:`command line interface <usage>` or a python API interface.
 In this section we will (mostly) illustrate how to use the python API interface.
 
 A Quick example
@@ -20,7 +22,7 @@ A Quick example
 Let's start with a complete quick example, leaving detailed explanations
 to the following sections.
 
-First we import nbconvert and the ``ExecutePreprocessor`` class:
+First we import nbconvert and the :class:`ExecutePreprocessor` class:
 
 .. code-block:: python
 

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -9,16 +9,16 @@ To export the notebook to other formats see section
 :doc:`nbconvert_library`.
 
 Executing notebooks programmatically is useful, for example, as a test layer
-in python libraries that include example notebooks, or as a way to
+in Python libraries that include example notebooks, or as a way to
 automate the data analysis in projects involving more than one notebook.
 
 The same functionality of executing notebooks is exposed through a
-:doc:`command line interface <usage>` or a python API interface.
+:doc:`command line interface <usage>` or a Python API interface.
 As an example, a notebook can be executed from the command line with::
 
     jupyter nbconvert --to notebook --execute mynotebook.ipynb
 
-In this section we will (mostly) illustrate how to use the python API interface.
+In this section we will (mostly) illustrate how to use the Python API interface.
 
 A Quick example
 ---------------
@@ -46,7 +46,7 @@ define respectively the execution timeout and the execution kernel.
 
     The option to specify **kernel_name** is new in nbconvert 4.2.
     When not specified or when using nbconvert <4.2,
-    the default python kernel is chosen.
+    the default Python kernel is chosen.
 
 To actually run the notebook we call the method ``preprocess``::
 
@@ -88,11 +88,11 @@ The second traitlet, ``kernel_name``, allows specifying the name of the kernel
 to be used for the execution. By default, the kernel name is obtained from the
 notebook metadata. The traitlet ``kernel_name`` allows to specify a user-defined
 kernel, overriding the value in the notebook metadata. A common use case
-is that of a python 2/3 library which includes documentation/testing
+is that of a Python 2/3 library which includes documentation/testing
 notebooks. These notebooks will specify either a python2 or python3 kernel
 in their metadata
 (depending on the kernel used the last time the notebook was saved).
-In reality, these notebooks will work on both python 2/3 and, for testing,
+In reality, these notebooks will work on both Python 2/3 and, for testing,
 it is important to be able to execute them programmatically on both
 versions. Here the traitlet ``kernel_name`` comes to help:
 we can just run each notebook twice, specifying first "python2" and then

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -37,12 +37,12 @@ we can load it with::
 
 Next, we configure the notebook execution mode::
 
-    ep = ExecutePreprocessor(timeout=3600, kernel_name='python3')
+    ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
 
 We specified two (optional) arguments ``timeout`` and ``kernel_name``, which
 define respectively the execution timeout and the execution kernel.
 
-    The option to specify **kernel_name** it's new in nbconvert 4.2.
+    The option to specify **kernel_name** is new in nbconvert 4.2.
     When not specified or when using nbconvert <4.2,
     the default python kernel is chosen.
 

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -32,7 +32,8 @@ we can load it with:
 
 .. code-block:: python
 
-    nb = nbformat.read(open(notebook_filename), as_version=4)
+    with open(notebook_filename) as f:
+        nb = nbformat.read(f, as_version=4)
 
 Next, we configure the notebook execution mode:
 

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -3,8 +3,8 @@ Executing notebooks
 
 In this section we show how to execute a ``.ipynb`` notebook
 document saving the result in notebook format.
-To export the notebook to other formats see the
-:ref:`next section <nbconvert_library>`.
+To export the notebook to other formats see section
+:ref:`Using nbconvert as a library <nbconvert_library>`.
 
 Executing notebooks programmatically is useful, for example, as a test layer
 in python libraries that include example notebooks, or as a way to
@@ -43,8 +43,9 @@ Next, we configure the notebook execution mode:
 We specified two (optional) arguments ``timeout`` and ``kernel_name``, which
 define respectively the execution timeout and the execution kernel.
 
-    The **kernel_name** keyword `requires <https://github.com/jupyter/nbconvert/pull/177>`__
-    nbconvert 4.2 (unreleased, use master branch from github).
+    The option to specify **kernel_name** it's new in nbconvert 4.2.
+    When not specified or when using nbconvert <4.2,
+    the default python kernel is chosen.
 
 To actually run the notebook we call the method ``preprocess``:
 
@@ -59,15 +60,16 @@ Finally, to save the resulting notebook:
 
 .. code-block:: python
 
-    nbformat.write(nb, open('executed_notebook.ipynb', mode='wt'))
+    with open('executed_notebook.ipynb', 'wt') as f:
+        nbformat.write(nb, f)
 
 That's all. Your executed notebook will be saved in the current folder
-in the file *executed_notebook.ipynb*.
+in the file ``executed_notebook.ipynb``.
 
 Execution arguments
 -------------------
 
-The arguments passed to ``ExecutePreprocessor`` are configuration options
+The arguments passed to :class:`ExecutePreprocessor` are configuration options
 called `traitlets <http://traitlets.readthedocs.org/>`_.
 There are many cool things about traitlets, for example
 they enforce the type of the input and they can be accessed/modified as
@@ -75,13 +77,14 @@ class attributes. Moreover, each traitlet is automatically exposed
 as command-line options. For example, we can pass the timeout from the
 command-line like this::
 
-    jupyter nbconvert --ExecutePreprocessor.timeout=3600 --to notebook --execute mynotebook.ipynb
+    jupyter nbconvert --ExecutePreprocessor.timeout=600 --to notebook --execute mynotebook.ipynb
 
 Let's now discuss in more detail the two traitlets we used.
 
-The ``timeout`` traitlet defines the maximum time (in seconds) the notebook is
+The ``timeout`` traitlet defines the maximum time (in seconds) each notebook
+cell is
 allowed to run, if the execution takes longer an exception will be raised.
-The default is only 30 s, so in many cases you may want to specify
+The default is 30 s, so in cases of long-running cells you may want to specify
 an higher value.
 
 The second traitlet, ``kernel_name``, allows specifying the name of the kernel
@@ -115,7 +118,7 @@ After an error, we can still save the notebook as before:
 
 The saved notebook contains the output up until the failing cell,
 and includes a full stack-trace and error (which can help debugging).
-A pattern I use to execute notebooks while handling errors is the following:
+A useful pattern to execute notebooks while handling errors is the following:
 
 .. code-block:: python
 
@@ -134,12 +137,13 @@ In case of errors, however, an additional message is printed and the
 ``CellExecutionError`` is raised. The messages directs the user to
 the saved notebook for further inspection.
 
-As a last scenario, sometimes notebooks contains independent computations
-in each code cell.
-In this case it can be useful to run the notebook until the end,
-in order to get a complete picture of all cells that are failing.
-Luckily enough, the ``allow_errors`` traitlet (default False) allows to do that.
+As a last scenario, it is sometimes useful to execute notebooks which
+raise exceptions, for example to show an error conditions.
+In this case, instead of stopping the execution on the first error,
+we can keep executing the notebook using the traitlet ``allow_errors``
+(default False).
 With ``allow_errors=True``,
-the notebook is executed until the end, and a ``CellExecutionError`` is raised
-if one or more cells threw an error. In this case, the output notebook
-will contain the stack-traces and error messages for all the failing cells.
+the notebook is executed until the end, regardless of any error encountered
+during the execution. The output notebook,
+will contain the stack-traces and error messages for **all** the cells
+raising exceptions.

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -5,12 +5,12 @@ Executing notebooks
 
 Jupyter notebooks are often saved with cleared output cells. nbconvert
 provides a helpful way to execute the input cells of an .ipynb notebook
-file and save the results, both input and output cells, as an .ipynb file.
+file and save the results, both input and output cells, as a .ipynb file.
 
 In this section we show how to execute a ``.ipynb`` notebook
 document saving the result in notebook format.
-If you need to export notebooks to other formats (optionally executing them
-during conversion) see section :doc:`nbconvert_library`.
+If you need to export notebooks to other formats, such as reStructured Text
+or Markdown (optionally executing them) see section :doc:`nbconvert_library`.
 
 Executing notebooks can be very helpful, for example, to run all notebooks
 in Python library in one step, or as a way to
@@ -22,7 +22,7 @@ As an example, a notebook can be executed from the command line with::
 
     jupyter nbconvert --to notebook --execute mynotebook.ipynb
 
-In this section we will (mostly) illustrate how to use the Python API interface.
+This section will illustrate the Python API interface.
 
 A Quick example
 ---------------
@@ -59,7 +59,7 @@ To actually run the notebook we call the method ``preprocess``::
 Hopefully, we will not get any errors during the notebook execution
 (see the last section for error handling). Note that ``path`` specifies
 in which folder to execute the notebook.
-Finally, to save the resulting notebook::
+Finally, save the resulting notebook with::
 
     with open('executed_notebook.ipynb', 'wt') as f:
         nbformat.write(nb, f)
@@ -98,7 +98,7 @@ in their metadata
 (depending on the kernel used the last time the notebook was saved).
 In reality, these notebooks will work on both Python 2/3 and, for testing,
 it is important to be able to execute them programmatically on both
-versions. Here the traitlet ``kernel_name`` comes to help:
+versions. Here the traitlet ``kernel_name`` is helpful:
 we can just run each notebook twice, specifying first "python2" and then
 "python3" as kernel name.
 
@@ -106,7 +106,7 @@ Error Handling
 --------------
 
 In the previous sections we saw how to save an executed notebook, assuming
-there are no execution error. But, what if there are errors?
+there are no execution errors. But, what if there are errors?
 
 An error during the notebook execution, by default, will stop the execution
 and raise a ``CellExecutionError``. Conveniently, the source cell causing
@@ -132,11 +132,11 @@ A useful pattern to execute notebooks while handling errors is the following::
 
 This will save the executed notebook regardless of execution errors.
 In case of errors, however, an additional message is printed and the
-``CellExecutionError`` is raised. The messages directs the user to
+``CellExecutionError`` is raised. The message directs the user to
 the saved notebook for further inspection.
 
 As a last scenario, it is sometimes useful to execute notebooks which
-raise exceptions, for example to show an error conditions.
+raise exceptions, for example to show an error condition.
 In this case, instead of stopping the execution on the first error,
 we can keep executing the notebook using the traitlet ``allow_errors``
 (default False).

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -3,13 +3,17 @@ Executing notebooks
 
 .. module:: nbconvert.preprocessors
 
+Jupyter notebooks are often saved with cleared output cells. nbconvert
+provides a helpful way to execute the input cells of an .ipynb notebook
+file and save the results, both input and output cells, as an .ipynb file.
+
 In this section we show how to execute a ``.ipynb`` notebook
 document saving the result in notebook format.
-To export the notebook to other formats see section
-:doc:`nbconvert_library`.
+If you need to export notebooks to other formats (optionally executing them
+during conversion) see section :doc:`nbconvert_library`.
 
-Executing notebooks programmatically is useful, for example, as a test layer
-in Python libraries that include example notebooks, or as a way to
+Executing notebooks can be very helpful, for example, to run all notebooks
+in Python library in one step, or as a way to
 automate the data analysis in projects involving more than one notebook.
 
 The same functionality of executing notebooks is exposed through a

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -14,6 +14,10 @@ automate the data analysis in projects involving more than one notebook.
 
 The same functionality of executing notebooks is exposed through a
 :doc:`command line interface <usage>` or a python API interface.
+As an example, a notebook can be executed from the command line with::
+
+    jupyter nbconvert --to notebook --execute mynotebook.ipynb
+
 In this section we will (mostly) illustrate how to use the python API interface.
 
 A Quick example
@@ -22,9 +26,7 @@ A Quick example
 Let's start with a complete quick example, leaving detailed explanations
 to the following sections.
 
-First we import nbconvert and the :class:`ExecutePreprocessor` class:
-
-.. code-block:: python
+First we import nbconvert and the :class:`ExecutePreprocessor` class::
 
     import nbformat
     from nbconvert.preprocessors import ExecutePreprocessor

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -107,7 +107,7 @@ there are no execution error. But, what if there are errors?
 An error during the notebook execution, by default, will stop the execution
 and raise a ``CellExecutionError``. Conveniently, the source cell causing
 the error and the original error name and message are also printed.
-After an error, we can still save the notebook as before:
+After an error, we can still save the notebook as before::
 
     with open('executed_notebook.ipynb', mode='wt') as f:
         nbformat.write(nb, f)

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -46,7 +46,7 @@ Next, we configure the notebook execution mode::
     ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
 
 We specified two (optional) arguments ``timeout`` and ``kernel_name``, which
-define respectively the execution timeout and the execution kernel.
+define respectively the cell execution timeout and the execution kernel.
 
     The option to specify **kernel_name** is new in nbconvert 4.2.
     When not specified or when using nbconvert <4.2,
@@ -128,7 +128,8 @@ A useful pattern to execute notebooks while handling errors is the following::
         print(msg)
         raise
     finally:
-        nbformat.write(nb, open(notebook_filename_out, mode='wt'))
+        with open(notebook_filename_out, mode='wt') as f:
+            nbformat.write(nb, f)
 
 This will save the executed notebook regardless of execution errors.
 In case of errors, however, an additional message is printed and the

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -29,17 +29,13 @@ First we import nbconvert and the :class:`ExecutePreprocessor` class:
     import nbformat
     from nbconvert.preprocessors import ExecutePreprocessor
 
-Assuming that ``notebook_filename`` is the path of a notebook,
-we can load it with:
-
-.. code-block:: python
+Assuming that ``notebook_filename`` contains the path of a notebook,
+we can load it with::
 
     with open(notebook_filename) as f:
         nb = nbformat.read(f, as_version=4)
 
-Next, we configure the notebook execution mode:
-
-.. code-block:: python
+Next, we configure the notebook execution mode::
 
     ep = ExecutePreprocessor(timeout=3600, kernel_name='python3')
 
@@ -50,18 +46,14 @@ define respectively the execution timeout and the execution kernel.
     When not specified or when using nbconvert <4.2,
     the default python kernel is chosen.
 
-To actually run the notebook we call the method ``preprocess``:
-
-.. code-block:: python
+To actually run the notebook we call the method ``preprocess``::
 
     ep.preprocess(nb, {'metadata': {'path': 'notebooks/'}})
 
 Hopefully, we will not get any errors during the notebook execution
 (see the last section for error handling). Note that ``path`` specifies
 in which folder to execute the notebook.
-Finally, to save the resulting notebook:
-
-.. code-block:: python
+Finally, to save the resulting notebook::
 
     with open('executed_notebook.ipynb', 'wt') as f:
         nbformat.write(nb, f)
@@ -115,15 +107,12 @@ and raise a ``CellExecutionError``. Conveniently, the source cell causing
 the error and the original error name and message are also printed.
 After an error, we can still save the notebook as before:
 
-.. code-block:: python
-
-    nbformat.write(nb, open('executed_notebook.ipynb', mode='wt'))
+    with open('executed_notebook.ipynb', mode='wt') as f:
+        nbformat.write(nb, f)
 
 The saved notebook contains the output up until the failing cell,
 and includes a full stack-trace and error (which can help debugging).
-A useful pattern to execute notebooks while handling errors is the following:
-
-.. code-block:: python
+A useful pattern to execute notebooks while handling errors is the following::
 
     try:
         out = ep.preprocess(nb, {'metadata': {'path': run_path}})

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -1,0 +1,145 @@
+Executing notebooks
+===================
+
+In this section we show how to execute a ``.ipynb`` notebook
+document saving the result in notebook format.
+To export the notebook to other formats see the
+:ref:`next section <nbconvert_library>`.
+
+Executing notebooks programmatically is useful, for example, as a test layer
+in python libraries that include example notebooks, or as a way to
+automate the data analysis in projects involving more than one notebook.
+
+The same functionality of executing notebooks is exposed through a
+:ref:`command line interface <commandline_usage>` or a python API interface.
+In this section we will (mostly) illustrate how to use the python API interface.
+
+A Quick example
+---------------
+
+Let's start with a complete quick example, leaving detailed explanations
+to the following sections.
+
+First we import nbconvert and the ``ExecutePreprocessor`` class:
+
+.. code-block:: python
+
+    import nbformat
+    from nbconvert.preprocessors import ExecutePreprocessor
+
+Assuming that ``notebook_filename`` is the path of a notebook,
+we can load it with:
+
+.. code-block:: python
+
+    nb = nbformat.read(open(notebook_filename), as_version=4)
+
+Next, we configure the notebook execution mode:
+
+.. code-block:: python
+
+    ep = ExecutePreprocessor(timeout=3600, kernel_name='python3')
+
+We specified two (optional) arguments ``timeout`` and ``kernel_name``, which
+define respectively the execution timeout and the execution kernel.
+
+    The **kernel_name** keyword `requires <https://github.com/jupyter/nbconvert/pull/177>`__
+    nbconvert 4.2 (unreleased, use master branch from github).
+
+To actually run the notebook we call the method ``preprocess``:
+
+.. code-block:: python
+
+    ep.preprocess(nb, {'metadata': {'path': 'notebooks/'}})
+
+Hopefully, we will not get any errors during the notebook execution
+(see the last section for error handling). Note that ``path`` specifies
+in which folder to execute the notebook.
+Finally, to save the resulting notebook:
+
+.. code-block:: python
+
+    nbformat.write(nb, open('executed_notebook.ipynb', mode='wt'))
+
+That's all. Your executed notebook will be saved in the current folder
+in the file *executed_notebook.ipynb*.
+
+Execution arguments
+-------------------
+
+The arguments passed to ``ExecutePreprocessor`` are configuration options
+called `traitlets <http://traitlets.readthedocs.org/>`_.
+There are many cool things about traitlets, for example
+they enforce the type of the input and they can be accessed/modified as
+class attributes. Moreover, each traitlet is automatically exposed
+as command-line options. For example, we can pass the timeout from the
+command-line like this::
+
+    jupyter nbconvert --ExecutePreprocessor.timeout=3600 --to notebook --execute mynotebook.ipynb
+
+Let's now discuss in more detail the two traitlets we used.
+
+The ``timeout`` traitlet defines the maximum time (in seconds) the notebook is
+allowed to run, if the execution takes longer an exception will be raised.
+The default is only 30 s, so in many cases you may want to specify
+an higher value.
+
+The second traitlet, ``kernel_name``, allows specifying the name of the kernel
+to be used for the execution. By default, the kernel name is obtained from the
+notebook metadata. The traitlet ``kernel_name`` allows to specify a user-defined
+kernel, overriding the value in the notebook metadata. A common use case
+is that of a python 2/3 library which includes documentation/testing
+notebooks. These notebooks will specify either a python2 or python3 kernel
+in their metadata
+(depending on the kernel used the last time the notebook was saved).
+In reality, these notebooks will work on both python 2/3 and, for testing,
+it is important to be able to execute them programmatically on both
+versions. Here the traitlet ``kernel_name`` comes to help:
+we can just run each notebook twice, specifying first "python2" and then
+"python3" as kernel name.
+
+Error Handling
+--------------
+
+In the previous sections we saw how to save an executed notebook, assuming
+there are no execution error. But, what if there are errors?
+
+An error during the notebook execution, by default, will stop the execution
+and raise a ``CellExecutionError``. Conveniently, the source cell causing
+the error and the original error name and message are also printed.
+After an error, we can still save the notebook as before:
+
+.. code-block:: python
+
+    nbformat.write(nb, open('executed_notebook.ipynb', mode='wt'))
+
+The saved notebook contains the output up until the failing cell,
+and includes a full stack-trace and error (which can help debugging).
+A pattern I use to execute notebooks while handling errors is the following:
+
+.. code-block:: python
+
+    try:
+        out = ep.preprocess(nb, {'metadata': {'path': run_path}})
+    except CellExecutionError:
+        msg = 'Error executing the notebook "%s".\n\n' % notebook_filename
+        msg += 'See notebook "%s" for the traceback.' % notebook_filename_out
+        print(msg)
+        raise
+    finally:
+        nbformat.write(nb, open(notebook_filename_out, mode='wt'))
+
+This will save the executed notebook regardless of execution errors.
+In case of errors, however, an additional message is printed and the
+``CellExecutionError`` is raised. The messages directs the user to
+the saved notebook for further inspection.
+
+As a last scenario, sometimes notebooks contains independent computations
+in each code cell.
+In this case it can be useful to run the notebook until the end,
+in order to get a complete picture of all cells that are failing.
+Luckily enough, the ``allow_errors`` traitlet (default False) allows to do that.
+With ``allow_errors=True``,
+the notebook is executed until the end, and a ``CellExecutionError`` is raised
+if one or more cells threw an error. In this case, the output notebook
+will contain the stack-traces and error messages for all the failing cells.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ document file into various static formats. It can also execute notebooks
 programmatically.
 
 ``nbconvert`` is both a python library and a command line tool (invoked as
-``juyter nbconvert ...``).
+``jupyter nbconvert ...``).
 The ``nbconvert`` library is also used to implement the 'Download as' feature within the
 Jupyter Notebook web app.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,9 @@ The ``nbconvert`` tool allows you to convert an ``.ipynb`` notebook
 document file into various static formats. It can also execute notebooks
 programmatically.
 
-Currently, ``nbconvert`` is provided as a command line tool, run as a script
-using Jupyter. It also powers the 'Download as' feature within the
+``nbconvert`` is both a python library and a command line tool (invoked as
+``juyter nbconvert ...``).
+The ``nbconvert`` library is also used to implement the 'Download as' feature within the
 Jupyter Notebook web app.
 
 Contents:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Contents:
    config_options
    latex_citations
    customizing
+   execute_api
    nbconvert_library
    api/index
    changelog

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,8 @@ Converting Notebooks to Other Formats
 =====================================
 
 The ``nbconvert`` tool allows you to convert an ``.ipynb`` notebook
-document file into various static formats.
+document file into various static formats. It can also execute notebooks
+programmatically.
 
 Currently, ``nbconvert`` is provided as a command line tool, run as a script
 using Jupyter. It also powers the 'Download as' feature within the

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,5 +1,3 @@
-.. commandline_usage:
-
 Command-Line Usage
 ==================
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,3 +1,5 @@
+.. commandline_usage:
+
 Command-Line Usage
 ==================
 

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -39,8 +39,8 @@ class ExecutePreprocessor(Preprocessor):
         help=dedent(
             """
             The time to wait (in seconds) for output from executions.
-            If a cell execution takes longer, a `CellExecutionError`
-            is raised.
+            If a cell execution takes longer, an exception (TimeoutError
+            on python 3+, RuntimeError on python 2) is raised.
             """
         )
     )

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -36,7 +36,13 @@ class ExecutePreprocessor(Preprocessor):
     """
 
     timeout = Integer(30, config=True,
-        help="The time to wait (in seconds) for output from executions."
+        help=dedent(
+            """
+            The time to wait (in seconds) for output from executions.
+            If a cell execution takes longer, a `CellExecutionError`
+            is raised.
+            """
+        )
     )
 
     interrupt_on_timeout = Bool(

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -78,6 +78,27 @@ class ExecutePreprocessor(Preprocessor):
 
 
     def preprocess(self, nb, resources):
+        """
+        Preprocess notebook executing each code cell.
+
+        The input argument `nb` is modified in-place.
+
+        Parameters
+        ----------
+        nb : NotebookNode
+            Notebook being executed.
+        resources : dictionary
+            Additional resources used in the conversion process. For example,
+            passing ``{'metadata': {'path': run_path}}`` sets the
+            execution path to ``run_path``.
+
+        Returns
+        -------
+        nb : NotebookNode
+            The executed notebook.
+        resources : dictionary
+            Additional resources used in the conversion process.
+        """
         path = resources.get('metadata', {}).get('path', '')
         if path == '':
             path = None
@@ -104,7 +125,9 @@ class ExecutePreprocessor(Preprocessor):
 
     def preprocess_cell(self, cell, resources, cell_index):
         """
-        Apply a transformation on each code cell. See base.py for details.
+        Executes a single code cell. See base.py for details.
+
+        To execute all cells see :meth:`preprocess`.
         """
         if cell.cell_type != 'code':
             return cell, resources

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -54,10 +54,12 @@ class ExecutePreprocessor(Preprocessor):
         False, config=True,
         help=dedent(
             """
-            If `True`, a `CellExecutionError` is raised if any of the notebook
-            cells raises an exception during execution. Otherwise, execution
-            is continued and the output from the exception is included in the
-            cell output.
+            If `False` (default), when a cell raises an error the
+            execution is stoppped and a `CellExecutionError`
+            is raised.
+            If `True`, execution errors are ignored and the execution
+            is continued until the end of the notebook. Output from
+            exceptions is included in the cell output in both cases.
             """
         )
     )


### PR DESCRIPTION
This section shows how to execute notebooks using nbconvert API. The executed notebook is saved in notebook format. There is no discussion on exporting notebooks to other format (topic already addressed in another section of the docs).

This is heavily based on this blog post: [Batch Execution of Jupyter Notebooks](http://tritemio.github.io/smbits/2016/01/02/execute-notebooks/).

Except for links/formatting fixes it should be ready for review. I can rebase to clean history before merge.