### PR TITLE
Add kernel-specific templates

### DIFF
--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -13,6 +13,8 @@ import copy
 import collections
 import datetime
 
+from ipython_genutils.py3compat import PY3
+from jupyter_client.kernelspec import find_kernel_specs
 from traitlets.config.configurable import LoggingConfigurable
 from traitlets.config import Config
 import nbformat
@@ -123,6 +125,9 @@ class Exporter(LoggingConfigurable):
         """
         nb_copy = copy.deepcopy(nb)
         resources = self._init_resources(resources)
+
+        # if found, add a kernel name
+        resources['kernel_name'] = nb['metadata'].get('kernelspec', {}).get('name', None)
         
         if 'language' in nb['metadata']:
             resources['language'] = nb['metadata']['language'].lower()

--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -76,8 +76,8 @@ class LatexExporter(TemplateExporter):
                              Highlight2Latex(pygments_lexer=lexer, parent=self))
         return super(LatexExporter, self).from_notebook_node(nb, resources, **kw)
 
-    def _create_environment(self):
-        environment = super(LatexExporter, self)._create_environment()
+    def get_environment(self, kernel_name):
+        environment = super(LatexExporter, self).get_environment(kernel_name)
 
         # Set special Jinja2 syntax that will not conflict with latex.
         environment.block_start_string = "((*"

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -142,11 +142,13 @@ class TemplateExporter(Exporter):
         for try_name in try_names:
             self.log.debug("Attempting to load template %s", try_name)
             try:
-                template = self.get_environment(kernel_name).get_template(try_name)
+                env = self.get_environment(kernel_name)
+                template = env.get_template(try_name)
             except (TemplateNotFound, IOError):
                 pass
             else:
-                self.log.debug("Loaded template %s", try_name)
+                _source, path, _up_to_date = env.loader.get_source(env, try_name)
+                self.log.debug("Loaded template %s from %s", try_name, path)
                 return template
 
         raise TemplateNotFound(self.template_file)

--- a/nbconvert/exporters/tests/files/kernel_template.ipynb
+++ b/nbconvert/exporters/tests/files/kernel_template.ipynb
@@ -1,0 +1,20 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "some *markdown*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Test Kernel",
+   "language": "none",
+   "name": "test"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbconvert/exporters/tests/files/kernels/test/kernel.json
+++ b/nbconvert/exporters/tests/files/kernels/test/kernel.json
@@ -1,0 +1,5 @@
+{
+  "argv": ["false"],
+  "display_name": "Test Kernel",
+  "language": "none"
+}

--- a/nbconvert/exporters/tests/files/kernels/test/templates/markdown.tpl
+++ b/nbconvert/exporters/tests/files/kernels/test/templates/markdown.tpl
@@ -1,0 +1,5 @@
+{% extends 'display_priority.tpl' %}
+
+{% block markdowncell scoped %}
+Test md code: {{ cell.source }}
+{% endblock markdowncell %}

--- a/nbconvert/exporters/tests/test_kernel_templates.py
+++ b/nbconvert/exporters/tests/test_kernel_templates.py
@@ -1,0 +1,26 @@
+"""Tests for Kernel-specific templates"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from testpath import modified_env
+
+from .base import ExportersTestsBase
+from ..markdown import MarkdownExporter
+
+
+class TestKernelTemplates(ExportersTestsBase):
+    """Tests for Kernel-specific templates"""
+
+    exporter_class = MarkdownExporter
+    should_include_raw = ['markdown', 'html']
+
+    def setUp(self):
+        super(TestKernelTemplates, self).setUp()
+        self.env = modified_env({'JUPYTER_PATH': self._get_files_path()})
+
+    def test_export(self):
+        """Will the kernel-specific template be used?"""
+        with self.env:
+            output, resources = MarkdownExporter().from_filename(self._get_notebook('kernel_template.ipynb'))
+        self.assertIn('Test md code: some *markdown*', output)

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ package_data = {
         'tests/exporter_entrypoint/*.py',
         'tests/exporter_entrypoint/*/*.*',
         'exporters/tests/files/*.*',
+        'exporters/tests/files/kernels/*/kernel.json',
+        'exporters/tests/files/kernels/*/*/*.*',
         'preprocessors/tests/files/*.*',
     ],
 }


### PR DESCRIPTION
this adds kernel-specific templates and removes caching. several runs of the test suite showed that caching had no effect on its runtime that is above noise level.
