### PR TITLE
Traceback in cell execution error

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -28,6 +28,7 @@ class CellExecutionError(ConversionException):
     failures gracefully.
     """
     def __init__(self, traceback):
+        super(CellExecutionError, self).__init__(traceback)
         self.traceback = traceback
 
     def __str__(self):

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 """
 Module with tests for the execute preprocessor.
 """
@@ -12,12 +14,13 @@ import os
 import re
 
 import nbformat
+import sys
 
 from .base import PreprocessorTestsBase
 from ..execute import ExecutePreprocessor, CellExecutionError
 
 from nbconvert.filters import strip_ansi
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_in
 from testpath import modified_env
 
 addr_pat = re.compile(r'0x[0-9a-f]{7,9}')
@@ -184,7 +187,12 @@ class TestExecute(PreprocessorTestsBase):
         res['metadata']['path'] = os.path.dirname(filename)
         with assert_raises(CellExecutionError) as exc:
             self.run_notebook(filename, dict(allow_errors=False), res)
-        self.assertIsInstance(str(exc), str)
+        self.assertIsInstance(str(exc.exception), str)
+        if sys.version_info >= (3, 0):
+            assert_in(u"# üñîçø∂é", str(exc.exception))
+        else:
+            assert_in(u"# üñîçø∂é".encode('utf8', 'replace'),
+                      str(exc.exception))
 
     def test_custom_kernel_manager(self):
         from .fake_kernelmanager import FakeCustomKernelManager

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -335,6 +335,17 @@ class TestNbConvertApp(TestsBase):
             with assert_raises(OSError):
                 self.nbconvert('--execute --to markdown --stdout notebook3*.ipynb')
 
+    def test_errors_print_traceback(self):
+        """
+        Verify that the stderr output contains the traceback of the cell execution exception.
+        """
+        with self.create_temp_cwd(['notebook3_with_errors.ipynb']):
+            _, error_output = self.nbconvert('--execute --to markdown --stdout notebook3_with_errors.ipynb',
+                                             ignore_return_code=True)
+            assert_in('print("Some text before the error")', error_output)
+            assert_in('raise RuntimeError("This is a deliberate exception")', error_output)
+            assert_in('RuntimeError: This is a deliberate exception', error_output)
+
     def test_fenced_code_blocks_markdown(self):
         """
         Verify that input cells use fenced code blocks with the language

--- a/nbconvert/utils/exceptions.py
+++ b/nbconvert/utils/exceptions.py
@@ -13,6 +13,4 @@
 
 class ConversionException(Exception):
     """An exception raised by the conversion process."""
-    
-    def __init__(self, message):
-        super(ConversionException, self).__init__(message)
+    pass

--- a/nbconvert/utils/exceptions.py
+++ b/nbconvert/utils/exceptions.py
@@ -13,5 +13,6 @@
 
 class ConversionException(Exception):
     """An exception raised by the conversion process."""
-
-    pass
+    
+    def __init__(self, message):
+        super(ConversionException, self).__init__(message)


### PR DESCRIPTION
We're executing Notebooks during CI to make sure the content is always up-to-date.

However, if the execution fails, we get the following error message fro nbconvert:

```
[NbConvertApp] Converting notebook /u/matej/Test.ipynb to notebook
[NbConvertApp] Executing notebook with kernel: python2
[NbConvertApp] ERROR | Error while converting '/u/matej/Test.ipynb'
Traceback (most recent call last):
...UNINFORMATIVE INTERNAL STACK TRACE...
File "/u/matej/git/open-source/nbconvert/nbconvert/preprocessors/execute.py", line 113, in preprocess_cell
raise CellExecutionError(msg)
CellExecutionError
[1] 110973 exit 1 jupyter nbconvert --to notebook --stdout --execute ~/Test.ipynb
```

The message only says `CellExecutionError`, which makes it hard to pinpoint the cell and code where things went wrong.

This patch adds a traceback to the error message. It now looks like this:

```
[NbConvertApp] Converting notebook /u/matej/Test.ipynb to notebook
[NbConvertApp] Executing notebook with kernel: python2
[NbConvertApp] ERROR | Error while converting '/u/matej/Test.ipynb'
Traceback (most recent call last):
...UNINFORMATIVE INTERNAL STACK TRACE...
File "/u/matej/git/open-source/nbconvert/nbconvert/preprocessors/execute.py", line 113, in preprocess_cell
raise CellExecutionError(msg)
CellExecutionError: An error occurred while executing the following cell:
------------------
import dakjdnsak
------------------
ImportError: No module named dakjdnsak
[1] 111347 exit 1 jupyter nbconvert --to notebook --stdout --execute ~/Test.ipynb
```