### PR TITLE
Allow customization of URL used to load mathjax

### DIFF
--- a/nbconvert/templates/html/mathjax.tpl
+++ b/nbconvert/templates/html/mathjax.tpl
@@ -1,6 +1,6 @@
-{%- macro mathjax() -%}
+{%- macro mathjax(url='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML') -%}
     <!-- Load mathjax -->
-    <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script src="{{url}}"></script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({


### PR DESCRIPTION
Wikimedia's privacy policy doesn't allow loading 3rd party
scripts, and this would allow us to override the mathjax
URL more easily (since we already override the base templates)