### PR TITLE
Add extension for highlighting to correct doc build warnings

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,6 +6,7 @@ dependencies:
 - pandoc
 - nbformat
 - jupyter_client
+- ipython
 - sphinx>=1.3.6
 - sphinx_rtd_theme
 - entrypoints

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'nbsphinx',
+    'IPython.sphinxext.ipython_console_highlighting',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This corrects the 'IPython lexer' not found warnings when building the docs.