### PR TITLE
Add packages required by IRkernel/repr

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -61,6 +61,8 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{hyperref}
     \usepackage{longtable} % longtable support required by pandoc >1.10
     \usepackage{booktabs}  % table support for pandoc > 1.12.2
+    \usepackage[inline]{enumitem} % IRkernel/repr support (it uses the enumerate* environment)
+    \usepackage{minted}           % highlighting support for IRkernel/repr
     \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
                                 % normalem makes italics be italics, not underlines
     ((* endblock packages *))


### PR DESCRIPTION
The [IRkernel](https://github.com/IRkernel/IRkernel)’s display machinery, powered by the [repr](https://github.com/IRkernel/repr) R package, by default requires two LaTeX packages.

Since there is

1. no way to specify required packages during kernel runtime, and
2. templates aren’t kernel specific

this project is the right place for adding LaTeX packages. Eventually it would be nice to have a way to register notebook-wide data that can be used by templates, and therefore allow for kernels and extension packages to influence LaTeX packages, HTML scripts, and the like. this idea is also discussed in IRkernel/IRdisplay#14