### PR TITLE
use xelatex by default

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -35,7 +35,7 @@ class PDFExporter(LatexExporter):
         help="How many times latex will be called."
     )
 
-    latex_command = List([u"pdflatex", u"{filename}"], config=True, 
+    latex_command = List([u"xelatex", u"{filename}"], config=True,
         help="Shell command used to compile latex."
     )
 


### PR DESCRIPTION
xelatex seems to be strictly more capable than pdflatex, and a more sensible default in 2016.

Just like with pdflatex -> xelatex, people can use config to pick another implementation if the default doesn't suit them for whatever reason.

cf #281