### PR TITLE
Make exporter_map available from nbconvert.exporters.export

### DIFF
--- a/nbconvert/exporters/exporter_locator.py
+++ b/nbconvert/exporters/exporter_locator.py
@@ -33,6 +33,7 @@ __all__ = [
     'get_exporter',
     'get_export_names',
     'ExporterNameError',
+    'exporter_map',
 ]
 
 exporter_map = dict(


### PR DESCRIPTION
The notebook package expects to import it from there, so the rearrangement had broken it.

```
NotebookApp: WARNING: 500 GET /a%40b/nbconvert/html/foo/testnb.ipynb?download=False (127.0.0.1): Could not import nbconvert: cannot import name 'exporter_map'
```