### PR TITLE
preprocessors/execute: added timeout_func for variable cell timeouts

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from Queue import Empty  # Py 2
 
-from traitlets import List, Unicode, Bool, Enum
+from traitlets import List, Unicode, Bool, Enum, Any
 
 from nbformat.v4 import output_from_msg
 from .base import Preprocessor
@@ -35,7 +35,7 @@ class CellExecutionError(ConversionException):
         if not isinstance(s, str):
             s = s.encode('utf8', 'replace')
         return s
-    
+
     def __unicode__(self):
         return self.traceback
 
@@ -52,7 +52,27 @@ class ExecutePreprocessor(Preprocessor):
             If a cell execution takes longer, an exception (TimeoutError
             on python 3+, RuntimeError on python 2) is raised.
 
-            `None` or `-1` will disable the timeout.
+            `None` or `-1` will disable the timeout. If `timeout_func` is set,
+            it overrides `timeout`.
+            """
+        )
+    ).tag(config=True)
+
+    timeout_func = Any(
+        default_value=None,
+        allow_none=True,
+        help=dedent(
+            """
+            A callable which, when given the cell source as input,
+            returns the time to wait (in seconds) for output from cell
+            executions. If a cell execution takes longer, an exception
+            (TimeoutError on python 3+, RuntimeError on python 2) is
+            raised.
+
+            Returning `None` or `-1` will disable the timeout for the cell.
+            Not setting `timeout_func` will cause the preprocessor to
+            default to using the `timeout` trait for all cells. The
+            `timeout_func` trait overrides `timeout` if it is not `None`.
             """
         )
     ).tag(config=True)
@@ -104,7 +124,7 @@ class ExecutePreprocessor(Preprocessor):
             """
             )
     ).tag(config=True)
-    
+
     shutdown_kernel = Enum(['graceful', 'immediate'],
         default_value='graceful',
         help=dedent(
@@ -197,8 +217,12 @@ class ExecutePreprocessor(Preprocessor):
         # wait for finish, with timeout
         while True:
             try:
-                timeout = self.timeout
-                if timeout < 0:
+                if self.timeout_func is not None:
+                    timeout = self.timeout_func(cell.source)
+                else:
+                    timeout = self.timeout
+
+                if not timeout or timeout < 0:
                     timeout = None
                 msg = self.kc.shell_channel.get_msg(timeout=timeout)
             except Empty:

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -218,7 +218,7 @@ class ExecutePreprocessor(Preprocessor):
         while True:
             try:
                 if self.timeout_func is not None:
-                    timeout = self.timeout_func(cell.source)
+                    timeout = self.timeout_func(cell)
                 else:
                     timeout = self.timeout
 

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -43,7 +43,7 @@ class TestExecute(PreprocessorTestsBase):
             for line in output['traceback']:
                 tb.append(strip_ansi(line))
             output['traceback'] = tb
-            
+
         return output
 
 
@@ -79,7 +79,7 @@ class TestExecute(PreprocessorTestsBase):
 
 
     def run_notebook(self, filename, opts, resources):
-        """Loads and runs a notebook, returning both the version prior to 
+        """Loads and runs a notebook, returning both the version prior to
         running it and the version after running it.
 
         """
@@ -157,6 +157,22 @@ class TestExecute(PreprocessorTestsBase):
             exception = RuntimeError
 
         assert_raises(exception, self.run_notebook, filename, dict(timeout=1), res)
+
+    def test_timeout_func(self):
+        """Check that an error is raised when a computation times out"""
+        current_dir = os.path.dirname(__file__)
+        filename = os.path.join(current_dir, 'files', 'Interrupt.ipynb')
+        res = self.build_resources()
+        res['metadata']['path'] = os.path.dirname(filename)
+        try:
+            exception = TimeoutError
+        except NameError:
+            exception = RuntimeError
+
+        def timeout_func(source):
+            return 10
+
+        assert_raises(exception, self.run_notebook, filename, dict(timeout_func=timeout_func), res)
 
     def test_allow_errors(self):
         """


### PR DESCRIPTION
Implements `timeout_func` from https://github.com/jupyter/nbconvert/issues/346

Note I couldn't figure out how to get fully passing tests, as I was getting a bunch of errors like `FileNotFoundError: '<snip>/nbconvert/resources/style.min.css'` when I ran `py.test`. Do you use a different testing framework? If so, could you add a short description in the readme of the process of setting up a local dev version to run the tests specifically?