### PR TITLE
Corrects a typo

### DIFF
--- a/docs/source/nbconvert_library.ipynb
+++ b/docs/source/nbconvert_library.ipynb
@@ -518,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },


### PR DESCRIPTION
In reviewing #488, I noticed a typo in the cell number of one of the example notebooks. This corrects the typo 1 -> 11.