### PR TITLE
do not suppress kernel errors

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -194,7 +194,6 @@ class ExecutePreprocessor(Preprocessor):
         self.km, self.kc = start_new_kernel(
             kernel_name=kernel_name,
             extra_arguments=self.extra_arguments,
-            stderr=open(os.devnull, 'w'),
             cwd=path)
         self.kc.allow_stdin = False
 


### PR DESCRIPTION
This can be important info when things go wrong

alternately:

- only allow kernel output on debug
- enable explicit suppression on `--quiet` etc.