### PR TITLE
Added a comment on Jinja expression syntax

### DIFF
--- a/docs/source/customizing.rst
+++ b/docs/source/customizing.rst
@@ -208,6 +208,10 @@ A few gotchas
 Jinja blocks use ``{% %}`` by default which does not play nicely with
 LaTeX, so those are replaced by ``((* *))`` in LaTeX templates.
 
+Jinja expressions use ``{{ }}`` by default which does not play nicely with
+LaTeX, so those are replaced by ``((( )))`` in LaTeX templates.
+
+
 Templates that use cell metadata
 --------------------------------
 


### PR DESCRIPTION
Support for Jinja expressions syntax seems to be present, but undocumented (as far as I could tell).

To do something simple, adding one LaTeX package, it's appealing to create a new template that inherits from 'article.tplx' and uses Jinja's super() expression in the packages block.  The super() expression will inherit the previous contents of the block, which makes things much easier.
Example:
```latex
((* extends 'article.tplx' *))
((* block packages *))
% Use a different font:
\usepackage{libertine}
((( super() )))
((* endblock packages *))
```