### PR TITLE
prepare changelog for 4.2

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,8 +6,13 @@ Changes in nbconvert
 
 `4.2 on GitHub <https://github.com/jupyter/nbconvert/milestones/4.2>`_
 
+- :ref:`Custom Exporters <external_exporters>` can be provided by external packages,
+  and registered with nbconvert via setuptools entrypoints.
 - allow nbconvert reading from stdin with ``--stdin`` option (write into
   ``notebook`` basename)
+- Various ANSI-escape fixes and improvements
+- Various LaTeX/PDF export fixes
+- Various fixes and improvements for executing notebooks with ``--execute``.
 
 4.1
 ---


### PR DESCRIPTION
We should be ready to release nbconvert 4.2 after this.

cc @willingc for release/docs

The list of [4.2 PRs](https://github.com/jupyter/nbconvert/pulls?utf8=✓&q=is%3Apr+milestone%3A4.2), if anyone has changes they would like to highlight beyond what I have added here.