### PR TITLE
LaTeX: Use appropriate math font for Palatino (mathpazo)

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -14,8 +14,8 @@ This template does not define a docclass, the inheriting class must define this.
     
     ((* block packages *))
     \usepackage[T1]{fontenc}
-    % Nicer default font than Computer Modern for most use cases
-    \usepackage{palatino}
+    % Nicer default font (+ math font) than Computer Modern for most use cases
+    \usepackage{mathpazo}
 
     % Basic figure setup, for now with no caption control since it's done
     % automatically by Pandoc (which extracts ![](path) syntax from Markdown).


### PR DESCRIPTION
The text font was changed to Palatino in #178, but the math font wasn't.
The package [`mathpazo`](https://www.ctan.org/pkg/mathpazo) keeps Palatino as text font and selects a suitable math font, too.