### PR TITLE
Import audit conclusion

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -17,6 +17,7 @@ import uuid
 from traitlets import HasTraits, Unicode, List, Dict, default, observe
 from traitlets.utils.importstring import import_item
 from ipython_genutils import py3compat
+from jinja2 import TemplateNotFound, Environment, ChoiceLoader, FileSystemLoader
 
 from nbconvert import filters
 from .exporter import Exporter
@@ -178,7 +179,6 @@ class TemplateExporter(Exporter):
         
         This is triggered by various trait changes that would change the template.
         """
-        from jinja2 import TemplateNotFound
 
         if not self.template_file:
             raise ValueError("No template_file specified!")

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -10,10 +10,6 @@ from __future__ import print_function, absolute_import
 import os
 import uuid
 
-# other libs/dependencies are imported at runtime
-# to move ImportErrors to runtime when the requirement is actually needed
-
-
 from traitlets import HasTraits, Unicode, List, Dict, default, observe
 from traitlets.utils.importstring import import_item
 from ipython_genutils import py3compat
@@ -295,7 +291,6 @@ class TemplateExporter(Exporter):
         """
         Create the Jinja templating environment.
         """
-        from jinja2 import Environment, ChoiceLoader, FileSystemLoader
         here = os.path.dirname(os.path.realpath(__file__))
 
         paths = self.template_path + \

--- a/nbconvert/exporters/tests/test_export.py
+++ b/nbconvert/exporters/tests/test_export.py
@@ -9,6 +9,7 @@ import os
 import sys
 
 import nbformat
+import nbconvert.tests
 
 from .base import ExportersTestsBase
 from ..base import get_exporter, export, ExporterNameError, get_export_names
@@ -92,7 +93,6 @@ class TestExport(ExportersTestsBase):
             pass
 
 def test_get_exporter_entrypoint():
-    import nbconvert.tests
     p = os.path.join(os.path.dirname(nbconvert.tests.__file__), 'exporter_entrypoint')
     sys.path.insert(0, p)
     assert 'entrypoint_test' in get_export_names()

--- a/nbconvert/postprocessors/serve.py
+++ b/nbconvert/postprocessors/serve.py
@@ -10,7 +10,6 @@ import webbrowser
 
 from tornado import web, ioloop, httpserver, log
 from tornado.httpclient import AsyncHTTPClient
-
 from traitlets import Bool, Unicode, Int
 
 from .base import PostProcessorBase
@@ -76,7 +75,7 @@ class ServePostProcessor(PostProcessorBase):
             client=AsyncHTTPClient(),
         )
         
-
+        # hook up tornado logging to our logger
         log.app_log = self.log
 
         http_server = httpserver.HTTPServer(app)

--- a/nbconvert/postprocessors/serve.py
+++ b/nbconvert/postprocessors/serve.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 import os
 import webbrowser
 
-from tornado import web, ioloop, httpserver
+from tornado import web, ioloop, httpserver, log
 from tornado.httpclient import AsyncHTTPClient
 
 from traitlets import Bool, Unicode, Int
@@ -75,14 +75,10 @@ class ServePostProcessor(PostProcessorBase):
             cdn=self.reveal_cdn,
             client=AsyncHTTPClient(),
         )
-        # hook up tornado logging to our logger
-        try:
-            from tornado import log
-            log.app_log = self.log
-        except ImportError:
-            # old tornado (<= 3), ignore
-            pass
-    
+        
+
+        log.app_log = self.log
+
         http_server = httpserver.HTTPServer(app)
         http_server.listen(self.port, address=self.ip)
         url = "http://%s:%i/%s" % (self.ip, self.port, filename)

--- a/nbconvert/preprocessors/csshtmlheader.py
+++ b/nbconvert/preprocessors/csshtmlheader.py
@@ -13,6 +13,13 @@ from traitlets import Unicode
 from ipython_genutils.py3compat import str_to_bytes
 from .base import Preprocessor
 
+
+try:
+    from notebook import DEFAULT_STATIC_FILES_PATH
+except ImportError:
+    DEFAULT_STATIC_FILES_PATH = None
+
+
 class CSSHTMLHeaderPreprocessor(Preprocessor):
     """
     Preprocessor used to pre-process notebook for HTML output.  Adds IPython notebook
@@ -112,11 +119,6 @@ class CSSHTMLHeaderPreprocessor(Preprocessor):
         # Load the user's custom CSS and IPython's default custom CSS.  If they
         # differ, assume the user has made modifications to his/her custom CSS
         # and that we should inline it in the nbconvert output.
-        try:
-            from notebook import DEFAULT_STATIC_FILES_PATH
-        except ImportError:
-            DEFAULT_STATIC_FILES_PATH = None
-        
         config_dir = resources['config_dir']
         custom_css_filename = os.path.join(config_dir, 'custom', 'custom.css')
         if os.path.isfile(custom_css_filename):

--- a/nbconvert/preprocessors/csshtmlheader.py
+++ b/nbconvert/preprocessors/csshtmlheader.py
@@ -7,6 +7,7 @@
 import os
 import io
 import hashlib
+import nbconvert.resources
 
 from traitlets import Unicode
 from ipython_genutils.py3compat import str_to_bytes
@@ -53,7 +54,6 @@ class CSSHTMLHeaderPreprocessor(Preprocessor):
         header = []
         
         # Construct path to Jupyter CSS
-        import nbconvert.resources
         sheet_filename = os.path.join(
             os.path.dirname(nbconvert.resources.__file__),
             'style.min.css',

--- a/nbconvert/tests/base.py
+++ b/nbconvert/tests/base.py
@@ -10,6 +10,7 @@ import shlex
 import shutil
 import sys
 import unittest
+import nbconvert
 from subprocess import Popen, PIPE
 
 import nose.tools as nt
@@ -124,7 +125,6 @@ class TestsBase(unittest.TestCase):
         
         #Build a path using the nbconvert directory and the relative path we just
         #found.
-        import nbconvert
         path = os.path.dirname(nbconvert.__file__)
         return os.path.join(path, *names)
 

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ extras_require = setuptools_args['extras_require'] = {
     # FIXME: tests still require nose for some utility calls,
     # but we are running with pytest
     'test': ['pytest', 'pytest-cov', 'nose', 'ipykernel', 'testpath'],
-    'serve': ['tornado>=4.0,<5.0'],
+    'serve': ['tornado>=4.0'],
     'execute': ['jupyter_client'],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ extras_require = setuptools_args['extras_require'] = {
     # FIXME: tests still require nose for some utility calls,
     # but we are running with pytest
     'test': ['pytest', 'pytest-cov', 'nose', 'ipykernel', 'testpath'],
-    'serve': ['tornado'],
+    'serve': ['tornado>=4.0,<5.0'],
     'execute': ['jupyter_client'],
 }
 


### PR DESCRIPTION
Closes #424. 

Pygments, IPython, jupyter-client imports were left alone.

Upgraded required version of tornado to 4.0 (per suggestion by @carreau). 