### PR TITLE
Use tempdir to avoid creating untracked files in pdf tests

### DIFF
--- a/nbconvert/exporters/tests/test_pdf.py
+++ b/nbconvert/exporters/tests/test_pdf.py
@@ -34,7 +34,7 @@ class TestPDF(ExportersTestsBase):
         """Smoke test PDFExporter"""
         with tempdir.TemporaryDirectory() as td:
             newpath = os.path.join(td, os.path.basename(self._get_notebook()))
-            shutil.copy(self._get_notebook(),newpath)
+            shutil.copy(self._get_notebook(), newpath)
             (output, resources) = self.exporter_class(latex_count=1).from_filename(newpath)
             self.assertIsInstance(output, bytes)
             assert len(output) > 0

--- a/nbconvert/exporters/tests/test_pdf.py
+++ b/nbconvert/exporters/tests/test_pdf.py
@@ -5,8 +5,10 @@
 
 import logging
 import os
+import shutil
 
 from ipython_genutils.testing import decorators as dec
+from testpath import tempdir
 
 from .base import ExportersTestsBase
 from ..pdf import PDFExporter
@@ -30,7 +32,10 @@ class TestPDF(ExportersTestsBase):
     @dec.onlyif_cmds_exist('pandoc')
     def test_export(self):
         """Smoke test PDFExporter"""
-        (output, resources) = self.exporter_class(latex_count=1).from_filename(self._get_notebook())
-        self.assertIsInstance(output, bytes)
-        assert len(output) > 0
+        with tempdir.TemporaryDirectory() as td:
+            newpath = os.path.join(td, os.path.basename(self._get_notebook()))
+            shutil.copy(self._get_notebook(),newpath)
+            (output, resources) = self.exporter_class(latex_count=1).from_filename(newpath)
+            self.assertIsInstance(output, bytes)
+            assert len(output) > 0
 


### PR DESCRIPTION
When running tests locally, files that were not tracked by git were being created by the current tests for the pdf exporter. 

Now, it creates a temporary directory, copies the relevant files there, and then performs the needed operations. The temporary directory gets torn down as part of its context manager. 