### PR TITLE
Restructure LaTeX templates

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -3,7 +3,7 @@ This template builds upon the abstract template, adding common latex output
 functions.  Figures, data_text,
 This template does not define a docclass, the inheriting class must define this.=))
 
-((*- extends 'display_priority.tplx' -*))
+((*- extends 'document_contents.tplx' -*))
 
 %===============================================================================
 % Abstract overrides
@@ -152,74 +152,3 @@ This template does not define a docclass, the inheriting class must define this.
     ((* endblock postdoc *))
     \end{document}
 ((* endblock body *))
-
-%===============================================================================
-% Support blocks
-%===============================================================================
-
-% Displaying simple data text
-((* block data_text *))
-    \begin{verbatim}
-((( output.data['text/plain'] )))
-    \end{verbatim}
-((* endblock data_text *))
-
-% Display python error text as-is
-((* block error *))
-    \begin{Verbatim}[commandchars=\\\{\}]
-((( super() )))
-    \end{Verbatim}
-((* endblock error *))
-((* block traceback_line *))
-    ((( line | indent | strip_ansi | escape_latex )))
-((* endblock traceback_line *))
-
-% Display stream ouput with coloring
-((* block stream *))
-    \begin{Verbatim}[commandchars=\\\{\}]
-((( output.text | escape_latex | ansi2latex )))
-    \end{Verbatim}
-((* endblock stream *))
-
-% Display latex
-((* block data_latex -*))
-    ((( output.data['text/latex'] | citation2latex | strip_files_prefix | markdown2latex )))
-((* endblock data_latex *))
-
-% Display markdown
-((* block data_markdown -*))
-    ((( output.data['text/markdown'] | citation2latex | strip_files_prefix | markdown2latex )))
-((* endblock data_markdown *))
-
-% Default mechanism for rendering figures
-((*- block data_png -*))((( draw_figure(output.metadata.filenames['image/png']) )))((*- endblock -*))
-((*- block data_jpg -*))((( draw_figure(output.metadata.filenames['image/jpeg']) )))((*- endblock -*))
-((*- block data_svg -*))((( draw_figure(output.metadata.filenames['image/svg+xml']) )))((*- endblock -*))
-((*- block data_pdf -*))((( draw_figure(output.metadata.filenames['application/pdf']) )))((*- endblock -*))
-
-% Draw a figure using the graphicx package.
-((* macro draw_figure(filename) -*))
-((* set filename = filename | posix_path *))
-((*- block figure scoped -*))
-    \begin{center}
-    \adjustimage{max size={0.9\linewidth}{0.9\paperheight}}{((( filename )))}
-    \end{center}
-    { \hspace*{\fill} \\}
-((*- endblock figure -*))
-((*- endmacro *))
-
-% Redirect execute_result to display data priority.
-((* block execute_result scoped *))
-    ((* block data_priority scoped *))
-    ((( super() )))
-    ((* endblock *))
-((* endblock execute_result *))
-
-% Render markdown
-((* block markdowncell scoped *))
-    ((( cell.source | citation2latex | strip_files_prefix | markdown2latex )))
-((* endblock markdowncell *))
-
-% Don't display unknown types
-((* block unknowncell scoped *))
-((* endblock unknowncell *))

--- a/nbconvert/templates/latex/document_contents.tplx
+++ b/nbconvert/templates/latex/document_contents.tplx
@@ -1,0 +1,72 @@
+((*- extends 'display_priority.tplx' -*))
+
+%===============================================================================
+% Support blocks
+%===============================================================================
+
+% Displaying simple data text
+((* block data_text *))
+    \begin{verbatim}
+((( output.data['text/plain'] )))
+    \end{verbatim}
+((* endblock data_text *))
+
+% Display python error text as-is
+((* block error *))
+    \begin{Verbatim}[commandchars=\\\{\}]
+((( super() )))
+    \end{Verbatim}
+((* endblock error *))
+((* block traceback_line *))
+    ((( line | indent | strip_ansi | escape_latex )))
+((* endblock traceback_line *))
+
+% Display stream ouput with coloring
+((* block stream *))
+    \begin{Verbatim}[commandchars=\\\{\}]
+((( output.text | escape_latex | ansi2latex )))
+    \end{Verbatim}
+((* endblock stream *))
+
+% Display latex
+((* block data_latex -*))
+    ((( output.data['text/latex'] | citation2latex | strip_files_prefix | markdown2latex )))
+((* endblock data_latex *))
+
+% Display markdown
+((* block data_markdown -*))
+    ((( output.data['text/markdown'] | citation2latex | strip_files_prefix | markdown2latex )))
+((* endblock data_markdown *))
+
+% Default mechanism for rendering figures
+((*- block data_png -*))((( draw_figure(output.metadata.filenames['image/png']) )))((*- endblock -*))
+((*- block data_jpg -*))((( draw_figure(output.metadata.filenames['image/jpeg']) )))((*- endblock -*))
+((*- block data_svg -*))((( draw_figure(output.metadata.filenames['image/svg+xml']) )))((*- endblock -*))
+((*- block data_pdf -*))((( draw_figure(output.metadata.filenames['application/pdf']) )))((*- endblock -*))
+
+% Draw a figure using the graphicx package.
+((* macro draw_figure(filename) -*))
+((* set filename = filename | posix_path *))
+((*- block figure scoped -*))
+    \begin{center}
+    \adjustimage{max size={0.9\linewidth}{0.9\paperheight}}{((( filename )))}
+    \end{center}
+    { \hspace*{\fill} \\}
+((*- endblock figure -*))
+((*- endmacro *))
+
+% Redirect execute_result to display data priority.
+((* block execute_result scoped *))
+    ((* block data_priority scoped *))
+    ((( super() )))
+    ((* endblock *))
+((* endblock execute_result *))
+
+% Render markdown
+((* block markdowncell scoped *))
+    ((( cell.source | citation2latex | strip_files_prefix | markdown2latex )))
+((* endblock markdowncell *))
+
+% Don't display unknown types
+((* block unknowncell scoped *))
+((* endblock unknowncell *))


### PR DESCRIPTION
This is a first attempt to slightly restructure the LaTeX templates with the aim to make it easier to embed nbconvert's LaTeX output in another LaTeX document (see #239). The only thing this PR currently does is move the support blocks into a separate template called `latex/document_contents.tplx` as suggested by @takluyver.

With this change, when I run nbconvert using `--template document_contents.tplx` this creates a .tex file which contains only the parts between `\begin{document}` and `\end{document}` so that I can include it in another LaTeX document. However, the conversion also removes the "input" parts of any code cells because the relevant template blocks are defined in `style_ipython.tplx`, which is further down the template hierarchy. For my use case, stripping code input happens to be precisely what I need, but it should of course be supported to keep the input.

In an attempt to support this, I tried to move `style_ipython.tplx` further up in the hierarchy but ran into issues due to the way some template blocks currently inherit from / depend on each other. I don't currently have time to debug this but wanted to open a PR for discussion anyway.

One additional complication is that in order to correctly compile the resulting LaTeX code a whole lot of preamble definitions are needed (at least if the input part of code cells is to be retained; otherwise only a handful of packages need to be included). These LaTeX definitions live in `base.tplx`, but if nbconvert is called with the `document_contents.tplx` template then the user needs to copy these manually as they won't be part of the converted .tex file. I wonder if it would be feasible to provide a .sty file to make this less painful (but I don't know how to easily make this visible to the user's LaTeX installation).

Any comments / input / suggestions on any of this are welcome.