### PR TITLE
Change ipython_genutils.tempdir calls to testpath.tempdir and tempfile

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -9,7 +9,7 @@ import sys
 
 from ipython_genutils.py3compat import which, cast_bytes_py2
 from traitlets import Integer, List, Bool, Instance, Unicode
-from ipython_genutils.tempdir import TemporaryWorkingDirectory
+from testpath.tempdir import TemporaryWorkingDirectory
 from .latex import LatexExporter
 
 class LatexFailed(IOError):

--- a/nbconvert/exporters/tests/test_latex.py
+++ b/nbconvert/exporters/tests/test_latex.py
@@ -12,7 +12,7 @@ from ..latex import LatexExporter
 from nbformat import write
 from nbformat import v4
 from ipython_genutils.testing.decorators import onlyif_cmds_exist
-from ipython_genutils.tempdir import TemporaryDirectory
+from tempfile import TemporaryDirectory
 
 
 class TestLatexExporter(ExportersTestsBase):

--- a/nbconvert/exporters/tests/test_latex.py
+++ b/nbconvert/exporters/tests/test_latex.py
@@ -12,7 +12,7 @@ from ..latex import LatexExporter
 from nbformat import write
 from nbformat import v4
 from ipython_genutils.testing.decorators import onlyif_cmds_exist
-from tempfile import TemporaryDirectory
+from testpath.tempdir import TemporaryDirectory
 
 
 class TestLatexExporter(ExportersTestsBase):

--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -12,7 +12,7 @@ import sys
 import subprocess
 
 from ipython_genutils.py3compat import cast_unicode_py2
-from tempfile import TemporaryDirectory
+from testpath.tempdir import TemporaryDirectory
 from traitlets import Unicode, default
 
 from .convertfigures import ConvertFiguresPreprocessor

--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -12,7 +12,7 @@ import sys
 import subprocess
 
 from ipython_genutils.py3compat import cast_unicode_py2
-from ipython_genutils.tempdir import TemporaryDirectory
+from tempfile import TemporaryDirectory
 from traitlets import Unicode, default
 
 from .convertfigures import ConvertFiguresPreprocessor

--- a/nbconvert/tests/base.py
+++ b/nbconvert/tests/base.py
@@ -16,7 +16,7 @@ from subprocess import Popen, PIPE
 import nose.tools as nt
 
 from nbformat import v4, write
-from ipython_genutils.tempdir import TemporaryWorkingDirectory
+from testpath.tempdir import TemporaryWorkingDirectory
 
 from ipython_genutils.py3compat import string_types, bytes_to_str
 

--- a/setup.py
+++ b/setup.py
@@ -194,12 +194,13 @@ install_requires = setuptools_args['install_requires'] = [
     'entrypoints',
     'bleach',
     'pandocfilters>=1.4.1',
+    'testpath', 
 ]
 
 extras_require = setuptools_args['extras_require'] = {
     # FIXME: tests still require nose for some utility calls,
     # but we are running with pytest
-    'test': ['pytest', 'pytest-cov', 'nose', 'ipykernel', 'testpath'],
+    'test': ['pytest', 'pytest-cov', 'nose', 'ipykernel'],
     'serve': ['tornado>=4.0'],
     'execute': ['jupyter_client'],
 }


### PR DESCRIPTION
Elsewhere we speak of removing dependencies on ipython_genutils. I ran a grep and found the cases where I know we were using them needlessly, specifically related to creating temporary directories and replaced them with `testpath.tempdir` if it was a `TemporaryWorkingDirectory` and the standard library `tempfile` if it was a `TemporaryDirectory` since `testpath.tempdir` was just importing that itself anyway. 