### PR TITLE
[WIP] make anchor text configurable

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -5,7 +5,7 @@
 
 import os
 
-from traitlets import default
+from traitlets import default, Unicode
 from traitlets.config import Config
 
 from nbconvert.filters.highlight import Highlight2HTML
@@ -35,6 +35,14 @@ class HTMLExporter(TemplateExporter):
     
     output_mimetype = 'text/html'
     
+    anchor_link_text = Unicode(
+            help="The text used as the target for anchor links.").tag(config=True)
+
+    @default('anchor_link_text')
+    def _anchor_link_text(self):
+        """ Defaults to pilcrow (¶)"""
+        return u'¶'
+
     @property
     def default_config(self):
         c = Config({
@@ -66,4 +74,7 @@ class HTMLExporter(TemplateExporter):
         lexer = langinfo.get('pygments_lexer', langinfo.get('name', None))
         self.register_filter('highlight_code',
                              Highlight2HTML(pygments_lexer=lexer, parent=self))
+        if resources is None:
+            resources = {}
+        resources['anchor_text'] = self.anchor_link_text
         return super(HTMLExporter, self).from_notebook_node(nb, resources, **kw)

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -100,9 +100,9 @@ class IPythonRenderer(mistune.Renderer):
         formatter = HtmlFormatter()
         return highlight(code, lexer, formatter)
 
-    def header(self, text, level, raw=None):
+    def header(self, text, level, raw=None, anchor_text=''):
         html = super(IPythonRenderer, self).header(text, level, raw=raw)
-        return add_anchor(html)
+        return add_anchor(html, anchor_text=self.options['anchor_text'])
 
     # Pass math through unaltered - mathjax does the rendering in the browser
     def block_math(self, text):
@@ -114,6 +114,6 @@ class IPythonRenderer(mistune.Renderer):
     def inline_math(self, text):
         return '$%s$' % text
 
-def markdown2html_mistune(source):
+def markdown2html_mistune(source, anchor_text=u''):
     """Convert a markdown string to HTML using mistune"""
-    return MarkdownWithMath(renderer=IPythonRenderer(escape=False)).render(source)
+    return MarkdownWithMath(renderer=IPythonRenderer(escape=False,anchor_text=anchor_text)).render(source)

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -114,6 +114,6 @@ class IPythonRenderer(mistune.Renderer):
     def inline_math(self, text):
         return '$%s$' % text
 
-def markdown2html_mistune(source, anchor_text=u''):
+def markdown2html_mistune(source, anchor_text=u'¶'):
     """Convert a markdown string to HTML using mistune"""
     return MarkdownWithMath(renderer=IPythonRenderer(escape=False,anchor_text=anchor_text)).render(source)

--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -86,7 +86,7 @@ def _convert_header_id(header_contents):
     """
     return header_contents.replace(' ', '-')
 
-def add_anchor(html):
+def add_anchor(html, anchor_text=u'¶'):
     """Add an id and an anchor-link to an html header
     
     For use on markdown headings
@@ -99,9 +99,8 @@ def add_anchor(html):
     link = _convert_header_id(html2text(h))
     h.set('id', link)
     a = ElementTree.Element("a", {"class" : "anchor-link", "href" : "#" + link})
-    a.text = u'¶'
+    a.text = anchor_text
     h.append(a)
-
     # Known issue of Python3.x, ElementTree.tostring() returns a byte string
     # instead of a text string.  See issue http://bugs.python.org/issue10942
     # Workaround is to make sure the bytes are casted to a string.

--- a/nbconvert/templates/html/basic.tpl
+++ b/nbconvert/templates/html/basic.tpl
@@ -75,7 +75,7 @@ In&nbsp;[&nbsp;]:
 {{ self.empty_in_prompt() }}
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-{{ cell.source  | markdown2html | strip_files_prefix }}
+{{ cell.source  | markdown2html(anchor_text=resources.anchor_text) | strip_files_prefix }}
 </div>
 </div>
 </div>


### PR DESCRIPTION
So, I'm not super happy with this.

I haven't been able to figure out how to use traitlets effectively to pass arguments down to filters so I could call them from within templates, but I don't see that being done anywhere in a really obvious way. The closest thing I found was the [`reveal_prefix`](https://github.com/jupyter/nbconvert/blob/156918dfab64fd5c56269757254e7f041af990bd/nbconvert/exporters/slides.py#L78) used by the slides exporter, so I tried to mirror that structure. 

But it still required adding a bunch of arguments to different functions that seem like they should be redundant. Some guidance for simplifying this structure would be greatly appreciated.