### PR TITLE
Fix to allow invalidating the cached Jinja environment with recent traitlets

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -82,7 +82,7 @@ class TemplateExporter(Exporter):
         return self._template_cached
 
     _environment_cached = None
-    def _invalidate_environment_cache(self):
+    def _invalidate_environment_cache(self, change=None):
         self._environment_cached = None
         self._invalidate_template_cache()
 


### PR DESCRIPTION
New versions of traitlets now always pass an argument, so it failed without the argument. This was already fixed for the template cache.