### PR TITLE
Don't mention the log in exception message

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -237,8 +237,7 @@ class ExecutePreprocessor(Preprocessor):
                         exception = TimeoutError
                     except NameError:
                         exception = RuntimeError
-                    raise exception(
-                        "Cell execution timed out, see log for details.")
+                    raise exception("Cell execution timed out")
 
             if msg['parent_header'].get('msg_id') == msg_id:
                 break


### PR DESCRIPTION
At this point in the code it is impossible to know if there will be a log or not.
If the `ExecutePreprocessor` is used programmatically, there may be no log at all.

The information about the log should be added at a higher level in the call chain.

Note that some time ago, I've already removed a log message in #325, which should probably also be reintroduced somewhere higher up in the chain.