### PR TITLE
Don't instantiate InteractiveShell to for ipython2python filter

### DIFF
--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -190,7 +190,6 @@ def ipython2python(code):
     """
     try:
         from IPython.core.inputsplitter import IPythonInputSplitter
-        from IPython.core.interactiveshell import InteractiveShell
     except ImportError:
         warnings.warn(
             "IPython is needed to transform IPython syntax to pure Python."

--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -189,6 +189,7 @@ def ipython2python(code):
         IPython code, to be transformed to pure Python
     """
     try:
+        from IPython.core.inputsplitter import IPythonInputSplitter
         from IPython.core.interactiveshell import InteractiveShell
     except ImportError:
         warnings.warn(
@@ -197,8 +198,8 @@ def ipython2python(code):
         )
         return code
     else:
-        shell = InteractiveShell.instance()
-        return shell.input_transformer_manager.transform_cell(code)
+        isp = IPythonInputSplitter(line_input_checker=False)
+        return isp.transform_cell(code)
 
 def posix_path(path):
     """Turn a path into posix-style path/to/etc


### PR DESCRIPTION
Closes jupyter/notebook#1043 (hopefully)

In the notebook server, this was being run in a non-main thread (I guess). InteractiveShell registers atexit operations, which are run in the main thread, causing intermittent problems. Luckily, we don't
actually need all the shell functionality here, just the machinery to transform IPython special syntax.