### PR TITLE
correct 'unconfined' metadata conversion to HTML attribute

### DIFF
--- a/nbconvert/templates/html/basic.tpl
+++ b/nbconvert/templates/html/basic.tpl
@@ -144,7 +144,7 @@ width={{width}}
 {%- if height is not none %}
 height={{height}}
 {%- endif %}
-{%- if output | get_metadata('unconfined', 'image/png') -%}
+{%- if output | get_metadata('unconfined', 'image/png') %}
 class="unconfined"
 {%- endif %}
 >
@@ -166,7 +166,7 @@ width={{width}}
 {%- if height is not none %}
 height={{height}}
 {%- endif %}
-{%- if output | get_metadata('unconfined', 'image/jpeg') -%}
+{%- if output | get_metadata('unconfined', 'image/jpeg') %}
 class="unconfined"
 {%- endif %}
 >


### PR DESCRIPTION
When converting to HTML a Notebook that contains cells with images, if the cell contains image metadata with the `unconfined` attribute, the resulting HTML is wrong.

Specifically, this:

```
     "metadata": {
      "image/png": {
       "height": 2200,
       "unconfined": true,
       "width": 5500
      }
```
produces this:
```
width=5500
height=2200class="unconfined"
>
</div>
```

Notice the lack of space between the _width_ and the _class_ attributes. This causes the browser to ignore them, resulting in an image squeezed into the `<div>` (instead of the intended behaviour, which for "unconfined" is to provide scrollbars and render the image at full size).

The patch is a simple modification of the `basic` HTML template to avoid suppressing the whitespace between both attributes, therefore creating the correct HTML:

```
width=5500
height=2200 
class="unconfined"
>
</div>
```
(BTW, the `unconfined` attribute is also ignored for SVG images, but that cannot be corrected in the template since SVG elements are processed whole; instead the "unconfined" class attribute should be added to the `<svg>` element, but I don't know how to do that)