### PR TITLE
Raise error on iopub timeout in execute preprocessor

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -85,6 +85,20 @@ class ExecutePreprocessor(Preprocessor):
         )
     )
 
+    raise_on_iopub_timeout = Bool(
+        False, config=True,
+        help=dedent(
+            """
+            If `False` (default), then the kernel will continue waiting for
+            iopub messages until it receives all of them. If `True`, then an
+            error will be thrown after the first timeout. This option generally
+            does not need to be used, but may be useful in contexts where there
+            is the possibility of executing notebooks with memory-consuming
+            infinite loops.
+            """
+            )
+        )
+
 
     def preprocess(self, nb, resources):
         """
@@ -205,7 +219,10 @@ class ExecutePreprocessor(Preprocessor):
                 msg = self.kc.iopub_channel.get_msg(timeout=4)
             except Empty:
                 self.log.warn("Timeout waiting for IOPub output")
-                break
+                if self.raise_on_iopub_timeout:
+                    raise RuntimeError("Timeout waiting for IOPub output")
+                else:
+                    break
             if msg['parent_header'].get('msg_id') != msg_id:
                 # not an output from our execution
                 continue

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -90,11 +90,12 @@ class ExecutePreprocessor(Preprocessor):
         help=dedent(
             """
             If `False` (default), then the kernel will continue waiting for
-            iopub messages until it receives all of them. If `True`, then an
-            error will be thrown after the first timeout. This option generally
-            does not need to be used, but may be useful in contexts where there
-            is the possibility of executing notebooks with memory-consuming
-            infinite loops.
+            iopub messages until it receives a kernel idle message, or until a
+            timeout occurs, at which point the currently executing cell will be
+            skipped. If `True`, then an error will be raised after the first
+            timeout. This option generally does not need to be used, but may be
+            useful in contexts where there is the possibility of executing
+            notebooks with memory-consuming infinite loops.
             """
             )
         )


### PR DESCRIPTION
For nbgrader, it is possible that long-running, memory consuming cells will produce an iopub timeout. This causes the nbconvert preprocessor to just break out of the loop and continue executing other cells, which isn't what we'd want for nbgrader (see https://github.com/jupyter/nbgrader/issues/427). This PR makes it configurable whether to break out of the loop or throw an error, with the current behavior remaining the default option.