### PR TITLE
Add support for discovering separately installed exporters using entry points

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -14,6 +14,7 @@ import sys
 import os
 import glob
 
+import entrypoints
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
 from traitlets.config import catch_config_error, Configurable
 from traitlets import (
@@ -47,9 +48,16 @@ def get_exporter(name):
             log = logging.getLogger()
             log.error("Error importing %s" % name, exc_info=True)
             pass
+    else:
+        try:
+            return entrypoints.get_single('nbconvert.exporter', name).load()
+        except entrypoints.NoSuchEntryPoint:
+            pass
 
+    valid_names = sorted(get_export_names() +
+                     list(entrypoints.get_group_named('nbconvert.exporter')))
     raise ValueError('Unknown exporter "%s", did you mean one of: %s?'
-                     % (name, ', '.join(sorted(get_export_names()))))
+                     % (name, ', '.join(valid_names)))
 
 
 class DottedOrNone(DottedObjectName):

--- a/nbconvert/tests/exporter_entrypoint/eptest-0.1.dist-info/entry_points.txt
+++ b/nbconvert/tests/exporter_entrypoint/eptest-0.1.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[nbconvert.exporter]
+entrypoint_test = eptest:DummyExporter

--- a/nbconvert/tests/exporter_entrypoint/eptest.py
+++ b/nbconvert/tests/exporter_entrypoint/eptest.py
@@ -1,0 +1,4 @@
+from nbconvert.exporters import Exporter
+
+class DummyExporter(Exporter):
+    pass

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -6,9 +6,12 @@
 
 import os
 import io
+import sys
 
 from .base import TestsBase
 from ..postprocessors import PostProcessorBase
+from nbconvert import nbconvertapp
+from nbconvert.exporters import Exporter
 
 from traitlets.tests.utils import check_help_all_output
 from ipython_genutils.testing import decorators as dec
@@ -358,3 +361,12 @@ class TestNbConvertApp(TestsBase):
         with self.create_temp_cwd(['latex-linked-image.ipynb', 'testimage.png']):
             self.nbconvert('--to pdf latex-linked-image.ipynb')
             assert os.path.isfile('latex-linked-image.pdf')
+
+def test_get_exporter_entrypoint():
+    p = os.path.join(os.path.dirname(__file__), 'exporter_entrypoint')
+    sys.path.insert(0, p)
+    try:
+        cls = nbconvertapp.get_exporter('entrypoint_test')
+        assert issubclass(cls, Exporter), cls
+    finally:
+        del sys.path[0]

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ package_data = {
     'nbconvert.resources' : ['style.min.css'],
     'nbconvert' : [
         'tests/files/*.*',
-        'tests/exporter_entrypoint/*.*',
+        'tests/exporter_entrypoint/*.py',
         'tests/exporter_entrypoint/*/*.*',
         'exporters/tests/files/*.*',
         'preprocessors/tests/files/*.*',

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ package_data = {
     'nbconvert.resources' : ['style.min.css'],
     'nbconvert' : [
         'tests/files/*.*',
+        'tests/exporter_entrypoint/*.*',
+        'tests/exporter_entrypoint/*/*.*',
         'exporters/tests/files/*.*',
         'preprocessors/tests/files/*.*',
     ],

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ install_requires = setuptools_args['install_requires'] = [
     'traitlets',
     'jupyter_core',
     'nbformat',
+    'entrypoints',
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
The group name to advertise additional exporters is `nbconvert.exporter`.

This adds a dependency on my (tiny) [entrypoints](http://entrypoints.readthedocs.org/en/latest/index.html) module.