### PR TITLE
Language specificity in codeblocks in rst template

### DIFF
--- a/nbconvert/templates/rst.tpl
+++ b/nbconvert/templates/rst.tpl
@@ -12,8 +12,6 @@
 {{".. code:: "-}}
 {%- if nb.metadata.language_info.pygments_lexer -%}
     {{ nb.metadata.language_info.pygments_lexer }}
-{%- elif nb.metadata.language_info.codemirror_mode -%}
-    {{ nb.metadata.language_info.codemirror_mode.name }}
 {%- elif nb.metadata.language_info.name -%}
     {{ nb.metadata.language_info.name }}
 {%- endif %}

--- a/nbconvert/templates/rst.tpl
+++ b/nbconvert/templates/rst.tpl
@@ -9,14 +9,14 @@
 
 {% block input %}
 {%- if cell.source.strip() -%}
-.. code::
-{%- if nb.metadata.language_info.pygments_lexer %}
+{{".. code:: "-}}
+{%- if nb.metadata.language_info.pygments_lexer -%}
     {{ nb.metadata.language_info.pygments_lexer }}
-{%- elif nb.metadata.language_info.codemirror_mode.name -%}
+{%- elif nb.metadata.language_info.codemirror_mode -%}
     {{ nb.metadata.language_info.codemirror_mode.name }}
 {%- elif nb.metadata.language_info.name -%}
     {{ nb.metadata.language_info.name }}
-{%- endif -%}
+{%- endif %}
 
 {{ cell.source | indent}}
 {% endif -%}

--- a/nbconvert/templates/rst.tpl
+++ b/nbconvert/templates/rst.tpl
@@ -9,7 +9,14 @@
 
 {% block input %}
 {%- if cell.source.strip() -%}
-.. code:: python
+.. code::
+{%- if nb.metadata.language_info.pygments_lexer %}
+    {{ nb.metadata.language_info.pygments_lexer }}
+{%- elif nb.metadata.language_info.codemirror_mode.name -%}
+    {{ nb.metadata.language_info.codemirror_mode.name }}
+{%- elif nb.metadata.language_info.name -%}
+    {{ nb.metadata.language_info.name }}
+{%- endif -%}
 
 {{ cell.source | indent}}
 {% endif -%}


### PR DESCRIPTION
This addresses #366, does not generalise it to markdown. Shouldn't be hard to do but perhaps we want that as a different PR.