### PR TITLE
Fix bug when there is "<" in the math formula

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -8,6 +8,7 @@ Used from markdown.py
 from __future__ import print_function
 
 import re
+import html
 
 import mistune
 
@@ -104,20 +105,19 @@ class IPythonRenderer(mistune.Renderer):
         html = super(IPythonRenderer, self).header(text, level, raw=raw)
         return add_anchor(html)
 
-    def escape_lt(self,text):
-        return text.replace('<','&lt;')
+    def escape_html(self,text):
+        return html.escape(text,quote=False)
 
-    # Pass math through unaltered - mathjax does the rendering in the browser
     def block_math(self, text):
-        return '$$%s$$' % self.escape_lt(text)
+        return '$$%s$$' % self.escape_html(text)
 
     def latex_environment(self, name, text):
-        name = self.escape_lt(name)
-        text = self.escape_lt(text)
+        name = self.escape_html(name)
+        text = self.escape_html(text)
         return r'\begin{%s}%s\end{%s}' % (name, text, name)
 
     def inline_math(self, text):
-        return '$%s$' % self.escape_lt(text)
+        return '$%s$' % self.escape_html(text)
 
 def markdown2html_mistune(source):
     """Convert a markdown string to HTML using mistune"""

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -104,15 +104,20 @@ class IPythonRenderer(mistune.Renderer):
         html = super(IPythonRenderer, self).header(text, level, raw=raw)
         return add_anchor(html)
 
+    def escape_lt(self,text):
+        return text.replace('<','&lt;')
+
     # Pass math through unaltered - mathjax does the rendering in the browser
     def block_math(self, text):
-        return '$$%s$$' % text
+        return '$$%s$$' % self.escape_lt(text)
 
     def latex_environment(self, name, text):
+        name = self.escape_lt(name)
+        text = self.escape_lt(text)
         return r'\begin{%s}%s\end{%s}' % (name, text, name)
 
     def inline_math(self, text):
-        return '$%s$' % text
+        return '$%s$' % self.escape_lt(text)
 
 def markdown2html_mistune(source):
     """Convert a markdown string to HTML using mistune"""

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -8,7 +8,7 @@ Used from markdown.py
 from __future__ import print_function
 
 import re
-import html
+import cgi
 
 import mistune
 
@@ -105,8 +105,12 @@ class IPythonRenderer(mistune.Renderer):
         html = super(IPythonRenderer, self).header(text, level, raw=raw)
         return add_anchor(html)
 
+    # We must be careful here for compatibility
+    # html.escape() is not availale on python 2.7
+    # For more details, see:
+    # https://wiki.python.org/moin/EscapingHtml
     def escape_html(self,text):
-        return html.escape(text,quote=False)
+        return cgi.escape(text)
 
     def block_math(self, text):
         return '$$%s$$' % self.escape_html(text)

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -5,7 +5,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import re
-import html
 from copy import copy
 from functools import partial
 
@@ -147,7 +146,7 @@ class TestMarkdown(TestsBase):
             self.assertNotIn(">", math)
             self.assertNotRegex(math,"&(?![gt;|lt;|amp;])")
             # the result should be able to be unescaped correctly
-            self.assertEquals(case,html.unescape(math))
+            self.assertEquals(case,self._unescape(math))
 
     def test_markdown2html_math_mixed(self):
         """ensure markdown between inline and inline-block math"""
@@ -188,7 +187,8 @@ i.e. the $i^{th}$"""
         ]
 
         for case in cases:
-            self.assertIn(case, html.unescape(markdown2html(case)))
+            s = markdown2html(case)
+            self.assertIn(case,self._unescape(s))
 
     @dec.onlyif_cmds_exist('pandoc')
     def test_markdown2rst(self):
@@ -210,3 +210,14 @@ i.e. the $i^{th}$"""
         else:
             for token in tokens:
                 self.assertIn(token, results)
+
+    def _unescape(self,s):
+        # undo cgi.escape() manually
+        # We must be careful here for compatibility
+        # html.unescape() is not availale on python 2.7
+        # For more information, see:
+        # https://wiki.python.org/moin/EscapingHtml
+        s = s.replace("&lt;", "<")
+        s = s.replace("&gt;", ">")
+        s = s.replace("&amp;", "&")
+        return s

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -136,7 +136,16 @@ class TestMarkdown(TestsBase):
         # all the "<", ">", "&" must be escaped correctly
         cases = [ "$a<b&b<lt$",
                   "$a<b&lt;b>a;a-b<0$",
-                  "$<k'>$"]
+                  "$<k'>$",
+                  "$$a<b&b<lt$$",
+                  "$$a<b&lt;b>a;a-b<0$$",
+                  "$$<k'>$$",
+                  """$
+\begin{tabular}{ l c r }
+  1 & 2 & 3 \\
+  4 & 5 & 6 \\
+  7 & 8 & 9 \\
+\end{tabular}$"""]
         for case in cases:
             result = markdown2html(case)
             math = re.search("\$.*\$",result).group(0)

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -118,8 +118,9 @@ class TestMarkdown(TestsBase):
         ]:
             self._try_markdown(markdown2html, md, tokens)
 
-    def test_markdown2html_math_noescape(self):
+    def test_markdown2html_math(self):
         # Mathematical expressions not containing <, >, & should be passed through unaltered
+        # all the "<", ">", "&" must be escaped correctly
         cases = [("\\begin{equation*}\n"
                   "\\left( \\sum_{k=1}^n a_k b_k \\right)^2 \\leq \\left( \\sum_{k=1}^n a_k^2 \\right) \\left( \\sum_{k=1}^n b_k^2 \\right)\n"
                   "\\end{equation*}"),
@@ -127,14 +128,8 @@ class TestMarkdown(TestsBase):
                   "a = 1 *3* 5\n"
                   "$$"),
                   "$ a = 1 *3* 5 $",
-                  "$s_i = s_{i}\n$"
-                ]
-        for case in cases:
-            self.assertIn(case, markdown2html(case))
-
-    def test_markdown2html_math_escape(self):
-        # all the "<", ">", "&" must be escaped correctly
-        cases = [ "$a<b&b<lt$",
+                  "$s_i = s_{i}\n$",
+                  "$a<b&b<lt$",
                   "$a<b&lt;b>a;a-b<0$",
                   "$<k'>$",
                   "$$a<b&b<lt$$",
@@ -146,6 +141,7 @@ class TestMarkdown(TestsBase):
   4 & 5 & 6 \\
   7 & 8 & 9 \\
 \end{tabular}$"""]
+
         for case in cases:
             result = markdown2html(case)
             math = re.search("\$.*\$",result).group(0)

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -144,6 +144,9 @@ class TestMarkdown(TestsBase):
             # "&" not followed by "lt;", "gt;", or "amp;".
             self.assertNotIn("<", math)
             self.assertNotIn(">", math)
+            # python 2.7 has assertNotRegexpMatches instead of assertNotRegex
+            if not hasattr(self, 'assertNotRegex'):
+                self.assertNotRegex = self.assertNotRegexpMatches
             self.assertNotRegex(math,"&(?![gt;|lt;|amp;])")
             # the result should be able to be unescaped correctly
             self.assertEquals(case,self._unescape(math))

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -136,15 +136,19 @@ class TestMarkdown(TestsBase):
                   "$$a<b&lt;b>a;a-b<0$$",
                   "$$<k'>$$",
                   """$
-\begin{tabular}{ l c r }
+\\begin{tabular}{ l c r }
   1 & 2 & 3 \\
   4 & 5 & 6 \\
   7 & 8 & 9 \\
-\end{tabular}$"""]
+\\end{tabular}$"""]
 
         for case in cases:
             result = markdown2html(case)
-            math = re.search("\$.*\$",result).group(0)
+            # find the equation in the generated texts
+            search_result = re.search("\$.*\$",result,re.DOTALL)
+            if search_result is None:
+                search_result = re.search("\\\\begin\\{equation.*\\}.*\\\\end\\{equation.*\\}",result,re.DOTALL)
+            math = search_result.group(0)
             # the resulting math part can not contain "<", ">" or
             # "&" not followed by "lt;", "gt;", or "amp;".
             self.assertNotIn("<", math)


### PR DESCRIPTION
The easiest way to trigger the bug is to add a markdown cell and put $$<k'>$$.
When the notebook is converted to html, the "<" is left unescaped,
which makes browsers parse this as a html tag