### PR TITLE
Allow specifying templates as paths

### DIFF
--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -104,15 +104,16 @@ class TestExporter(ExportersTestsBase):
 
     def test_relative_template_file(self):
         with tempdir.TemporaryWorkingDirectory() as td:
-            template = os.path.join(td, 'relative_template.tpl')
+            os.mkdir('relative')
+            template = os.path.abspath(os.path.join(td, 'relative', 'relative_template.tpl'))
             test_output = 'relative!'
             with open(template, 'w') as f:
                 f.write(test_output)
             config = Config()
             config.TemplateExporter.template_file = template
             exporter = self._make_exporter(config=config)
-            assert exporter.template.filename == template
-            assert os.path.dirname(template) in exporter.template_path
+            assert os.path.abspath(exporter.template.filename) == template
+            assert os.path.dirname(template) in [ os.path.abspath(d) for d in exporter.template_path ]
 
     def _make_exporter(self, config=None):
         # Create the exporter instance, make sure to set a template name since

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -2,28 +2,18 @@
 Module with tests for templateexporter.py
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, the IPython Development Team.
-#
+# Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+import os
 
 from traitlets.config import Config
 
 from .base import ExportersTestsBase
 from .cheese import CheesePreprocessor
 from ..templateexporter import TemplateExporter
+from testpath import tempdir
 
-
-#-----------------------------------------------------------------------------
-# Class
-#-----------------------------------------------------------------------------
 
 class TestExporter(ExportersTestsBase):
     """Contains test functions for exporter.py"""
@@ -100,9 +90,35 @@ class TestExporter(ExportersTestsBase):
         assert resources is not None
         assert resources['cheese'] == 'real'
 
+    def test_absolute_template_file(self):
+        with tempdir.TemporaryDirectory() as td:
+            template = os.path.join(td, 'abstemplate.tpl')
+            test_output = 'absolute!'
+            with open(template, 'w') as f:
+                f.write(test_output)
+            config = Config()
+            config.TemplateExporter.template_file = template
+            exporter = self._make_exporter(config=config)
+            assert exporter.template.filename == template
+            assert os.path.dirname(template) in exporter.template_path
+
+    def test_relative_template_file(self):
+        with tempdir.TemporaryWorkingDirectory() as td:
+            template = os.path.join(td, 'relative_template.tpl')
+            test_output = 'relative!'
+            with open(template, 'w') as f:
+                f.write(test_output)
+            config = Config()
+            config.TemplateExporter.template_file = template
+            exporter = self._make_exporter(config=config)
+            assert exporter.template.filename == template
+            assert os.path.dirname(template) in exporter.template_path
 
     def _make_exporter(self, config=None):
         # Create the exporter instance, make sure to set a template name since
         # the base TemplateExporter doesn't have a template associated with it.
-        exporter = TemplateExporter(config=config, template_file='python')
-        return exporter        
+        exporter = TemplateExporter(config=config)
+        if not exporter.template_file:
+            # give it a default if not specified
+            exporter.template_file = 'python'
+        return exporter

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -14,7 +14,7 @@ from nbconvert.exporters import Exporter
 
 from traitlets.tests.utils import check_help_all_output
 from ipython_genutils.testing import decorators as dec
-from ipython_genutils import tempdir
+from testpath import tempdir
 from nose.tools import assert_raises, assert_in, assert_not_in
 
 #-----------------------------------------------------------------------------
@@ -90,6 +90,32 @@ class TestNbConvertApp(TestsBase):
             assert not os.path.isfile('notebook1.py')
             assert os.path.isfile('notebook2.py')
 
+    def test_absolute_template_file(self):
+        """--template '/path/to/template.tpl'"""
+        with self.create_temp_cwd(['notebook*.ipynb']), tempdir.TemporaryDirectory() as td:
+            template = os.path.join(td, 'mytemplate.tpl')
+            test_output = 'success!'
+            with open(template, 'w') as f:
+                f.write(test_output)
+            self.nbconvert('--log-level 0 notebook2 --template %s' % template)
+            assert os.path.isfile('notebook2.html')
+            with open('notebook2.html') as f:
+                text = f.read()
+            assert text == test_output
+
+    def test_relative_template_file(self):
+        """Test --template 'relative/path.tpl'"""
+        with self.create_temp_cwd(['notebook*.ipynb']):
+            os.mkdir('relative')
+            template = os.path.join('relative', 'path.tpl')
+            test_output = 'success!'
+            with open(template, 'w') as f:
+                f.write(test_output)
+            self.nbconvert('--log-level 0 notebook2 --template %s' % template)
+            assert os.path.isfile('notebook2.html')
+            with open('notebook2.html') as f:
+                text = f.read()
+            assert text == test_output
 
     @dec.onlyif_cmds_exist('xelatex')
     @dec.onlyif_cmds_exist('pandoc')


### PR DESCRIPTION
including absolute paths

Detect template-as-path, and ensure directory is on template_path.

Tests added for both relative and absolute paths.

closes #391
closes #345