### PR TITLE
add test to avoid nbsphinx issue with template extensions

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -209,7 +209,6 @@ class TemplateExporter(Exporter):
         """
         self.log.debug("Attempting to load template %s", template_file)
         self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
-        pass
 
     def _load_template(self):
         """Load the Jinja template object from the template file

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -204,6 +204,12 @@ class TemplateExporter(Exporter):
         self.observe(self._invalidate_template_cache,
                      list(self.traits(affects_template=True)))
 
+    def _log_template_loading(self,template_file):
+        """ abstract away some of the loggging for finding templates
+        """
+        self.log.debug("Attempting to load template %s", template_file)
+        self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
+        pass
 
     def _load_template(self):
         """Load the Jinja template object from the template file
@@ -220,33 +226,24 @@ class TemplateExporter(Exporter):
         template_file = self.template_file
         
         try:
-            _log_template_loading(template_file)
+            self._log_template_loading(template_file)
             return self.environment.get_template(template_file)
         except TemplateNotFound:
             if self.template_file.endswith(self.template_extension):
                 try: 
                     template_file = self.template_file[:-len(self.template_extension)]
-                    _log_template_loading(template_file)
+                    self._log_template_loading(template_file)
+                    return self.environment.get_template(template_file)
                 except TemplateNotFound:
                     raise TemplateNotFound(template_file)
             else:
                 try:
                     template_file = self.template_file + self.template_extension
-                    _log_template_loading(template_file)
+                    self._log_template_loading(template_file)
                     return self.environment.get_template(template_file)
                 except TemplateNotFound:
                     raise TemplateNotFound(template_file)
-        
-        self.log.debug("Attempting to load template %s", template_file)
-        self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
-        return self.environment.get_template(template_file)
 
-    def _log_template_loading(template_file):
-        """ abstract away some of the loggging for finding templates
-        """
-        self.log.debug("Attempting to load template %s", template_file)
-        self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
-        pass
 
     def from_notebook_node(self, nb, resources=None, **kw):
         """

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -71,12 +71,13 @@ class ExtensionTolerantLoader(BaseLoader):
    
 
     def get_source(self, environment, template):
+        
         try:
             return self.loader.get_source(environment, template)
         except TemplateNotFound:
             if template.endswith(self.extension):
                 raise TemplateNotFound(template)
-            return self.loader.get_source(environment, template+self.extension)
+            return self.loader.get_source(environment, template + self.extension)
 
     def list_templates(self):
         return self.loader.list_templates()
@@ -217,6 +218,34 @@ class TemplateExporter(Exporter):
         # template by name with extension added, then try loading the template
         # as if the name is explicitly specified.
         template_file = self.template_file
+        
+        if not self.template_file.endswith(self.template_extension):
+            try: 
+                self.log.debug("Attempting to load template %s", template_file)
+                self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
+                return self.environment.get_template(template_file)
+            except TemplateNotFound:
+                try: 
+                    template_file = self.template_file + self.template_extension
+                    self.log.debug("Attempting to load template %s", template_file)
+                    self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
+                    return self.environment.get_template(template_file)
+                except TemplateNotFound:
+                    raise TemplateNotFound(template_file)
+        else:
+            try: 
+                self.log.debug("Attempting to load template %s", template_file)
+                self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
+                return self.environment.get_template(template_file)
+            except TemplateNotFound:
+                try: 
+                    template_file = self.template_file[:-len(self.template_extension)]
+                    self.log.debug("Attempting to load template %s", template_file)
+                    self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
+                    return self.environment.get_template(template_file)
+                except TemplateNotFound:
+                    raise TemplateNotFound(template_file)
+        
         self.log.debug("Attempting to load template %s", template_file)
         self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
         return self.environment.get_template(template_file)

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -219,29 +219,20 @@ class TemplateExporter(Exporter):
         # as if the name is explicitly specified.
         template_file = self.template_file
         
-        if not self.template_file.endswith(self.template_extension):
-            try: 
-                self.log.debug("Attempting to load template %s", template_file)
-                self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
-                return self.environment.get_template(template_file)
-            except TemplateNotFound:
-                try: 
-                    template_file = self.template_file + self.template_extension
-                    self.log.debug("Attempting to load template %s", template_file)
-                    self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
-                    return self.environment.get_template(template_file)
-                except TemplateNotFound:
-                    raise TemplateNotFound(template_file)
-        else:
-            try: 
-                self.log.debug("Attempting to load template %s", template_file)
-                self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
-                return self.environment.get_template(template_file)
-            except TemplateNotFound:
+        try:
+            _log_template_loading(template_file)
+            return self.environment.get_template(template_file)
+        except TemplateNotFound:
+            if self.template_file.endswith(self.template_extension):
                 try: 
                     template_file = self.template_file[:-len(self.template_extension)]
-                    self.log.debug("Attempting to load template %s", template_file)
-                    self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
+                    _log_template_loading(template_file)
+                except TemplateNotFound:
+                    raise TemplateNotFound(template_file)
+            else:
+                try:
+                    template_file = self.template_file + self.template_extension
+                    _log_template_loading(template_file)
                     return self.environment.get_template(template_file)
                 except TemplateNotFound:
                     raise TemplateNotFound(template_file)
@@ -249,6 +240,13 @@ class TemplateExporter(Exporter):
         self.log.debug("Attempting to load template %s", template_file)
         self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
         return self.environment.get_template(template_file)
+
+    def _log_template_loading(template_file):
+        """ abstract away some of the loggging for finding templates
+        """
+        self.log.debug("Attempting to load template %s", template_file)
+        self.log.debug("    template_path: %s", os.pathsep.join(self.template_path))
+        pass
 
     def from_notebook_node(self, nb, resources=None, **kw):
         """

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -123,7 +123,6 @@ class TestExporter(ExportersTestsBase):
         # creates a class that uses this template with the template_file argument
         # converts an empty notebook using this mechanism
         my_loader = DictLoader({'my_template': "{%- extends 'rst.tpl' -%}"})
-        
         class MyExporter(TemplateExporter):
             template_file = 'my_template'
         
@@ -131,6 +130,18 @@ class TestExporter(ExportersTestsBase):
         nb = v4.new_notebook()
         out, resources = exporter.from_notebook_node(nb)
 
+    def test_in_memory_template_extensions(self):
+        # Loads in an in memory template using jinja2.DictLoader
+        # creates a class that uses this template with the template_file argument
+        # converts an empty notebook using this mechanism
+        my_loader = DictLoader({'my_template.tpl': "{%- extends 'rst.tpl' -%}"})
+
+        class MyExporter(TemplateExporter):
+            template_file = 'my_template'
+        
+        exporter = MyExporter(extra_loaders=[my_loader])
+        nb = v4.new_notebook()
+        out, resources = exporter.from_notebook_node(nb)
 
     def test_fail_to_find_template_file(self):
         # Create exporter with invalid template file, check that it doesn't

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -155,8 +155,12 @@ class TestExporter(ExportersTestsBase):
         with pytest.raises(TemplateNotFound):
             out, resources = exporter.from_notebook_node(nb)
         
-        
-        
+        template_2 = 'does_not_exist'
+        exporter = TemplateExporter(template_file=template_2)
+        assert template_2 not in exporter.environment.list_templates(extensions=['tpl'])
+        nb = v4.new_notebook()
+        with pytest.raises(TemplateNotFound):
+            out, resources = exporter.from_notebook_node(nb)
 
     def _make_exporter(self, config=None):
         # Create the exporter instance, make sure to set a template name since


### PR DESCRIPTION
Fixes issue #517 but does so in a way I don't like, I'm going to simplify the logic next.

This does mean you can't have both a template without and with a file extension and expect straightforward importing behaviour (but on disk templates should have extensions anyway).