### PR TITLE
add language cell-magic highlighting to more exports

### DIFF
--- a/nbconvert/exporters/asciidoc.py
+++ b/nbconvert/exporters/asciidoc.py
@@ -41,7 +41,10 @@ class ASCIIDocExporter(TemplateExporter):
                                           'text/latex'
                                           ]
             },
-            'ExtractOutputPreprocessor': {'enabled': True}
+            'ExtractOutputPreprocessor': {'enabled': True},
+            'HighlightMagicsPreprocessor': {
+                'enabled':True
+                },
         })
         c.merge(super(ASCIIDocExporter, self).default_config)
         return c

--- a/nbconvert/exporters/markdown.py
+++ b/nbconvert/exporters/markdown.py
@@ -42,7 +42,9 @@ class MarkdownExporter(TemplateExporter):
                                           'text/plain'
                                           ]
             },
-
+            'HighlightMagicsPreprocessor': {
+                'enabled':True
+                },
         })
         c.merge(super(MarkdownExporter, self).default_config)
         return c

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -26,6 +26,13 @@ class RSTExporter(TemplateExporter):
 
     @property
     def default_config(self):
-        c = Config({'ExtractOutputPreprocessor':{'enabled':True}})
+        c = Config({
+            'ExtractOutputPreprocessor':{
+                'enabled':True
+                },
+            'HighlightMagicsPreprocessor': {
+                'enabled':True
+                },
+            })
         c.merge(super(RSTExporter,self).default_config)
         return c

--- a/nbconvert/templates/asciidoc.tpl
+++ b/nbconvert/templates/asciidoc.tpl
@@ -11,11 +11,11 @@
 {%- endif -%}
 [source
 {%- if 'magics_language' in cell.metadata  -%}
-    {{, cell.metadata.magics_language}}
+   , {{ cell.metadata.magics_language}}
 {%- elif 'pygments_lexer' in nb.metadata.get('language_info', {}) -%}
-    {{, nb.metadata.language_info.pygments_lexer }}
+   , {{ nb.metadata.language_info.pygments_lexer }}
 {%- elif 'name' in nb.metadata.get('language_info', {}) -%}
-    {{, nb.metadata.language_info.name }}
+   , {{ nb.metadata.language_info.name }}
 {%- endif -%}]
 ----
 {{ cell.source}}

--- a/nbconvert/templates/asciidoc.tpl
+++ b/nbconvert/templates/asciidoc.tpl
@@ -9,7 +9,14 @@
     +*In[]:*+
 {%- endif -%}
 {%- endif -%}
-[source{% if nb.metadata.language_info %}, {{ nb.metadata.language_info.name }}{% endif %}]
+[source
+{%- if 'magics_language' in cell.metadata  -%}
+    {{, cell.metadata.magics_language}}
+{%- elif 'pygments_lexer' in nb.metadata.get('language_info', {}) -%}
+    {{, nb.metadata.language_info.pygments_lexer }}
+{%- elif 'name' in nb.metadata.get('language_info', {}) -%}
+    {{, nb.metadata.language_info.name }}
+{%- endif -%}]
 ----
 {{ cell.source}}
 ----

--- a/nbconvert/templates/latex/style_ipython.tplx
+++ b/nbconvert/templates/latex/style_ipython.tplx
@@ -21,7 +21,7 @@
 
 ((* block input scoped *))
 ((*- if resources.global_content_filter.include_input_prompt *))
-    ((( add_prompt(cell.source | highlight_code(strip_verbatim=True), cell, 'In ', 'incolor') )))
+    ((( add_prompt(cell.source | highlight_code(strip_verbatim=True, metadata=cell.metadata), cell, 'In ', 'incolor') )))
 ((* endif *))
 ((* endblock input *))
 

--- a/nbconvert/templates/latex/style_python.tplx
+++ b/nbconvert/templates/latex/style_python.tplx
@@ -17,9 +17,9 @@
 ((* block input scoped *))
     \begin{Verbatim}[commandchars=\\\{\}]
 ((*- if resources.global_content_filter.include_input_prompt *))
-((( cell.source | highlight_code(strip_verbatim=True) | add_prompts )))
+((( cell.source | highlight_code(strip_verbatim=True, metadata=cell.metadata) | add_prompts )))
 ((* else *))
-((( cell.source | highlight_code(strip_verbatim=True) )))
+((( cell.source | highlight_code(strip_verbatim=True, metadata=cell.metadata) )))
 ((* endif *))
     \end{Verbatim}
 ((* endblock input *))

--- a/nbconvert/templates/markdown.tpl
+++ b/nbconvert/templates/markdown.tpl
@@ -11,8 +11,6 @@
 ```
 {%- if 'magics_language' in cell.metadata  -%}
     {{ cell.metadata.magics_language}}
-{%- elif 'pygments_lexer' in nb.metadata.get('language_info', {}) -%}
-    {{ nb.metadata.language_info.pygments_lexer }}
 {%- elif 'name' in nb.metadata.get('language_info', {}) -%}
     {{ nb.metadata.language_info.name }}
 {%- endif %}

--- a/nbconvert/templates/markdown.tpl
+++ b/nbconvert/templates/markdown.tpl
@@ -8,7 +8,14 @@
 {%- endblock output_prompt %}
 
 {% block input %}
-```{% if nb.metadata.language_info %}{{ nb.metadata.language_info.name }}{% endif %}
+```
+{%- if 'magics_language' in cell.metadata  -%}
+    {{ cell.metadata.magics_language}}
+{%- elif 'pygments_lexer' in nb.metadata.get('language_info', {}) -%}
+    {{ nb.metadata.language_info.pygments_lexer }}
+{%- elif 'name' in nb.metadata.get('language_info', {}) -%}
+    {{ nb.metadata.language_info.name }}
+{%- endif %}
 {{ cell.source}}
 ```
 {% endblock input %}

--- a/nbconvert/templates/rst.tpl
+++ b/nbconvert/templates/rst.tpl
@@ -7,10 +7,12 @@
 {% block output_prompt %}
 {% endblock output_prompt %}
 
-{% block input %}
+{% block input scoped%}
 {%- if cell.source.strip() -%}
 {{".. code:: "-}}
-{%- if 'pygments_lexer' in nb.metadata.get('language_info', {}) -%}
+{%- if 'magics_language' in cell.metadata  -%}
+    {{ cell.metadata.magics_language}}
+{%- elif 'pygments_lexer' in nb.metadata.get('language_info', {}) -%}
     {{ nb.metadata.language_info.pygments_lexer }}
 {%- elif 'name' in nb.metadata.get('language_info', {}) -%}
     {{ nb.metadata.language_info.name }}


### PR DESCRIPTION
LaTeX exporter had the ability to inherit cell magics, but nothing was actually being done to enable that in the template because it wasn't passing the cell metadata. 

@Carreau 