### PR TITLE
refactor add_anchor to isolate reuable id generation

### DIFF
--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -77,12 +77,14 @@ def html2text(element):
     return text
 
 
-def convert_header_id(header_contents):
-    """Convert header contents to valid id value. Takes html as input, returns string.
+def _convert_header_id(header_contents):
+    """Convert header contents to valid id value. Takes string as input, returns string.
+    
+    Note: this may be subject to change in the case of changes to how we wish to generate ids.
 
     For use on markdown headings.
     """
-    return html2text(header_contents).replace(' ', '-')
+    return header_contents.replace(' ', '-')
 
 def add_anchor(html):
     """Add an id and an anchor-link to an html header
@@ -94,7 +96,7 @@ def add_anchor(html):
     except Exception:
         # failed to parse, just return it unmodified
         return html
-    link = convert_header_id(h)
+    link = _convert_header_id(html2text(h))
     h.set('id', link)
     a = ElementTree.Element("a", {"class" : "anchor-link", "href" : "#" + link})
     a.text = u'¶'

--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -77,17 +77,12 @@ def html2text(element):
     return text
 
 
-def convert_header_id(html):
+def convert_header_id(header_contents):
     """Convert header contents to valid id value. Takes html as input, returns string.
 
     For use on markdown headings.
     """
-    try:
-        h = ElementTree.fromstring(py3compat.cast_bytes_py2(html, encoding='utf-8'))
-    except Exception:
-        # failed to parse, just return it unmodified
-        return html
-    return html2text(h).replace(' ', '-')
+    return html2text(header_contents).replace(' ', '-')
 
 def add_anchor(html):
     """Add an id and an anchor-link to an html header

--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -77,8 +77,20 @@ def html2text(element):
     return text
 
 
+def convert_header_id(html):
+    """Convert header contents to valid id value. Takes html as input, returns string.
+
+    For use on markdown headings.
+    """
+    try:
+        h = ElementTree.fromstring(py3compat.cast_bytes_py2(html, encoding='utf-8'))
+    except Exception:
+        # failed to parse, just return it unmodified
+        return html
+    return html2text(h).replace(' ', '-')
+
 def add_anchor(html):
-    """Add an anchor-link to an html header
+    """Add an id and an anchor-link to an html header
     
     For use on markdown headings
     """
@@ -87,7 +99,7 @@ def add_anchor(html):
     except Exception:
         # failed to parse, just return it unmodified
         return html
-    link = html2text(h).replace(' ', '-')
+    link = convert_header_id(h)
     h.set('id', link)
     a = ElementTree.Element("a", {"class" : "anchor-link", "href" : "#" + link})
     a.text = u'¶'


### PR DESCRIPTION
This isn't quite ready, as it breaks. But I wanted to put it up here to get comments on whether more should be put in here. E.g., should we do anything else that would make our mechanism more similar to the pandoc [autolinking mechanism](http://pandoc.org/MANUAL.html#header-identifiers)?

Not sure, but right now it's erring because the wrong things are being passed around.