### PR TITLE
Shorter timeout for collecting iopub messages after executing

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -197,7 +197,12 @@ class ExecutePreprocessor(Preprocessor):
 
         while True:
             try:
-                msg = self.kc.iopub_channel.get_msg(timeout=1)
+                # We've already waited for execute_reply, so all output
+                # should already be waiting. However, on slow networks, like
+                # in certain CI systems, waiting < 1 second might miss messages.
+                # So long as the kernel sends a status:idle message when it
+                # finishes, we won't actually have to wait this long, anyway.
+                msg = self.kc.iopub_channel.get_msg(timeout=4)
             except Empty:
                 self.log.warn("Timeout waiting for IOPub output")
                 break

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -197,7 +197,7 @@ class ExecutePreprocessor(Preprocessor):
 
         while True:
             try:
-                msg = self.kc.iopub_channel.get_msg(timeout=self.timeout)
+                msg = self.kc.iopub_channel.get_msg(timeout=1)
             except Empty:
                 self.log.warn("Timeout waiting for IOPub output")
                 break


### PR DESCRIPTION
When this runs, we have already waited up to self.timeout seconds for execute_reply, so all the outputs should already be queued.

This should make execution much faster for kernels that don't send the kernel status messages.

Closes gh-234