### PR TITLE
Don't remove the newline when converting notebooks to notebooks (#207)

### DIFF
--- a/nbconvert/exporters/notebook.py
+++ b/nbconvert/exporters/notebook.py
@@ -29,4 +29,6 @@ class NotebookExporter(Exporter):
         else:
             resources['output_suffix'] = '.nbconvert'
         output = nbformat.writes(nb_copy, version=self.nbformat_version)
+        if not output.endswith("\n"):
+            output = output + "\n"
         return output, resources

--- a/nbconvert/exporters/tests/test_notebook.py
+++ b/nbconvert/exporters/tests/test_notebook.py
@@ -24,7 +24,7 @@ class TestNotebookExporter(ExportersTestsBase):
             file_contents = f.read()
         (output, resources) = self.exporter_class().from_filename(self._get_notebook())
         assert len(output) > 0
-        assert_big_text_equal(output.strip(), file_contents.strip())
+        assert_big_text_equal(output, file_contents)
 
     def test_downgrade_3(self):
         exporter = self.exporter_class(nbformat_version=3)


### PR DESCRIPTION
Fixes #207.
I checked, and the regression test without the ``strip`` didn't pass before, but now passes.