### PR TITLE
Fixing the widget calls, conditionally embedding the script tag

### DIFF
--- a/nbconvert/templates/html/basic.tpl
+++ b/nbconvert/templates/html/basic.tpl
@@ -242,7 +242,7 @@ var element = $('#{{ div_id }}');
 
 {%- block footer %}
 {% set mimetype = 'application/vnd.jupyter.widget-state+json'%} 
-{% if mimetype in nb.metadata.widgets %}
+{% if mimetype in nb.metadata.get("widgets",{})%}
 <script type="{{ mimetype }}">
 {{ nb.metadata.widgets[mimetype] | json_dumps }}
 </script>

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -10,6 +10,10 @@
 <meta charset="utf-8" />
 <title>{{resources['metadata']['name']}}</title>
 
+{%- if "widgets" in nb.metadata -%}
+<script src="https://unpkg.com/jupyter-js-widgets@2.0.*/dist/embed.js"></script>
+{%- endif-%}
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 


### PR DESCRIPTION
This makes widgets actually work in nbconvert, this closes https://github.com/jupyter/nbviewer/pull/650 for now. And finishes up closing #481. 

Also, made it so that it wouldn't err if a notebook is passed in that does not have the widgets metadata.

This shouldn't break anything and should be a high priority merge to fix a potential break in #482.