### PR TITLE
Add links to tests by having them in the example notebook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ addons:
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    # - wget https://hackage.haskell.org/package/pandoc-1.19.1/pandoc-1.19.1.tar.gz && tar -xzvf pandoc-1.19.1.tar.gz
-    - wget http://c90cb902a90d6a506ab3-a24171cbeaa42ce11788f0df3362e902.r46.cf5.rackcdn.com/pandoc-1.15.0.6.tar.gz && tar -xzvf pandoc-1.15.0.6.tar.gz 
+    - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
     - pip install -f travis-wheels/wheelhouse . codecov coverage
     - pip install nbconvert[execute,serve,test]
     - python -m ipykernel.kernelspec --user

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ addons:
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - wget http://c90cb902a90d6a506ab3-a24171cbeaa42ce11788f0df3362e902.r46.cf5.rackcdn.com/pandoc-1.15.0.6.tar.gz && tar -xzf pandoc-1.15.0.6.tar.gz
+    # - wget https://hackage.haskell.org/package/pandoc-1.19.1/pandoc-1.19.1.tar.gz && tar -xzvf pandoc-1.19.1.tar.gz
+    - wget http://c90cb902a90d6a506ab3-a24171cbeaa42ce11788f0df3362e902.r46.cf5.rackcdn.com/pandoc-1.15.0.6.tar.gz && tar -xzvf pandoc-1.15.0.6.tar.gz 
     - pip install -f travis-wheels/wheelhouse . codecov coverage
     - pip install nbconvert[execute,serve,test]
     - python -m ipykernel.kernelspec --user

--- a/nbconvert/exporters/tests/files/notebook2.ipynb
+++ b/nbconvert/exporters/tests/files/notebook2.ipynb
@@ -17,9 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -38,9 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np"
@@ -56,9 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "a = np.random.uniform(size=(100,100))"
@@ -67,9 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -89,9 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "evs = np.linalg.eigvals(a)"
@@ -100,9 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -129,9 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -164,26 +150,33 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
-    "This cell is just markdown for testing whether an ASCIIDoc quirk is caught.\n",
+    "This cell is just markdown testing whether an ASCIIDoc quirk is caught and whether [header links are rendered](#numpy-and-matplotlib-examples) even if they [don't resolve correctly now](#NumPy-and-Matplotlib-examples).\n",
     "\n",
     "one *test* two *tests*. three *tests*"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
I noticed none of the link code included in https://github.com/jupyter/nbconvert/pull/458 was being tested. 

Figured I'd preëmptively include links for both pandoc compatible and incompatible automatic header-id generation.