### PR TITLE
Use upright quotes for code in LaTeX

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -13,6 +13,7 @@ This template does not define a docclass, the inheriting class must define this.
     ((* block docclass *))((* endblock docclass *))
     
     ((* block packages *))
+    \usepackage[T1]{fontenc}
     % Nicer default font than Computer Modern for most use cases
     \usepackage{palatino}
 

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -43,6 +43,11 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{amsmath} % Equations
     \usepackage{amssymb} % Equations
     \usepackage{textcomp} % defines textquotesingle
+    % Hack from http://tex.stackexchange.com/a/47451/13684:
+    \AtBeginDocument{%
+        \def\PYZsq{\textquotesingle}% Upright quotes in Pygmentized code
+    }
+    \usepackage{upquote} % Upright quotes for verbatim code
     \usepackage{eurosym} % defines \euro
     \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
     \usepackage[utf8x]{inputenc} % Allow utf-8 characters in the tex document


### PR DESCRIPTION
I'm not quite sure if that's the right fix, but at least it seems to fix the problem.