### PR TITLE
Graceful kernel shutdown by ExecutePreprocessor

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -109,9 +109,9 @@ class ExecutePreprocessor(Preprocessor):
         default_value='graceful',
         help=dedent(
             """
-            If `graceful` (default), then the kernel will given time to clean
+            If `graceful` (default), then the kernel is given time to clean
             up after executing all cells, e.g., to execute its `atexit` hooks.
-            If `immediate` or `now, then the kernel is signaled to immediately
+            If `immediate`, then the kernel is signaled to immediately
             terminate.
             """
             )

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -103,7 +103,16 @@ class ExecutePreprocessor(Preprocessor):
             """
             )
     ).tag(config=True)
-
+    
+    kill_kernel_at_end = Bool(False,
+        help=dedent(
+            """
+            If `False` (default), then the kernel will given time to clean up
+            after executing all cells, e.g., to execute its `atexit` hooks.
+            If `True`, then the kernel is signaled to immediately terminate.
+            """
+            )
+    ).tag(config=True)
 
     def preprocess(self, nb, resources):
         """
@@ -147,7 +156,7 @@ class ExecutePreprocessor(Preprocessor):
             nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
         finally:
             self.kc.stop_channels()
-            self.km.shutdown_kernel(now=True)
+            self.km.shutdown_kernel(now=self.kill_kernel_at_end)
 
         return nb, resources
 

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from Queue import Empty  # Py 2
 
-from traitlets import List, Unicode, Bool
+from traitlets import List, Unicode, Bool, Enum
 
 from nbformat.v4 import output_from_msg
 from .base import Preprocessor
@@ -104,12 +104,14 @@ class ExecutePreprocessor(Preprocessor):
             )
     ).tag(config=True)
     
-    kill_kernel_at_end = Bool(False,
+    shutdown_kernel = Enum(['graceful', 'immediate', 'now'],
+        default_value='graceful',
         help=dedent(
             """
-            If `False` (default), then the kernel will given time to clean up
-            after executing all cells, e.g., to execute its `atexit` hooks.
-            If `True`, then the kernel is signaled to immediately terminate.
+            If `graceful` (default), then the kernel will given time to clean
+            up after executing all cells, e.g., to execute its `atexit` hooks.
+            If `immediate` or `now, then the kernel is signaled to immediately
+            terminate.
             """
             )
     ).tag(config=True)
@@ -156,7 +158,7 @@ class ExecutePreprocessor(Preprocessor):
             nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
         finally:
             self.kc.stop_channels()
-            self.km.shutdown_kernel(now=self.kill_kernel_at_end)
+            self.km.shutdown_kernel(now=self.shutdown_kernel in ['immediate', 'now'])
 
         return nb, resources
 

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -1,4 +1,5 @@
-"""Module containing a preprocessor that removes the outputs from code cells"""
+"""Module containing a preprocessor that executes the code cells
+and updates outputs"""
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -104,7 +104,7 @@ class ExecutePreprocessor(Preprocessor):
             )
     ).tag(config=True)
     
-    shutdown_kernel = Enum(['graceful', 'immediate', 'now'],
+    shutdown_kernel = Enum(['graceful', 'immediate'],
         default_value='graceful',
         help=dedent(
             """
@@ -158,7 +158,7 @@ class ExecutePreprocessor(Preprocessor):
             nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
         finally:
             self.kc.stop_channels()
-            self.km.shutdown_kernel(now=self.shutdown_kernel in ['immediate', 'now'])
+            self.km.shutdown_kernel(now=self.shutdown_kernel == 'immediate')
 
         return nb, resources
 


### PR DESCRIPTION
A new `ExecutePreprocessor.kill_kernel_at_end` option controls whether it should kill the kernel immediately (as before) or allow it to shutdown properly (new default), e.g., executing all its `atexit` hooks.  The previous behavior of immediately terminating kernel causes many carefully prepared libraries in notebooks to result in a unexpected state after executing them with nbconvert.

Fixes Calysto/matlab_kernel#11