### PR TITLE
Pin python version to 3.5 for RTD so that docs will build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: nbconvert_docs
 channels:
   - conda-forge
 dependencies:
-- python>=3.5
+- python==3.5
 - pandoc
 - nbformat
 - jupyter_client


### PR DESCRIPTION
I'm not entirely sure why, but when readthedocs attempts to use python 3.6 to build our docs, it fails. 

I think this may relate to dependencies that do not expect to be interpreted via python 3.6. See the error log at https://readthedocs.org/projects/nbconvert/builds/4854852/.

Or the issue I filed with conda at https://github.com/conda/conda/issues/4168

What really confuses me though is that this included some dependencies that list `3.6*` as a potential version number… The only reason I thought to notice this is that I saw `py36_` in the installation file names. 

Solution: pinning the version at 3.5 until we figure out how to better solve this problem. (Note, the rtd build succeeds with this change, see https://readthedocs.org/projects/nbconvert-mp/builds/4855978/)