### PR TITLE
Incorrectly transforms multiple markdown email

### DIFF
--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -178,9 +178,8 @@ i.e. the $i^{th}$"""
             self._try_markdown(markdown2rst, test, tokens[index])
 
     def test_multiple_email_links(self):
-        cases = {'<d.e@f.g>': '<a href="mailto:a@b.c">a@b.c</a>. '}
-        for md, html in cases.items():
-            self.assertIn(html, markdown2html(md))
+        # https://github.com/jupyter/nbviewer/issues/582
+        self.assertNotIn('<c.d@e.f>', markdown2html('<a@b.c> <c.d@e.f>'))
 
     def _try_markdown(self, method, test, tokens):
         results = method(test)

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -123,7 +123,7 @@ class TestMarkdown(TestsBase):
                 ]
         for case in cases:
             self.assertIn(case, markdown2html(case))
-    
+
     def test_markdown2html_math_mixed(self):
         """ensure markdown between inline and inline-block math"""
         case = """The entries of $C$ are given by the exact formula:
@@ -177,6 +177,14 @@ i.e. the $i^{th}$"""
         for index, test in enumerate(self.tests):
             self._try_markdown(markdown2rst, test, tokens[index])
 
+    def test_multiple_email_links(self):
+        cases = {
+            '<a@b.c> <d.e@f.g>':
+                '<a href="mailto:a@b.c">a@b.c</a>. '
+                '<a href="mailto:d.e@f.g">d.e@f.g</a>.'
+        }
+        for md, html in cases.items():
+            self.assertIn(html, markdown2html(md))
 
     def _try_markdown(self, method, test, tokens):
         results = method(test)

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -178,11 +178,7 @@ i.e. the $i^{th}$"""
             self._try_markdown(markdown2rst, test, tokens[index])
 
     def test_multiple_email_links(self):
-        cases = {
-            '<a@b.c> <d.e@f.g>':
-                '<a href="mailto:a@b.c">a@b.c</a>. '
-                '<a href="mailto:d.e@f.g">d.e@f.g</a>.'
-        }
+        cases = {'<d.e@f.g>': '<a href="mailto:a@b.c">a@b.c</a>. '}
         for md, html in cases.items():
             self.assertIn(html, markdown2html(md))
 


### PR DESCRIPTION
This was uncovered in the wild:
https://github.com/jupyter/nbviewer/issues/582

From the [spec](https://daringfireball.net/projects/markdown/syntax):
```
Markdown supports a shortcut style for creating “automatic” links for URLs and email
addresses: simply surround the URL or email address with angle brackets. What this
means is that if you want to show the actual text of a URL or email address, and also
have it be a clickable link, you can do this:

<http://example.com/>

Markdown will turn this into:

<a href="http://example.com/">http://example.com/</a>
Automatic links for email addresses work similarly, except that Markdown will also
perform a bit of randomized decimal and hex entity-encoding to help obscure your
address from address-harvesting spambots. For example, Markdown will turn this:

<address@example.com>
```

This adds a minimum failing test, looking at solutions... probably regex-fu... 
