### PR TITLE
Allow kernel authors to suggest a package for script export

### DIFF
--- a/nbconvert/exporters/base.py
+++ b/nbconvert/exporters/base.py
@@ -26,6 +26,7 @@ __all__ = [
     'get_exporter',
     'get_export_names',
     'ExporterNameError',
+    'ExporterNotFound',
 ]
 
 
@@ -85,10 +86,18 @@ def export(exporter, nb, **kw):
     return output, resources
 
 
+class ExporterNotFound(ValueError):
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return ('Unknown exporter "%s", did you mean one of: %s?'
+                 % (self.name, ', '.join(get_export_names())))
+
 def get_exporter(name):
     """Given an exporter name or import path, return a class ready to be instantiated
     
-    Raises ValueError if exporter is not found
+    Raises ExporterNotFound if exporter is not found
     """
 
     try:
@@ -106,8 +115,7 @@ def get_exporter(name):
             log = get_logger()
             log.error("Error importing %s" % name, exc_info=True)
 
-    raise ValueError('Unknown exporter "%s", did you mean one of: %s?'
-                     % (name, ', '.join(get_export_names())))
+    raise ExporterNotFound(name)
 
 
 def get_export_names():

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -6,9 +6,7 @@
 from .templateexporter import TemplateExporter
 
 from traitlets import Dict, default
-from traitlets.utils.importstring import import_item
-from .base import get_exporter
-
+from .base import get_exporter, ExporterNotFound
 
 class ScriptExporter(TemplateExporter):
     
@@ -23,14 +21,30 @@ class ScriptExporter(TemplateExporter):
         
         # delegate to custom exporter, if specified
         exporter_name = langinfo.get('nbconvert_exporter')
-        if exporter_name and exporter_name != 'script':
-            self.log.debug("Loading script exporter: %s", exporter_name)
-            if exporter_name not in self._exporters:
+
+        if (not exporter_name) or exporter_name == 'script':
+            return self._plain_export(nb, resources, langinfo, **kw)
+
+
+        self.log.debug("Loading script exporter: %s", exporter_name)
+        if exporter_name not in self._exporters:
+            try:
                 Exporter = get_exporter(exporter_name)
                 self._exporters[exporter_name] = Exporter(parent=self)
-            exporter = self._exporters[exporter_name]
-            return exporter.from_notebook_node(nb, resources, **kw)
-        
+            except ExporterNotFound:
+                warn = self.log.warn
+                warn("Exporter '%s' not available,"
+                     "falling back to plain script export" % exporter_name)
+                exporter_dist = langinfo.get('nbconvert_exporter_dist', None)
+                if exporter_dist:
+                    warn("The notebook's metadata suggests installing the "
+                         "'%s' package to provide this exporter" % exporter_dist)
+                return self._plain_export(nb, resources, langinfo, **kw)
+
+        exporter = self._exporters[exporter_name]
+        return exporter.from_notebook_node(nb, resources, **kw)
+
+    def _plain_export(self, nb, resources, langinfo, **kw):
         self.file_extension = langinfo.get('file_extension', '.txt')
         self.output_mimetype = langinfo.get('mimetype', 'text/plain')
         return super(ScriptExporter, self).from_notebook_node(nb, resources, **kw)


### PR DESCRIPTION
Part of gh-361

Now that we use entry points to find exporters, kernel authors could provide a custom script exporter, and specify it in language_info metadata. But currently, if that package is not installed, nbconvert will fail with an unhelpful error message. This is a problem especially for kernels which are not distributed as Python packages (e.g. R, Julia)

With this PR, if the specified exporter cannot be found, nbconvert will display a warning and fall back on plain script export. It also looks for a new field in language_info, called 'nbconvert_exporter_dist', to provide a suggestion of a package to install for better script export. If we do go for this, it will need to be documented in the messaging docs.