### PR TITLE
Add warning about unsupported mimetypes.

### DIFF
--- a/nbconvert/filters/datatypefilter.py
+++ b/nbconvert/filters/datatypefilter.py
@@ -18,6 +18,7 @@ NbConvertBase.display_data_priority
 #-----------------------------------------------------------------------------
 
 from ..utils.base import NbConvertBase
+from warnings import warn
 
 __all__ = ['DataTypeFilter']
 
@@ -25,9 +26,19 @@ class DataTypeFilter(NbConvertBase):
     """ Returns the preferred display format """
         
     def __call__(self, output):
-        """ Return the first available format in the priority """
+        """ Return the first available format in the priority.
 
+        Produces a UserWarning if no compatible mimetype is found.
+        
+        `output` is dict with structure {mimetype-of-element: value-of-element}
+        
+        """
         for fmt in self.display_data_priority:
             if fmt in output:
                 return [fmt]
+        warn("Your element with mimetype(s) {mimetypes}"
+                      " is not able to be represented.".format(
+                          mimetypes=output.keys())
+                      )
+        
         return []

--- a/nbconvert/filters/tests/test_datatypefilter.py
+++ b/nbconvert/filters/tests/test_datatypefilter.py
@@ -15,13 +15,13 @@ class TestDataTypeFilter(TestsBase):
         DataTypeFilter()
 
     def test_junk_types(self):
-        """Can the DataTypeFilter pickout a useful type from a list of junk types?"""
+        """Can the DataTypeFilter pickout a useful type from a dict with junk types as keys?"""
         filter = DataTypeFilter()
-        assert "image/png" in filter(["hair", "water", "image/png", "rock"])
-        assert "application/pdf" in filter(["application/pdf", "hair", "water", "png", "rock"])
-        self.assertEqual(filter(["hair", "water", "rock"]), [])
+        assert "image/png" in filter({"hair":"1", "water":2, "image/png":3, "rock":4.0})
+        assert "application/pdf" in filter({"application/pdf":"file_path", "hair":2, "water":"yay", "png":'not a png', "rock":'is a rock'})
+        self.assertEqual(filter({"hair":"this is not", "water":"going to return anything", "rock":"or is it"}), [])
 
     def test_null(self):
         """Will the DataTypeFilter fail if no types are passed in?"""
         filter = DataTypeFilter()
-        self.assertEqual(filter([]), [])
+        self.assertEqual(filter({}), [])


### PR DESCRIPTION
Closes #425. 

Adds explanation of the expected input structure to documentation of the `DataTypeFilter` `__call__` method.