### PR TITLE
Custom script exporter[WIP]

### DIFF
--- a/nbconvert/exporters/export.py
+++ b/nbconvert/exporters/export.py
@@ -178,4 +178,5 @@ def get_export_names():
     Exporters can be found in external packages by registering
     them as an nbconvert.exporter entrypoint.
     """
-    return sorted(entrypoints.get_group_named('nbconvert.exporters'))
+    return sorted(exporter_map.keys()) + \
+           sorted(entrypoints.get_group_named('nbconvert.exporters'))

--- a/nbconvert/exporters/export.py
+++ b/nbconvert/exporters/export.py
@@ -178,5 +178,4 @@ def get_export_names():
     Exporters can be found in external packages by registering
     them as an nbconvert.exporter entrypoint.
     """
-    return sorted(exporter_map.keys()) + \
-           sorted(entrypoints.get_group_named('nbconvert.exporters'))
+    return sorted(entrypoints.get_group_named('nbconvert.exporters'))

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -18,7 +18,6 @@ class ScriptExporter(TemplateExporter):
 
     def from_notebook_node(self, nb, resources=None, **kw):
         langinfo = nb.metadata.get('language_info', {})
-        print("I am here") 
         # delegate to custom exporter, if specified
         exporter_name = langinfo.get('nbconvert_exporter')
         if exporter_name and exporter_name != 'script':
@@ -27,10 +26,8 @@ class ScriptExporter(TemplateExporter):
             if exporter_name not in self._exporters:
                 try: 
                     Exporter = get_exporter(exporter_name)
-                    print("i am here")
                     self._exporters[exporter_name] = Exporter(parent=self)
                 except:
-                    print("yes you found me")
                     if langinfo.get('nbconvert_exporter_package',""):
                         external_exporter_name = langinfo.get('nbconvert_exporter_package')
                         try: 

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -7,7 +7,6 @@ from .templateexporter import TemplateExporter
 
 from traitlets import Dict, default
 from traitlets.utils.importstring import import_item
-from .export import ExporterNameError
 
 class ScriptExporter(TemplateExporter):
     
@@ -38,6 +37,7 @@ class ScriptExporter(TemplateExporter):
                             Exporter = get_exporter(external_exporter_name)
                             self._exporters[external_exporter_name] = Exporter(parent=self)
                         except:
+                            from .export import ExporterNameError
                             raise ExporterNameError("The Exporter named {nbconvert_exporter_package} cannot be found, try pip install {nbconvert_exporter_package}.".format(nbconvert_exporter_package=external_exporter_name))
                     else:
                         raise ExporterNameError("The Exporter named {exporter_name} cannot be found.".format(exporter_name=exporter_name)) 

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -27,13 +27,13 @@ class ScriptExporter(TemplateExporter):
                 try: 
                     Exporter = get_exporter(exporter_name)
                     self._exporters[exporter_name] = Exporter(parent=self)
-                except:
+                except ValueError:
                     if langinfo.get('nbconvert_exporter_package',""):
                         external_exporter_name = langinfo.get('nbconvert_exporter_package')
                         try: 
                             Exporter = get_exporter(external_exporter_name)
                             self._exporters[external_exporter_name] = Exporter(parent=self)
-                        except:
+                        except ValueError:
                             raise ExporterNameError("The Exporter named {nbconvert_exporter_package} cannot be found, try pip install {nbconvert_exporter_package}.".format(nbconvert_exporter_package=external_exporter_name))
                     else:
                         raise ExporterNameError("The Exporter named {exporter_name} cannot be found.".format(exporter_name=exporter_name)) 

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -34,7 +34,10 @@ class ScriptExporter(TemplateExporter):
                             Exporter = get_exporter(external_exporter_name)
                             self._exporters[external_exporter_name] = Exporter(parent=self)
                         except ValueError:
-                            raise ExporterNameError("The Exporter named {nbconvert_exporter_package} cannot be found, try pip install {nbconvert_exporter_package}.".format(nbconvert_exporter_package=external_exporter_name))
+                            raise ExporterNameError("The Exporter named "
+                            "{nbconvert_exporter_package} cannot be found"
+                            ", try pip install "
+                            "{nbconvert_exporter_package}.".format(nbconvert_exporter_package=external_exporter_name))
                     else:
                         raise ExporterNameError("The Exporter named {exporter_name} cannot be found.".format(exporter_name=exporter_name)) 
 

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -7,7 +7,7 @@ from .templateexporter import TemplateExporter
 
 from traitlets import Dict, default
 from traitlets.utils.importstring import import_item
-
+from .export import ExporterNameError
 
 class ScriptExporter(TemplateExporter):
     
@@ -19,15 +19,29 @@ class ScriptExporter(TemplateExporter):
 
     def from_notebook_node(self, nb, resources=None, **kw):
         langinfo = nb.metadata.get('language_info', {})
-        
+        print("I am here") 
         # delegate to custom exporter, if specified
         exporter_name = langinfo.get('nbconvert_exporter')
         if exporter_name and exporter_name != 'script':
             self.log.debug("Loading script exporter: %s", exporter_name)
             from .export import get_exporter
             if exporter_name not in self._exporters:
-                Exporter = get_exporter(exporter_name)
-                self._exporters[exporter_name] = Exporter(parent=self)
+                try: 
+                    Exporter = get_exporter(exporter_name)
+                    print("i am here")
+                    self._exporters[exporter_name] = Exporter(parent=self)
+                except:
+                    print("yes you found me")
+                    if langinfo.get('nbconvert_exporter_package',""):
+                        external_exporter_name = langinfo.get('nbconvert_exporter_package')
+                        try: 
+                            Exporter = get_exporter(external_exporter_name)
+                            self._exporters[external_exporter_name] = Exporter(parent=self)
+                        except:
+                            raise ExporterNameError("The Exporter named {nbconvert_exporter_package} cannot be found, try pip install {nbconvert_exporter_package}.".format(nbconvert_exporter_package=external_exporter_name))
+                    else:
+                        raise ExporterNameError("The Exporter named {exporter_name} cannot be found.".format(exporter_name=exporter_name)) 
+
             exporter = self._exporters[exporter_name]
             return exporter.from_notebook_node(nb, resources, **kw)
         

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -8,6 +8,7 @@ from .templateexporter import TemplateExporter
 from traitlets import Dict, default
 from traitlets.utils.importstring import import_item
 
+
 class ScriptExporter(TemplateExporter):
     
     _exporters = Dict()
@@ -18,6 +19,7 @@ class ScriptExporter(TemplateExporter):
 
     def from_notebook_node(self, nb, resources=None, **kw):
         langinfo = nb.metadata.get('language_info', {})
+        
         # delegate to custom exporter, if specified
         exporter_name = langinfo.get('nbconvert_exporter')
         if exporter_name and exporter_name != 'script':

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -8,7 +8,6 @@ from .templateexporter import TemplateExporter
 from traitlets import Dict, default
 from traitlets.utils.importstring import import_item
 
-
 class ScriptExporter(TemplateExporter):
     
     _exporters = Dict()
@@ -19,7 +18,6 @@ class ScriptExporter(TemplateExporter):
 
     def from_notebook_node(self, nb, resources=None, **kw):
         langinfo = nb.metadata.get('language_info', {})
-        
         # delegate to custom exporter, if specified
         exporter_name = langinfo.get('nbconvert_exporter')
         if exporter_name and exporter_name != 'script':

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -24,7 +24,7 @@ class ScriptExporter(TemplateExporter):
         exporter_name = langinfo.get('nbconvert_exporter')
         if exporter_name and exporter_name != 'script':
             self.log.debug("Loading script exporter: %s", exporter_name)
-            from .export import get_exporter
+            from .export import get_exporter, ExporterNameError
             if exporter_name not in self._exporters:
                 try: 
                     Exporter = get_exporter(exporter_name)
@@ -36,7 +36,6 @@ class ScriptExporter(TemplateExporter):
                             Exporter = get_exporter(external_exporter_name)
                             self._exporters[external_exporter_name] = Exporter(parent=self)
                         except:
-                            from .export import ExporterNameError
                             raise ExporterNameError("The Exporter named {nbconvert_exporter_package} cannot be found, try pip install {nbconvert_exporter_package}.".format(nbconvert_exporter_package=external_exporter_name))
                     else:
                         raise ExporterNameError("The Exporter named {exporter_name} cannot be found.".format(exporter_name=exporter_name)) 

--- a/nbconvert/exporters/tests/files/ScriptExporterTest.ipynb
+++ b/nbconvert/exporters/tests/files/ScriptExporterTest.ipynb
@@ -54,7 +54,8 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
+   "nbconvert_exporter": "this_doesnt_exist",
+   "nbconvert_exporter_package": "do_you_see_me",
    "pygments_lexer": "ipython3",
    "version": "3.5.2"
   }

--- a/nbconvert/exporters/tests/files/ScriptExporterTest.ipynb
+++ b/nbconvert/exporters/tests/files/ScriptExporterTest.ipynb
@@ -1,0 +1,64 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(os.path.curdir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
So this should address #361 at least partially. 

But the code is icky. Try excepts inside other try excepts with if statements embedded…

Also, I don't like the way it's printing three exceptions right now when applied to the included test `ScriptExporterTest.ipynb`, two that we don't want that return a list of exporters(one for `this_doesnt_exist` and one for `do_you_see_me`) and the one that we do want for `do_you_see_me`  (which includes the error message to try to `pip install do_you_see_me`)

It looks like that's happening because there is an error associated with `get_exporter` that we aren't able to suppress. One solution would be to have a flag in `get_exporter()` that can suppress printing an error message. If we were to do that, I'd suggest only turning the flag on for the new custom_exporter_name call to `get_exporter` because there may be cases where there is no `nbconvert_exporter_package` we want the other `get_exporter` to err.  

Also this process revealed #413 

I could use some help in thinking through this more clearly for the sake of having less terrible looking code. But, the fact that those `get_exporter()` calls are both happening suggests to me that, however ugly, the logic behind this is solid. 
