### PR TITLE
bring up to date with nbsphinx's compatibility with sphinx 1.5.1

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,9 +7,9 @@ dependencies:
 - nbformat
 - jupyter_client
 - ipython
-- sphinx>=1.3.6,!=1.5.0,!=1.5.1
+- sphinx>=1.5.1
 - sphinx_rtd_theme
 - tornado
 - entrypoints
 - pip:
-    - nbsphinx
+    - nbsphinx>=0.2.12


### PR DESCRIPTION
Same as #493, but for 5.x not master. 

https://github.com/jupyter/nbconvert/issues/492#issuecomment-268060877 points out that we can update to the latest sphinx so long as we update to the latest nbsphinx.