### PR TITLE
Add configurable kernel_manager_class for execution

### DIFF
--- a/nbconvert/preprocessors/tests/fake_kernelmanager.py
+++ b/nbconvert/preprocessors/tests/fake_kernelmanager.py
@@ -1,0 +1,20 @@
+from jupyter_client.manager import KernelManager
+
+
+class FakeCustomKernelManager(KernelManager):
+    expected_methods = {
+        '__init__': 0,
+        'start_kernel': 0
+    }
+
+    def __init__(self, *args, **kwargs):
+        self.log.info('FakeCustomKernelManager initialized')
+        self.expected_methods['__init__'] += 1
+        super(FakeCustomKernelManager, self).__init__(*args, **kwargs)
+
+    def start_kernel(self, *args, **kwargs):
+        self.log.info('FakeCustomKernelManager started a kernel')
+        self.expected_methods['start_kernel'] += 1
+        return super(FakeCustomKernelManager, self).start_kernel(
+            *args,
+            **kwargs)

--- a/nbconvert/preprocessors/tests/fake_kernelmanager.py
+++ b/nbconvert/preprocessors/tests/fake_kernelmanager.py
@@ -4,7 +4,8 @@ from jupyter_client.manager import KernelManager
 class FakeCustomKernelManager(KernelManager):
     expected_methods = {
         '__init__': 0,
-        'start_kernel': 0
+        'client': 0,
+        'start_kernel': 0,
     }
 
     def __init__(self, *args, **kwargs):
@@ -16,5 +17,12 @@ class FakeCustomKernelManager(KernelManager):
         self.log.info('FakeCustomKernelManager started a kernel')
         self.expected_methods['start_kernel'] += 1
         return super(FakeCustomKernelManager, self).start_kernel(
+            *args,
+            **kwargs)
+
+    def client(self, *args, **kwargs):
+        self.log.info('FakeCustomKernelManager created a client')
+        self.expected_methods['client'] += 1
+        return super(FakeCustomKernelManager, self).client(
             *args,
             **kwargs)


### PR DESCRIPTION
This adds a new configuration option, `kernel_manager_class`, which is used in a custom `start_new_kernel`. This would allow a suitably configured system to resolve kernels in different ways, i.e. remote kernels, environment-aware kernels, etc.

```shell
$ jupyter nbconvert Untitled.ipynb --ExecutePreprocessor.kernel_manager_class=nbconvert.preprocessors.tests.fake_kernelmanager.FakeCustomKernelManager --execute
[NbConvertApp] Converting notebook Untitled.ipynb to html
[NbConvertApp] Executing notebook with kernel: python3
[NbConvertApp] FakeCustomKernelManager initialized
[NbConvertApp] FakeCustomKernelManager started a kernel
[NbConvertApp] FakeCustomKernelManager created a client
[NbConvertApp] Writing 249953 bytes to Untitled.html
```