### PR TITLE
Restore deprecated functions for nbconvert.exporters API

### DIFF
--- a/docs/source/api/exporters.rst
+++ b/docs/source/api/exporters.rst
@@ -8,6 +8,15 @@ Exporters
    :doc:`/config_options`
      Configurable options for the nbconvert application
 
+.. autofunction:: export
+
+.. autofunction:: get_exporter
+
+.. autofunction:: get_export_names
+
+Exporter base classes
+---------------------
+
 .. autoclass:: Exporter
 
     .. automethod:: __init__
@@ -57,14 +66,3 @@ inherit either directly or indirectly from
 .. autoclass:: PythonExporter
 
 .. autoclass:: RSTExporter
-
-Specialized exporter functions
-------------------------------
-
-These functions are essentially convenience functions that
-wrap the functionality of the classes documented in the previous
-section.
-
-
-
-.. autofunction:: export_by_name

--- a/nbconvert/exporters/__init__.py
+++ b/nbconvert/exporters/__init__.py
@@ -1,4 +1,7 @@
 from .export import *
+# These specific functions are deprecated as of 5.0:
+from .export import (export_custom, export_html, export_slides, export_latex,
+    export_pdf, export_markdown, export_python, export_script, export_rst)
 from .html import HTMLExporter
 from .slides import SlidesExporter
 from .templateexporter import TemplateExporter

--- a/nbconvert/exporters/__init__.py
+++ b/nbconvert/exporters/__init__.py
@@ -1,7 +1,4 @@
 from .export import *
-# These specific functions are deprecated as of 5.0:
-from .export import (export_custom, export_html, export_slides, export_latex,
-    export_pdf, export_markdown, export_python, export_script, export_rst)
 from .html import HTMLExporter
 from .slides import SlidesExporter
 from .templateexporter import TemplateExporter

--- a/nbconvert/exporters/export.py
+++ b/nbconvert/exporters/export.py
@@ -116,7 +116,7 @@ def _make_exporter(name, E):
     """make an export_foo function from a short key and Exporter class E"""
     def _export(nb, **kw):
         return export(E, nb, **kw)
-    _export.__doc__ = """Export a notebook object to {0} format""".format(name)
+    _export.__doc__ = """DEPRECATED: Export a notebook object to {0} format""".format(name)
     return _export
     
 g = globals()

--- a/nbconvert/exporters/export.py
+++ b/nbconvert/exporters/export.py
@@ -117,8 +117,10 @@ def _make_exporter(name, E):
     
 g = globals()
 
+# These specific functions are deprecated as of 5.0
 for name, E in exporter_map.items():
     g['export_%s' % name] = _make_exporter(name, E)
+    __all__.append('export_%s' % name)
 
 
 def export_by_name(format_name, nb, **kw):

--- a/nbconvert/exporters/export.py
+++ b/nbconvert/exporters/export.py
@@ -34,6 +34,7 @@ from .script import ScriptExporter
 __all__ = [
     'export',
     'export_by_name',
+    'get_exporter',
     'get_export_names',
     'ExporterNameError',
 ]
@@ -48,9 +49,9 @@ def export(exporter, nb, **kw):
     
     Parameters
     ----------
-    exporter : class:`~nbconvert.exporters.exporter.Exporter` class or instance
-      Class type or instance of the exporter that should be used.  If the
-      method initializes it's own instance of the class, it is ASSUMED that
+    exporter : :class:`~nbconvert.exporters.exporter.Exporter` class or instance
+      Class or instance of the exporter that should be used.  If the
+      method initializes its own instance of the class, it is ASSUMED that
       the class type provided exposes a constructor (``__init__``) with the same
       signature as the base Exporter class.
     nb : :class:`~nbformat.NotebookNode`
@@ -64,15 +65,10 @@ def export(exporter, nb, **kw):
     -------
     tuple
         output : str
-            Jinja 2 output.  This is the resulting converted notebook.
+            The resulting converted notebook.
         resources : dictionary
             Dictionary of resources used prior to and during the conversion 
             process.
-        exporter_instance : Exporter
-            Instance of the Exporter class used to export the document.  Useful
-            to caller because it provides a 'file_extension' property which
-            specifies what extension the output should be saved as.
-
     """
     
     #Check arguments
@@ -150,7 +146,7 @@ def export_by_name(format_name, nb, **kw):
 
 
 def get_exporter(name):
-    """ given an exporter name, return a class ready to be instantiated
+    """Given an exporter name or import path, return a class ready to be instantiated
     
     Raises ValueError if exporter is not found
     """

--- a/nbconvert/exporters/notebook.py
+++ b/nbconvert/exporters/notebook.py
@@ -8,7 +8,11 @@ import nbformat
 from traitlets import Enum, default
 
 class NotebookExporter(Exporter):
-    """Exports to an IPython notebook."""
+    """Exports to an IPython notebook.
+
+    This is useful when you want to use nbconvert's preprocessors to operate on
+    a notebook (e.g. to execute it) and then write it back to a notebook file.
+    """
 
     nbformat_version = Enum(list(nbformat.versions),
         default_value=nbformat.current_nbformat,

--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -29,7 +29,12 @@ class LatexFailed(IOError):
 
 
 class PDFExporter(LatexExporter):
-    """Writer designed to write to PDF files"""
+    """Writer designed to write to PDF files.
+
+    This inherits from :class:`LatexExporter`. It creates a Latex file in
+    a temporary directory using the template machinery, and then runs Latex
+    to create a pdf.
+    """
 
     latex_count = Integer(3,
         help="How many times latex will be called."

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -1,4 +1,4 @@
-"""restructuredText Exporter class"""
+"""reStructuredText Exporter class"""
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
@@ -11,7 +11,7 @@ from .templateexporter import TemplateExporter
 
 class RSTExporter(TemplateExporter):
     """
-    Exports restructured text documents.
+    Exports reStructuredText documents.
     """
     
     @default('file_extension')

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -63,6 +63,8 @@ class TemplateExporter(Exporter):
     this class.  Instead, override the template_file and file_extension
     traits via a config file.
 
+    Filters available by default for templates:
+
     {filters}
     """
     


### PR DESCRIPTION
Removing these from `__all__` breaks imports from the nbconvert.exporters API, which was their documented location. Let's leave them in place for one import cycle.

I've also updated, fixed and polished the exporter docs.