### PR TITLE
Add nbconvert.exporters.script entrypoints

### DIFF
--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -3,20 +3,37 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import entrypoints
 from .templateexporter import TemplateExporter
 
 from traitlets import Dict, default
-from traitlets.utils.importstring import import_item
 from .base import get_exporter
 
 
 class ScriptExporter(TemplateExporter):
-    
+    # Caches of already looked-up and instantiated exporters for delegation:
     _exporters = Dict()
+    _lang_exporters = Dict()
     
     @default('template_file')
     def _template_file_default(self):
         return 'script'
+
+    def _get_language_exporter(self, lang_name):
+        """Find an exporter for the language name from notebook metadata.
+
+        Uses the nbconvert.exporters.script group of entry points.
+        Returns None if no exporter is found.
+        """
+        if lang_name not in self._lang_exporters:
+            try:
+                Exporter = entrypoints.get_single(
+                    'nbconvert.exporters.script', lang_name).load()
+            except entrypoints.NoSuchEntryPoint:
+                self._lang_exporters[lang_name] = None
+            else:
+                self._lang_exporters[lang_name] = Exporter(parent=self)
+        return self._lang_exporters[lang_name]
 
     def from_notebook_node(self, nb, resources=None, **kw):
         langinfo = nb.metadata.get('language_info', {})
@@ -30,7 +47,16 @@ class ScriptExporter(TemplateExporter):
                 self._exporters[exporter_name] = Exporter(parent=self)
             exporter = self._exporters[exporter_name]
             return exporter.from_notebook_node(nb, resources, **kw)
-        
+
+        # Look up a script exporter for this notebook's language
+        lang_name = langinfo.get('name')
+        if lang_name:
+            self.log.debug("Using script exporter for language: %s", lang_name)
+            exporter = self._get_language_exporter(lang_name)
+            if exporter is not None:
+                return exporter.from_notebook_node(nb, resources, **kw)
+
+        # Fall back to plain script export
         self.file_extension = langinfo.get('file_extension', '.txt')
         self.output_mimetype = langinfo.get('mimetype', 'text/plain')
         return super(ScriptExporter, self).from_notebook_node(nb, resources, **kw)

--- a/nbconvert/exporters/tests/test_script.py
+++ b/nbconvert/exporters/tests/test_script.py
@@ -3,10 +3,11 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import os
 import sys
 
 from nbformat import v4
-from ipython_genutils.py3compat import PY3
+import nbconvert
 
 from .base import ExportersTestsBase
 from ..script import ScriptExporter
@@ -42,4 +43,17 @@ class TestScriptExporter(ExportersTestsBase):
         (output, resources) = self.exporter_class().from_notebook_node(pynb)
         self.assertIn('# coding: utf-8', output)
 
-        
+def test_script_exporter_entrypoint():
+    nb = v4.new_notebook()
+    nb.metadata.language_info = {
+        'name': 'dummy',
+        'mimetype': 'text/x-dummy',
+    }
+
+    p = os.path.join(os.path.dirname(nbconvert.tests.__file__), 'exporter_entrypoint')
+    sys.path.insert(0, p)
+    try:
+        output, _ = ScriptExporter().from_notebook_node(nb)
+        assert output == 'dummy-script-exported'
+    finally:
+        sys.path.remove(p)

--- a/nbconvert/tests/exporter_entrypoint/eptest-0.1.dist-info/entry_points.txt
+++ b/nbconvert/tests/exporter_entrypoint/eptest-0.1.dist-info/entry_points.txt
@@ -1,2 +1,5 @@
 [nbconvert.exporters]
 entrypoint_test = eptest:DummyExporter
+
+[nbconvert.exporters.script]
+dummy = eptest:DummyScriptExporter

--- a/nbconvert/tests/exporter_entrypoint/eptest.py
+++ b/nbconvert/tests/exporter_entrypoint/eptest.py
@@ -2,3 +2,7 @@ from nbconvert.exporters import Exporter
 
 class DummyExporter(Exporter):
     pass
+
+class DummyScriptExporter(Exporter):
+    def from_notebook_node(self, nb, resources=None, **kw):
+        return 'dummy-script-exported', resources


### PR DESCRIPTION
As discussed in gh-414, these are looked up by the language name in the notebook metadata. They override the default plain code export when you use `--to script`.

Closes gh-414