### PR TITLE
Document entrypoints for custom exporters

### DIFF
--- a/docs/source/external_exporters.rst
+++ b/docs/source/external_exporters.rst
@@ -5,26 +5,62 @@ Using external exporters
 
 .. versionadded:: 4.2
 
-    You can now use the ``--to`` flag to use custom export formats defined in other
-    libraries.
+    You can now use the ``--to`` flag to use custom export formats defined outside nbconvert.
 
 
 The command-line syntax to run the ``nbconvert`` script is::
 
-  $ jupyter nbconvert --to FORMAT notebook.ipynb
+  jupyter nbconvert --to FORMAT notebook.ipynb
 
 This will convert the Jupyter document file ``notebook.ipynb`` into the output
 format designated by the ``FORMAT`` string as explained below.
 
 A few built-in formats are available by default: `html`, `pdf`,
 `script`, `latex`. Each of these has its own _exporter_ with many configuration
-options that can be extended. Having the option to point to a different _exporter_ 
-allows authors to create their own fully customized templates. 
+options that can be extended. Having the option to point to a different _exporter_
+allows authors to create their own fully customized templates or export formats.
 
-A custom _exporter_ must be a globally importable python object. We recommend that
-these be distributed as python libraries.
 
-To export using an exporter from an external library, use the `fully qualified`
+A custom _exporter_ must be an importable Python object. We recommend that
+these be distributed as Python libraries.
+
+.. _entrypoints:
+
+Entry points
+------------
+
+Additional exporters may be registered as `entry points`_.
+nbconvert uses the ``nbconvert.exporters`` entry point to find exporters from any package you may have installed.
+
+If you are writing a Python package that provides an exporter,
+you can register them in your package's :file:`setup.py`:
+
+.. sourcecode:: python
+
+    setup(
+        ...
+        entry_points = {
+            'nbconvert.exporters': [
+                'foo = mymodule.FooExporter',
+                'bar = mymodule.BarExporter',
+            ],
+        }
+    )
+
+This will enable people who have installed your package to call::
+
+    jupyter nbconvert --to foo mynotebook.ipynb
+
+instead of having to specify the full import name of your exporters.
+
+.. _entry points: https://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins
+
+
+Exporters without entrypoints
+-----------------------------
+
+Custom exporters are encouraged to register themselves with entrypoints, as described above.
+If an exporter is not registered with an entrypoint, it can still be used with the fully qualified
 name of this exporter on the command line as the argument of the ``--to`` flag::
 
   $ jupyter nbconvert --to <full.qualified.name> notebook.ipynb
@@ -38,8 +74,8 @@ A library can therefore contain multiple exporters. All other flags of the comma
 line should behave the same as for built-in exporters. 
 
 
-Parameters controlled by external exporter
-==========================================
+Parameters controlled by an external exporter
+=============================================
 
 An external exporter can control almost any parameter of the notebook conversion
 process, from simple parameters such as the output file extension, to more complex

--- a/docs/source/external_exporters.rst
+++ b/docs/source/external_exporters.rst
@@ -53,7 +53,7 @@ This will enable people who have installed your package to call::
 
 instead of having to specify the full import name of your exporters.
 
-.. _entry points: https://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins
+.. _entry points: https://packaging.python.org/en/latest/distributing/#entry-points
 
 
 Exporters without entrypoints

--- a/docs/source/external_exporters.rst
+++ b/docs/source/external_exporters.rst
@@ -41,8 +41,8 @@ you can register them in your package's :file:`setup.py`:
         ...
         entry_points = {
             'nbconvert.exporters': [
-                'foo = mymodule.FooExporter',
-                'bar = mymodule.BarExporter',
+                'foo = mymodule:FooExporter',
+                'bar = mymodule:BarExporter',
             ],
         }
     )

--- a/nbconvert/exporters/export.py
+++ b/nbconvert/exporters/export.py
@@ -185,7 +185,7 @@ def get_exporter(name):
         return exporter_map[name.lower()]
 
     try:
-        return entrypoints.get_single('nbconvert.exporter', name).load()
+        return entrypoints.get_single('nbconvert.exporters', name).load()
     except entrypoints.NoSuchEntryPoint:
         pass
 
@@ -207,4 +207,4 @@ def get_export_names():
     them as an nbconvert.exporter entrypoint.
     """
     return sorted(exporter_map.keys()) + \
-           sorted(entrypoints.get_group_named('nbconvert.exporter'))
+           sorted(entrypoints.get_group_named('nbconvert.exporters'))

--- a/nbconvert/exporters/tests/test_export.py
+++ b/nbconvert/exporters/tests/test_export.py
@@ -6,11 +6,12 @@ Module with tests for export.py
 # Distributed under the terms of the Modified BSD License.
 
 import os
+import sys
 
 import nbformat
 
 from .base import ExportersTestsBase
-from ..export import *
+from ..export import get_exporter, export_by_name, export, Exporter, ExporterNameError, get_export_names
 from ..python import PythonExporter
 
 
@@ -87,4 +88,14 @@ class TestExport(ExportersTestsBase):
             (output, resources) = export(None, self._get_notebook())
         except TypeError:
             pass
-                
+
+def test_get_exporter_entrypoint():
+    import nbconvert.tests
+    p = os.path.join(os.path.dirname(nbconvert.tests.__file__), 'exporter_entrypoint')
+    sys.path.insert(0, p)
+    assert 'entrypoint_test' in get_export_names()
+    try:
+        cls = get_exporter('entrypoint_test')
+        assert issubclass(cls, Exporter), cls
+    finally:
+        del sys.path[0]

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -14,7 +14,6 @@ import sys
 import os
 import glob
 
-import entrypoints
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
 from traitlets.config import catch_config_error, Configurable
 from traitlets import (
@@ -23,7 +22,7 @@ from traitlets import (
 
 from ipython_genutils.importstring import import_item
 
-from .exporters.export import get_export_names, exporter_map
+from .exporters.export import get_export_names, get_exporter
 from nbconvert import exporters, preprocessors, writers, postprocessors, __version__
 from .utils.base import NbConvertBase
 from .utils.exceptions import ConversionException
@@ -32,33 +31,6 @@ from .utils.io import unicode_stdin_stream
 #-----------------------------------------------------------------------------
 #Classes and functions
 #-----------------------------------------------------------------------------
-
-def get_exporter(name):
-    """ given an exporter name, return a class ready to be instantiate
-    
-    Raises ValueError if exporter is not found
-    """
-    if name.lower() in exporter_map:
-        return exporter_map[name.lower()]
-
-    if '.' in name:
-        try:
-            return import_item(name)
-        except ImportError:
-            log = logging.getLogger()
-            log.error("Error importing %s" % name, exc_info=True)
-            pass
-    else:
-        try:
-            return entrypoints.get_single('nbconvert.exporter', name).load()
-        except entrypoints.NoSuchEntryPoint:
-            pass
-
-    valid_names = sorted(get_export_names() +
-                     list(entrypoints.get_group_named('nbconvert.exporter')))
-    raise ValueError('Unknown exporter "%s", did you mean one of: %s?'
-                     % (name, ', '.join(valid_names)))
-
 
 class DottedOrNone(DottedObjectName):
     """

--- a/nbconvert/tests/exporter_entrypoint/eptest-0.1.dist-info/entry_points.txt
+++ b/nbconvert/tests/exporter_entrypoint/eptest-0.1.dist-info/entry_points.txt
@@ -1,2 +1,2 @@
-[nbconvert.exporter]
+[nbconvert.exporters]
 entrypoint_test = eptest:DummyExporter

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -374,11 +374,3 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile('notebook4_jpeg.tex')
 
 
-def test_get_exporter_entrypoint():
-    p = os.path.join(os.path.dirname(__file__), 'exporter_entrypoint')
-    sys.path.insert(0, p)
-    try:
-        cls = nbconvertapp.get_exporter('entrypoint_test')
-        assert issubclass(cls, Exporter), cls
-    finally:
-        del sys.path[0]


### PR DESCRIPTION
In writing the docs, I noticed a few things to change:

- I consolidated the entrypoints code into the existing exporter discovery,
  so they are available from Python APIs, not just the CLI.
- Following existing conventions, I made the entry point name plural instead of singular.