### PR TITLE
Remove minted from Latex base template

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -62,7 +62,6 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage{longtable} % longtable support required by pandoc >1.10
     \usepackage{booktabs}  % table support for pandoc > 1.12.2
     \usepackage[inline]{enumitem} % IRkernel/repr support (it uses the enumerate* environment)
-    \usepackage{minted}           % highlighting support for IRkernel/repr
     \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
                                 % normalem makes italics be italics, not underlines
     ((* endblock packages *))


### PR DESCRIPTION
It requires a flag to disable a security feature, which we've decided not to use.

Closes gh-350

Alternative to #353 

Ping @amueller @janschulz @flying-sheep 