### PR TITLE
run tests with pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ __pycache__
 .DS_Store
 \#*#
 .#*
-.coverage
+.coverage*
+htmlcov
+.cache
 docs/source/*.tpl
 docs/source/config_options.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ install:
     - pip install nbconvert[execute,serve,test]
     - python -m ipykernel.kernelspec --user
 script:
-    - # need to cd or coverage report broken.
-    - cd /tmp/
-    - nosetests nbconvert --with-coverage --cover-package nbconvert --cover-inclusive --cover-xml --cover-xml-file=$TRAVIS_BUILD_DIR/coverage.xml
-    - cd -
+    # cd so we test the install, not the repo
+    - cd `mktemp -d`
+    - py.test --cov nbconvert -v --pyargs nbconvert
 after_success:
     - codecov

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ cd nbconvert
 pip install -e .
 ```
 
+Running the tests after a dev install above:
+
+```
+pip install nbconvert[test]
+py.test --pyargs nbconvert
+```
+
 
 ## Resources
 

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,9 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    'test': ['nose', 'ipykernel', 'testpath'],
+    # FIXME: tests still require nose for some utility calls,
+    # but we are running with pytest
+    'test': ['pytest', 'pytest-cov', 'nose', 'ipykernel', 'testpath'],
     'serve': ['tornado'],
     'execute': ['jupyter_client'],
 }


### PR DESCRIPTION
and add a note for running the tests in the dev-install section of the README.

all tests pass without modification, as long as nose is present, since we still use nose.tools in a few places.

We can remove the nose dependency in a later patch.