### PR TITLE
use pytest.mark.parameterize not yield tests from nose

### DIFF
--- a/nbconvert/filters/tests/test_citation.py
+++ b/nbconvert/filters/tests/test_citation.py
@@ -10,7 +10,7 @@
 # Imports
 #-----------------------------------------------------------------------------
 from ..citation import citation2latex
-from nose.tools import assert_equal
+import pytest
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -144,7 +144,9 @@ $1 < 2$ is true, but $3 > 4$ is false
 1 < 2 it is even worse if it is alone in a line.
 """}
 
-def test_citation2latex():
+
+@pytest.mark.parametrize(["in_arg", "out_arg"], [
+    (in_arg, out_arg) for (in_arg, out_arg) in test_md.items()])
+def test_citation2latex(in_arg, out_arg):
     """Are citations parsed properly?"""
-    for input, output in test_md.items():
-        yield (assert_equal, citation2latex(input), output)
+    assert citation2latex(in_arg)==out_arg


### PR DESCRIPTION
Got tired of the deprecation warnings, and after a little bit of looking into it, it wasn't too hard to fix. 

In fact the `@pytest.mark.parametrize` decorator may be useful in other contexts (now that I know how it works). 

But this is all I'm going to do in this pr. 