### PR TITLE
fix unicode errors in cell execution exceptions

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -30,6 +30,12 @@ class CellExecutionError(ConversionException):
         self.traceback = traceback
 
     def __str__(self):
+        s = self.__unicode__()
+        if not isinstance(s, str):
+            s = s.encode('utf8', 'replace')
+        return s
+    
+    def __unicode__(self):
         return self.traceback
 
 
@@ -164,7 +170,7 @@ class ExecutePreprocessor(Preprocessor):
         if not self.allow_errors:
             for out in outputs:
                 if out.output_type == 'error':
-                    pattern = """\
+                    pattern = u"""\
                         An error occurred while executing the following cell:
                         ------------------
                         {cell.source}

--- a/nbconvert/preprocessors/tests/files/Skip Exceptions.ipynb
+++ b/nbconvert/preprocessors/tests/files/Skip Exceptions.ipynb
@@ -14,12 +14,13 @@
      "traceback": [
       "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[1;31mException\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-1-335814d14fc1>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[1;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"message\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m<ipython-input-1-9abc744909d9>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;31m# üñîçø∂é\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 2\u001b[1;33m \u001b[1;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"message\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[1;31mException\u001b[0m: message"
      ]
     }
    ],
    "source": [
+    "# üñîçø∂é\n",
     "raise Exception(\"message\")"
    ]
   },
@@ -43,9 +44,7 @@
    ]
   }
  ],
- "metadata": {
-  "signature": "sha256:9d47889f0678e9685429071216d0f3354db59bb66489f3225bcadfb6a1a9bbba"
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 0
 }

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -166,4 +166,6 @@ class TestExecute(PreprocessorTestsBase):
         filename = os.path.join(current_dir, 'files', 'Skip Exceptions.ipynb')
         res = self.build_resources()
         res['metadata']['path'] = os.path.dirname(filename)
-        assert_raises(CellExecutionError, self.run_notebook, filename, dict(allow_errors=False), res)
+        with assert_raises(CellExecutionError) as exc:
+            self.run_notebook(filename, dict(allow_errors=False), res)
+        self.assertIsInstance(str(exc), str)


### PR DESCRIPTION
Avoids `str(exc)` returning unicode, which is not allowed for Exceptions.

closes #307