### PR TITLE
add cjk font commands by default, use fonts included in MacTeX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
     - texlive-xetex # latex to pdf converter
     - inkscape # for svgs in pdf output
     - texlive-lang-cjk # for cjk language support
+    - texlive-lang-chinese # chinese language support for now
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
     - texlive-xetex # latex to pdf converter
     - inkscape # for svgs in pdf output
     - texlive-lang-cjk # for cjk language support
-    - texlive-lang-chinese # chinese language support for now
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
     - cm-super # more fonts
     - texlive-xetex # latex to pdf converter
     - inkscape # for svgs in pdf output
+    - texlive-lang-cjk
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
     - cm-super # more fonts
     - texlive-xetex # latex to pdf converter
     - inkscape # for svgs in pdf output
-    - texlive-lang-cjk
+    - texlive-lang-cjk # for cjk language support
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -64,6 +64,11 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage[inline]{enumitem} % IRkernel/repr support (it uses the enumerate* environment)
     \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
                                 % normalem makes italics be italics, not underlines
+    \usepackage{xeCJK}  % this and the following needed to support chinese language
+    \setCJKmainfont[BoldFont=FandolSong-Bold.otf]{FandolSong-Regular.otf}
+    \setCJKsansfont[BoldFont=FandolHei-Bold.otf]{FandolHei-Regular.otf}
+    \setCJKmonofont{FandolFang-Regular.otf}
+    \newCJKfontfamily\kaiti{FandolKai-Regular.otf} 
     ((* endblock packages *))
 
     ((* block definitions *))


### PR DESCRIPTION
Closes #409 
Should also address https://github.com/jupyter/notebook/issues/1674

Right now I use the Fandol fonts as per [this stack overflow answer](http://tex.stackexchange.com/questions/223893/how-do-i-find-out-what-chinese-fonts-are-installed-with-my-mactex-installation) regarding the fonts that are installed by default with MacTeX. I feel like those are the only fonts we can expect to be installed by default. 

If that isn't cross platform compatible, we may need to ship a font with nbconvert to solve this problem. 

We should probably document that if people want to they can probably use custom fonts by using the command, \CJKfontspec{} in a rawNBconvert cell. That should work for any font that XeLaTeX can find.
