### PR TITLE
Remove overly specific logging message from ExecutePreprocessor

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -190,13 +190,8 @@ class ExecutePreprocessor(Preprocessor):
                     timeout = None
                 msg = self.kc.shell_channel.get_msg(timeout=timeout)
             except Empty:
-                self.log.error("""Timeout waiting for execute reply (%is).
-                If your cell should take longer than this, you can increase the timeout with:
-
-                    c.ExecutePreprocessor.timeout = SECONDS
-
-                in jupyter_nbconvert_config.py
-                """ % self.timeout)
+                self.log.error(
+                    "Timeout waiting for execute reply (%is)." % self.timeout)
                 if self.interrupt_on_timeout:
                     self.log.error("Interrupting kernel")
                     self.km.interrupt_kernel()
@@ -206,8 +201,8 @@ class ExecutePreprocessor(Preprocessor):
                         exception = TimeoutError
                     except NameError:
                         exception = RuntimeError
-                    raise exception("Cell execution timed out, see log"
-                                    " for details.")
+                    raise exception(
+                        "Cell execution timed out, see log for details.")
 
             if msg['parent_header'].get('msg_id') == msg_id:
                 break


### PR DESCRIPTION
The `ExecutePreprocessor` produces this error message on cell execution timeout:

```
Timeout waiting for execute reply (30s).
If your cell should take longer than this, you can increase the timeout with:

    c.ExecutePreprocessor.timeout = SECONDS

in jupyter_nbconvert_config.py
```

This makes sense when using the command line interface, but it is wrong and confusing when using the `ExecutePreprocessor` programmatically.

For now, I just removed the message, but it should probably be re-inserted somewhere in the command line app.