### PR TITLE
Execute needs at least jupyter_client 4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,7 @@ extras_require = setuptools_args['extras_require'] = {
     # but we are running with pytest
     'test': ['pytest', 'pytest-cov', 'nose', 'ipykernel', 'jupyter_client'],
     'serve': ['tornado>=4.0'],
-    'execute': ['jupyter_client'],
+    'execute': ['jupyter_client>=4.2'],
 }
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
`wait_for_ready()`'s `timeout` option was added in 4.2 and previous
versions complain as they don't expect extra arguments.

cc @michaelpacer 