### PR TITLE
Add pipeline overview to architecture documentation, fix README [WIP]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ is hosted on ReadTheDocs.
 
 4. Create an editable install for nbconvert using
 
-        $ pip install ../. -e 
+        $ pip install -e ../. 
 
    or if you want, `cd ..` and `pip install . -e`. But then you will need to `cd docs` before
    continuing to the next step.


### PR DESCRIPTION
I'm planning on looking at the writeup of the class structure more closely as I tried to extract much of the higher order description into the opening preamble.

I also want to add a few images to illustrate the structure.