### PR TITLE
Cleanup and document that `timeout` can be None, -1

### DIFF
--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -4,6 +4,10 @@ import os.path
 from nbconvert.nbconvertapp import NbConvertApp
 
 header = """\
+
+.. This is an automatically generated file.
+.. do not modify by hand.
+
 Configuration options
 =====================
 

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -86,7 +86,8 @@ The ``timeout`` traitlet defines the maximum time (in seconds) each notebook
 cell is
 allowed to run, if the execution takes longer an exception will be raised.
 The default is 30 s, so in cases of long-running cells you may want to specify
-an higher value.
+an higher value. The ``timeout`` option can also be set to ``None`` or ``-1``
+to remove any restriction on execution time.  
 
 The second traitlet, ``kernel_name``, allows specifying the name of the kernel
 to be used for the execution. By default, the kernel name is obtained from the

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -93,9 +93,7 @@ nbconvert_flags.update({
         },
         """Run nbconvert in place, overwriting the existing notebook (only 
         relevant when converting to notebook format)"""
-        ),
-
-
+        )
 })
 
 

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -45,7 +45,7 @@ class ExecutePreprocessor(Preprocessor):
             If a cell execution takes longer, an exception (TimeoutError
             on python 3+, RuntimeError on python 2) is raised.
 
-            `None`, or `0` will disable the timeout.
+            `None` or `-1` will disable the timeout.
             """
         )
     )
@@ -184,7 +184,7 @@ class ExecutePreprocessor(Preprocessor):
         while True:
             try:
                 timeout = self.timeout
-                if timeout <= 0:
+                if timeout < 0:
                     timeout = None
                 msg = self.kc.shell_channel.get_msg(timeout=timeout)
             except Empty:

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -11,11 +11,6 @@ import io
 import os
 import re
 
-try:
-    from queue import Empty  # Py 3
-except ImportError:
-    from Queue import Empty  # Py 2
-
 import nbformat
 
 from .base import PreprocessorTestsBase


### PR DESCRIPTION
Cf #260 for implementation and closes #256 

Also add a preventive header in a non-git-tracked file, that it is auto generated. 
@sandyshao worked on #260 so adding here to the issue so that she can
see how documentation is added to a project. 

@sandyshao once this get merged, you will be able to see the docs automatically updating [here](http://nbconvert.readthedocs.org/en/latest/).