### PR TITLE
support display_id in execute preprocessor

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from Queue import Empty  # Py 2
 
-from traitlets import List, Unicode, Bool, Enum, Any, Type, default
+from traitlets import List, Unicode, Bool, Enum, Any, Type, Dict, default
 
 from nbformat.v4 import output_from_msg
 from .base import Preprocessor
@@ -161,7 +161,15 @@ class ExecutePreprocessor(Preprocessor):
             raise ImportError("`nbconvert --execute` requires the jupyter_client package: `pip install jupyter_client`")
         return KernelManager
 
-    _display_id_map = {}
+    # mapping of locations of outputs with a given display_id
+    # tracks cell index and output index within cell.outputs for
+    # each appearance of the display_id
+    # {
+    #   'display_id': {
+    #     cell_idx: [output_idx,]
+    #   }
+    # }
+    _display_id_map = Dict()
 
     def preprocess(self, nb, resources):
         """

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -313,7 +313,7 @@ class ExecutePreprocessor(Preprocessor):
                 # not our reply
                 continue
 
-        outs = []
+        outs = cell.outputs = []
 
         while True:
             try:
@@ -349,7 +349,7 @@ class ExecutePreprocessor(Preprocessor):
             elif msg_type == 'execute_input':
                 continue
             elif msg_type == 'clear_output':
-                outs = []
+                outs[:] = []
                 # clear display_id mapping for this cell
                 for display_id, cell_map in self._display_id_map.items():
                     if self._cell_idx in cell_map:

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -261,12 +261,16 @@ class ExecutePreprocessor(Preprocessor):
     def _update_display_id(self, display_id, msg):
         """Update outputs with a given display_id"""
         if display_id not in self._display_id_map:
+            self.log.debug("display id %r not in %s", display_id, self._display_id_map)
             return
+
+        if msg['header']['msg_type'] == 'update_display_data':
+            msg['header']['msg_type'] = 'display_data'
 
         try:
             out = output_from_msg(msg)
         except ValueError:
-            self.log.error("unhandled iopub msg: " + msg_type)
+            self.log.error("unhandled iopub msg: " + msg['msg_type'])
             return
         
         for cell_idx, output_indices in self._display_id_map[display_id].items():

--- a/nbconvert/preprocessors/tests/files/update-display-id.ipynb
+++ b/nbconvert/preprocessors/tests/files/update-display-id.ipynb
@@ -1,0 +1,191 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "ip = get_ipython()\n",
+    "\n",
+    "from IPython.display import display\n",
+    "\n",
+    "def display_with_id(obj, display_id, update=False, execute_result=False):\n",
+    "    iopub = ip.kernel.iopub_socket\n",
+    "    session = get_ipython().kernel.session\n",
+    "    data, md = ip.display_formatter.format(obj)\n",
+    "    transient = {'display_id': str(display_id)}\n",
+    "    content = {'data': data, 'metadata': md, 'transient': transient}\n",
+    "    if execute_result:\n",
+    "      msg_type = 'execute_result'\n",
+    "      content['execution_count'] = ip.execution_count\n",
+    "    else:\n",
+    "      msg_type = 'update_display_data' if update else 'display_data'\n",
+    "    session.send(iopub, msg_type, content, parent=ip.parent_header)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'above'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'below'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display('above')\n",
+    "display_with_id(1, 'here')\n",
+    "display('below')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display_with_id(2, 'here')\n",
+    "display_with_id(3, 'there')\n",
+    "display_with_id(4, 'here')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display_with_id(5, 'there')\n",
+    "display_with_id(6, 'there', update=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "10"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "display_with_id(7, 'here')\n",
+    "display_with_id(8, 'here', update=True)\n",
+    "display_with_id(9, 'result', execute_result=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "display_with_id(10, 'result', update=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbconvert/preprocessors/tests/files/update-display-id.ipynb
+++ b/nbconvert/preprocessors/tests/files/update-display-id.ipynb
@@ -167,25 +167,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.3"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -24,6 +24,7 @@ from nose.tools import assert_raises, assert_in
 from testpath import modified_env
 
 addr_pat = re.compile(r'0x[0-9a-f]{7,9}')
+current_dir = os.path.dirname(__file__)
 
 class TestExecute(PreprocessorTestsBase):
     """Contains test functions for execute.py"""
@@ -104,7 +105,6 @@ class TestExecute(PreprocessorTestsBase):
 
     def test_run_notebooks(self):
         """Runs a series of test notebooks and compares them to their actual output"""
-        current_dir = os.path.dirname(__file__)
         input_files = glob.glob(os.path.join(current_dir, 'files', '*.ipynb'))
         for filename in input_files:
             if os.path.basename(filename) == "Disable Stdin.ipynb":
@@ -122,7 +122,6 @@ class TestExecute(PreprocessorTestsBase):
 
     def test_empty_path(self):
         """Can the kernel be started when the path is empty?"""
-        current_dir = os.path.dirname(__file__)
         filename = os.path.join(current_dir, 'files', 'HelloWorld.ipynb')
         res = self.build_resources()
         res['metadata']['path'] = ''
@@ -131,7 +130,6 @@ class TestExecute(PreprocessorTestsBase):
 
     def test_disable_stdin(self):
         """Test disabling standard input"""
-        current_dir = os.path.dirname(__file__)
         filename = os.path.join(current_dir, 'files', 'Disable Stdin.ipynb')
         res = self.build_resources()
         res['metadata']['path'] = os.path.dirname(filename)
@@ -223,3 +221,4 @@ class TestExecute(PreprocessorTestsBase):
 
         for method, call_count in expected:
             self.assertNotEqual(call_count, 0, '{} was called'.format(method))
+


### PR DESCRIPTION
Added in protocol v5.1, supported in notebook 5.0.

display_id allows updating existing outputs, so keep track of mapping of display_id to outputs.