### PR TITLE
Update copyright date in docs.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,9 +13,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-import shlex
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -60,7 +58,9 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'nbconvert'
-copyright = '2015, Jupyter Development Team'
+from datetime import date
+year = date.today().year
+copyright = '2015-%s, Jupyter Development Team' % year
 author = 'Jupyter Development Team'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Unlike source code, we can make it dynamic here. 
And I put the 2 dates just to avoid dispute of wether we want `initialYear` or `currentYear` in copyright notice. 