### PR TITLE
Add conda-forge as channel

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,12 +1,13 @@
 name: nbconvert_docs
 channels:
-- willingcn
+  - conda-forge
 dependencies:
-- python=3.5
+- python=3
 - pandoc
 - nbformat
 - jupyter_client
+- sphinx>=1.3.6
+- sphinx_rtd_theme
+- entrypoints
 - pip:
-    - sphinx==1.3.6
     - nbsphinx
-    - entrypoints


### PR DESCRIPTION
Update `environment.yml` to use condo-forge channel instead of my personal channel which was needed months ago since pandoc was not yet in the forge.