### PR TITLE
allow absolute path templates to be pass in

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -107,7 +107,7 @@ class TemplateExporter(Exporter):
 
     default_template = Unicode(u'').tag(affects_template=True)
 
-    template_path = List(['.']).tag(config=True, affects_environment=True)
+    template_path = List(['.', '/']).tag(config=True, affects_environment=True)
 
     default_template_path = Unicode(
         os.path.join("..", "templates"), 


### PR DESCRIPTION
Currently, when you pass an absolute path in for the template nbconvert fails to find the template. This change accepts both relative and absolute paths.