### PR TITLE
Don't import jupyter_client unless we're executing the notebook

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -18,7 +18,6 @@ from nbformat.v4 import output_from_msg
 from .base import Preprocessor
 from ..utils.exceptions import ConversionException
 from traitlets import Integer
-from jupyter_client.manager import KernelManager
 
 
 class CellExecutionError(ConversionException):
@@ -139,7 +138,7 @@ class ExecutePreprocessor(Preprocessor):
     ).tag(config=True)
 
     kernel_manager_class = Type(
-        default_value=KernelManager,
+        default_value='jupyter_client.manager.KernelManager',
         config=True,
         help='The kernel manager class to use.'
     )

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ install_requires = setuptools_args['install_requires'] = [
 extras_require = setuptools_args['extras_require'] = {
     # FIXME: tests still require nose for some utility calls,
     # but we are running with pytest
-    'test': ['pytest', 'pytest-cov', 'nose', 'ipykernel'],
+    'test': ['pytest', 'pytest-cov', 'nose', 'ipykernel', 'jupyter_client'],
     'serve': ['tornado>=4.0'],
     'execute': ['jupyter_client'],
 }


### PR DESCRIPTION
Closes gh-495

Also added `jupyter_client` as an explicit dependency for the tests, since it's imported in test code.