### PR TITLE
[WIP] use new KernelClient.execute_interactive

### DIFF
--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -170,7 +170,7 @@ class TestExecute(PreprocessorTestsBase):
             exception = RuntimeError
 
         def timeout_func(source):
-            return 10
+            return 1
 
         assert_raises(exception, self.run_notebook, filename, dict(timeout_func=timeout_func), res)
 


### PR DESCRIPTION
in execute preprocessor

Significantly simplifies the preprocessor, relying on upstream implementation.

WIP because it's not released yet.

I hit two missing features that we should either drop here or add there:
1. When we interrupt-on-timeout, we need to flush outputs,
   which suggests that flushing outputs with the hook
   should be a method on its own.
2. ExecutePreprocessor allows a separate timeout for no output,
   not just a total timeout for the whole execution.

cf https://github.com/jupyter/jupyter_client/pull/185
