### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
 [![Build Status](https://travis-ci.org/jupyter/nbconvert.svg?branch=master)](https://travis-ci.org/jupyter/nbconvert)
-[![Documentation Status](https://readthedocs.org/projects/nbconvert/badge/?version=latest)](http://nbconvert.readthedocs.org/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/nbconvert/badge/?version=latest)](https://nbconvert.readthedocs.io/en/latest/?badge=latest)
 [![codecov.io](https://codecov.io/github/jupyter/nbconvert/coverage.svg?branch=master)](https://codecov.io/github/jupyter/nbconvert?branch=master)
 
 
@@ -69,13 +69,13 @@ py.test --pyargs nbconvert
 
 ## Resources
 
-- [Documentation for Jupyter nbconvert](https://nbconvert.readthedocs.org/en/latest/)
+- [Documentation for Jupyter nbconvert](https://nbconvert.readthedocs.io/en/latest/)
   [[PDF](https://media.readthedocs.org/pdf/nbconvert/latest/nbconvert.pdf)]
 - [nbconvert examples on GitHub](https://github.com/jupyter/nbconvert-examples)
 - [Issues](https://github.com/jupyter/nbconvert/issues)
 - [Technical support - Jupyter Google Group](https://groups.google.com/forum/#!forum/jupyter)
 - [Project Jupyter website](https://jupyter.org)
-- [Documentation for Project Jupyter](https://jupyter.readthedocs.org/en/latest/index.html)
+- [Documentation for Project Jupyter](https://jupyter.readthedocs.io/en/latest/index.html)
   [[PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)]
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documenting nbconvert
 
-[Documentation for `nbconvert`](https://nbconvert.readthedocs.org/en/latest/)
+[Documentation for `nbconvert`](https://nbconvert.readthedocs.io/en/latest/)
 is hosted on ReadTheDocs.
 
 ## Build Documentation locally

--- a/docs/source/customizing.ipynb
+++ b/docs/source/customizing.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Under the hood, nbconvert uses [Jinja templates](http://jinja2.readthedocs.org/en/latest/intro.html) to specify how the notebooks should be formatted. These templates can be fully customized, allowing you to use nbconvert to create notebooks in different formats with different styles as well.\n",
+    "Under the hood, nbconvert uses [Jinja templates](https://jinja2.readthedocs.io/en/latest/intro.html) to specify how the notebooks should be formatted. These templates can be fully customized, allowing you to use nbconvert to create notebooks in different formats with different styles as well.\n",
     "\n",
     "Out of the box, nbconvert can be used to convert notebooks to plain Python files. For example, the following command converts the `example.ipynb` notebook to Python and prints out the result:"
    ]

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -79,7 +79,7 @@ Execution arguments (traitlets)
 -------------------------------
 
 The arguments passed to :class:`ExecutePreprocessor` are configuration options
-called `traitlets <http://traitlets.readthedocs.org/en/stable>`_.
+called `traitlets <https://traitlets.readthedocs.io/en/stable>`_.
 There are many cool things about traitlets. For example,
 they enforce the input type, and they can be accessed/modified as
 class attributes. Moreover, each traitlet is automatically exposed

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -3,7 +3,7 @@ Installation
 
 .. seealso::
 
-   `Installing Jupyter <https://jupyter.readthedocs.org/en/latest/install.html>`__
+   `Installing Jupyter <https://jupyter.readthedocs.io/en/latest/install.html>`__
      Nbconvert is part of the Jupyter ecosystem.
 
 Installing nbconvert

--- a/docs/source/nbconvert_library.ipynb
+++ b/docs/source/nbconvert_library.ipynb
@@ -99,7 +99,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The nbformat API returns a special type of dictionary. For this examle, you don't need to worry about the details of the structure (if you are interested, please see the [nbformat documentation](http://nbformat.readthedocs.org/en/latest/)).\n",
+    "The nbformat API returns a special type of dictionary. For this examle, you don't need to worry about the details of the structure (if you are interested, please see the [nbformat documentation](https://nbformat.readthedocs.io/en/latest/)).\n",
     "\n",
     "The nbconvert API exposes some basic exporters for common formats and defaults. You will start by using one of them. First, you will import one of these exporters (specifically, the HTML exporter), then instantiate it using most of the defaults, and then you will use it to process the notebook we downloaded earlier."
    ]


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.