### PR TITLE
Add block to allow customizing html output prompt

### DIFF
--- a/nbconvert/templates/html/basic.tpl
+++ b/nbconvert/templates/html/basic.tpl
@@ -53,6 +53,7 @@ In&nbsp;[&nbsp;]:
 
 {% block output %}
 <div class="output_area">
+{% block output_area_prompt %}
 {%- if output.output_type == 'execute_result' -%}
     <div class="prompt output_prompt">
 {%- if cell.execution_count is defined -%}
@@ -64,6 +65,7 @@ In&nbsp;[&nbsp;]:
     <div class="prompt">
 {%- endif -%}
     </div>
+{% endblock output_area_prompt %}
 {{ super() }}
 </div>
 {% endblock output %}


### PR DESCRIPTION
For generating HTML reports I usually want to completely hide cells' output, apart from a select few types such as HTML and images. I can almost accomplish this with a custom template inheriting from `full.tpl`, except that I can't hide the output prompt without hiding the cell output itself. I can if I add this block.