### PR TITLE
fix issue #463

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -14,15 +14,15 @@ from .latex import LatexExporter
 
 class LatexFailed(IOError):
     """Exception for failed latex run
-    
+
     Captured latex output is in error.output.
     """
     def __init__(self, output):
         self.output = output
-    
+
     def __unicode__(self):
         return u"PDF creating failed, captured latex output:\n%s" % self.output
-    
+
     def __str__(self):
         u = self.__unicode__()
         return cast_bytes_py2(u)
@@ -55,15 +55,15 @@ class PDFExporter(LatexExporter):
     temp_file_exts = List(['.aux', '.bbl', '.blg', '.idx', '.log', '.out'],
         help="File extensions of temp files to remove after running."
     ).tag(config=True)
-    
+
     texinputs = Unicode(help="texinputs dir. A notebook's directory is added")
     writer = Instance("nbconvert.writers.FilesWriter", args=())
-    
+
     _captured_output = List()
 
     def run_command(self, command_list, filename, count, log_function):
         """Run command_list count times.
-        
+
         Parameters
         ----------
         command_list : list
@@ -73,7 +73,7 @@ class PDFExporter(LatexExporter):
             The name of the file to convert.
         count : int
             How many times to run the command.
-        
+
         Returns
         -------
         success : bool
@@ -97,10 +97,10 @@ class PDFExporter(LatexExporter):
             raise OSError("{formatter} not found on PATH, if you have not installed "
                           "{formatter} you may need to do so. Find further instructions "
                           "at {link}.".format(formatter=command_list[0], link=link))
-        
+
         times = 'time' if count == 1 else 'times'
         self.log.info("Running %s %i %s: %s", command_list[0], count, times, command)
-        
+
         shell = (sys.platform == 'win32')
         if shell:
             command = subprocess.list2cmdline(command)
@@ -156,7 +156,7 @@ class PDFExporter(LatexExporter):
                 os.remove(filename+ext)
             except OSError:
                 pass
-    
+
     def from_notebook_node(self, nb, resources=None, **kw):
         latex, resources = super(PDFExporter, self).from_notebook_node(
             nb, resources=resources, **kw
@@ -166,31 +166,28 @@ class PDFExporter(LatexExporter):
             self.texinputs = resources['metadata']['path']
         else:
             self.texinputs = os.getcwd()
-        
+
         self._captured_outputs = []
         with TemporaryWorkingDirectory() as td:
             notebook_name = 'notebook'
             tex_file = self.writer.write(latex, resources, notebook_name=notebook_name)
             self.log.info("Building PDF")
             rc = self.run_latex(tex_file)
-            if rc:
+            if not rc:
                 rc = self.run_bib(tex_file)
-            if rc:
-                rc = self.run_latex(tex_file)
-            
+
             pdf_file = notebook_name + '.pdf'
             if not os.path.isfile(pdf_file):
                 raise LatexFailed('\n'.join(self._captured_output))
             self.log.info('PDF successfully created')
             with open(pdf_file, 'rb') as f:
                 pdf_data = f.read()
-        
+
         # convert output extension to pdf
         # the writer above required it to be tex
         resources['output_extension'] = '.pdf'
         # clear figure outputs, extracted by latex export,
         # so we don't claim to be a multi-file export.
         resources.pop('outputs', None)
-        
+
         return pdf_data, resources
-    

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -11,9 +11,9 @@ This template does not define a docclass, the inheriting class must define this.
 
 ((* block header *))
     ((* block docclass *))((* endblock docclass *))
-    
+
     ((* block packages *))
-    \usepackage[T1]{fontenc}
+    \usepackage[T2A]{fontenc}
     % Nicer default font (+ math font) than Computer Modern for most use cases
     \usepackage{mathpazo}
 
@@ -37,7 +37,7 @@ This template does not define a docclass, the inheriting class must define this.
     \DeclareCaptionLabelFormat{nolabel}{}
     \captionsetup{labelformat=nolabel}
 
-    \usepackage{adjustbox} % Used to constrain images to a maximum size 
+    \usepackage{adjustbox} % Used to constrain images to a maximum size
     \usepackage{xcolor} % Allow colors to be defined
     \usepackage{enumerate} % Needed for markdown enumerations to work
     \usepackage{geometry} % Used to adjust the document margins
@@ -53,8 +53,8 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
     \usepackage[utf8x]{inputenc} % Allow utf-8 characters in the tex document
     \usepackage{fancyvrb} % verbatim replacement that allows latex
-    \usepackage{grffile} % extends the file name processing of package graphics 
-                         % to support a larger range 
+    \usepackage{grffile} % extends the file name processing of package graphics
+                         % to support a larger range
     % The hyperref package gives us a pdf with properly built
     % internal navigation ('pdf bookmarks' for the table of contents,
     % internal cross-reference links, web links for URLs, etc.)
@@ -111,7 +111,7 @@ This template does not define a docclass, the inheriting class must define this.
     \newcommand{\RegionMarkerTok}[1]{{#1}}
     \newcommand{\ErrorTok}[1]{\textcolor[rgb]{1.00,0.00,0.00}{\textbf{{#1}}}}
     \newcommand{\NormalTok}[1]{{#1}}
-    
+
     % Additional commands for more recent versions of Pandoc
     \newcommand{\ConstantTok}[1]{\textcolor[rgb]{0.53,0.00,0.00}{{#1}}}
     \newcommand{\SpecialCharTok}[1]{\textcolor[rgb]{0.25,0.44,0.63}{{#1}}}
@@ -130,8 +130,8 @@ This template does not define a docclass, the inheriting class must define this.
     \newcommand{\AttributeTok}[1]{\textcolor[rgb]{0.49,0.56,0.16}{{#1}}}
     \newcommand{\InformationTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{{#1}}}}}
     \newcommand{\WarningTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{{#1}}}}}
-    
-    
+
+
     % Define a nice break command that doesn't care if a line doesn't already
     % exist.
     \def\br{\hspace*{\fill} \\* }
@@ -146,7 +146,7 @@ This template does not define a docclass, the inheriting class must define this.
 
     ((* block commands *))
     % Prevent overflowing lines due to hard-to-break entities
-    \sloppy 
+    \sloppy
     % Setup hyperref package
     \hypersetup{
       breaklinks=true,  % so long urls are correctly broken across lines
@@ -164,7 +164,7 @@ This template does not define a docclass, the inheriting class must define this.
 
 ((* block body *))
     \begin{document}
-    
+
     ((* block predoc *))
     ((* block maketitle *))\maketitle((* endblock maketitle *))
     ((* block abstract *))((* endblock abstract *))


### PR DESCRIPTION
Now “File -> Download as -> PDF via LaTeX (.pdf)” works well even if
jupyter notebook contains russian characters