### PR TITLE
Don't self-close non-void HTML tags

### DIFF
--- a/nbconvert/preprocessors/tests/test_sanitize.py
+++ b/nbconvert/preprocessors/tests/test_sanitize.py
@@ -8,6 +8,8 @@ from nbformat import v4 as nbformat
 class TestSanitizer(PreprocessorTestsBase):
     """Contains test functions for sanitize.py"""
 
+    maxDiff = None
+    
     def build_preprocessor(self):
         """Make an instance of a preprocessor"""
         preprocessor = SanitizeHTML()
@@ -44,9 +46,13 @@ class TestSanitizer(PreprocessorTestsBase):
                 'markdown',
                 """
                 ![some image](http://example.com/something.svg)
-                <object data="something.svg" type="image/svg+xml" />
+
+                <object data="something.svg" type="image/svg+xml"></object>
+
                 <embed data="something.svg" type="image/svg+xml" />
-                <iframe src="http://example.com/something.svg" />
+
+                <iframe src="http://example.com/something.svg"></iframe>
+
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 65">
                     <path fill="#1A374D" d="M42 27v-20c0-3.7-3.3-7-7-7s-7 3.3-7 7v21l12 15-7 15.7c14.5 13.9 35 2.8 35-13.7 0-13.3-13.4-21.8-26-18zm6 25c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z"/>
                     <path d="M14 27v-20c0-3.7-3.3-7-7-7s-7 3.3-7 7v41c0 8.2 9.2 17 20 17s20-9.2 20-20c0-13.3-13.4-21.8-26-18zm6 25c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z"/>


### PR DESCRIPTION
it's not valid HTML, though it is valid XML and browsers seem to guess at the intended meaning.

html5lib (used by Bleach) interprets self-closing tags that aren't valid as open tags, rather than open-and-close (the XML interpretation).