### PR TITLE
Fixes #199 : make emph be rendered as italics in pdf

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -33,7 +33,8 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{hyperref}
     \usepackage{longtable} % longtable support required by pandoc >1.10
     \usepackage{booktabs}  % table support for pandoc > 1.12.2
-    \usepackage{ulem} % ulem is needed to support strikethroughs (\sout)
+    \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
+                                % normalem makes italics be italics, not underlines
     ((* endblock packages *))
 
     ((* block definitions *))


### PR DESCRIPTION
Fixes #199.
Makes sure ``\emph`` are rendered as italics and not as underlines.
I tested and it works. As this is a rendering issue (I think), I'm not sure how to add a test.