### PR TITLE
handle missing language_info metadata in rst template

### DIFF
--- a/nbconvert/templates/rst.tpl
+++ b/nbconvert/templates/rst.tpl
@@ -10,9 +10,9 @@
 {% block input %}
 {%- if cell.source.strip() -%}
 {{".. code:: "-}}
-{%- if nb.metadata.language_info.pygments_lexer -%}
+{%- if 'pygments_lexer' in nb.metadata.get('language_info', {}) -%}
     {{ nb.metadata.language_info.pygments_lexer }}
-{%- elif nb.metadata.language_info.name -%}
+{%- elif 'name' in nb.metadata.get('language_info', {}) -%}
     {{ nb.metadata.language_info.name }}
 {%- endif %}
 


### PR DESCRIPTION
language_info may not be defined in skeleton notebooks. This should result in no highlighting, not an error.