### PR TITLE
Use resolve_references filter in Latex report template

### DIFF
--- a/nbconvert/templates/latex/report.tplx
+++ b/nbconvert/templates/latex/report.tplx
@@ -22,5 +22,5 @@
 ((* endblock docclass *))
 
 ((* block markdowncell scoped *))
-((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown', 'latex', extra_args=["--chapters"]) )))
+((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex', extra_args=["--chapters"]) )))
 ((* endblock markdowncell *))


### PR DESCRIPTION
@ketch alerted me in takluyver/bookbook#5 that we're overriding the markdowncell block in `report.tplx`, but haven't updated it to use the new resolve_references filter. David, do you have time to try this?

CC @mpacer 