### PR TITLE
Make Exporter.from_filename() use self.from_file()

### DIFF
--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -162,7 +162,7 @@ class Exporter(LoggingConfigurable):
         resources['metadata']['modified_date'] = modified_date.strftime(text.date_format)
 
         with io.open(filename, encoding='utf-8') as f:
-            return self.from_notebook_node(nbformat.read(f, as_version=4), resources=resources, **kw)
+            return self.from_file(f, resources=resources, **kw)
 
 
     def from_file(self, file_stream, resources=None, **kw):


### PR DESCRIPTION
In the spirit of polymorphism, `nbconvert.Exporter.from_filename()` should delegate to `self.from_file()`, or am I missing something?

BTW, what's with the ignored keyword args?
In my experience, unchecked keyword arguments are often a source of subtle bugs and major frustration.