### PR TITLE
Add width tags for jpeg and png when present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ htmlcov
 .cache
 docs/source/*.tpl
 docs/source/config_options.rst
+# Eclipse pollutes the filesystem
+.project
+.pydevproject
+.settings

--- a/nbconvert/exporters/tests/test_rst.py
+++ b/nbconvert/exporters/tests/test_rst.py
@@ -52,3 +52,12 @@ class TestRSTExporter(ExportersTestsBase):
         # adding an empty code cell shouldn't change output
         self.assertEqual(output.strip(), output2.strip())
         
+
+    @onlyif_cmds_exist('pandoc')
+    def test_png_metadata(self):
+        """
+        Does RSTExporter treat pngs with width/height metadata correctly?
+        """
+        (output, resources) = RSTExporter().from_filename(
+            self._get_notebook(nb_name="pngmetadata.ipynb"))
+        assert len(output) > 0

--- a/nbconvert/templates/rst.tpl
+++ b/nbconvert/templates/rst.tpl
@@ -50,14 +50,14 @@
 
 {% block data_png %}
 .. image:: {{ output.metadata.filenames['image/png'] | urlencode }}
-{%- if output.metadata['image/png'].get('width', '') %}
+{%- if 'image/png' in output.metadata and output.metadata['image/png'].get('width', '') %}
    :width: {{ output.metadata['image/png'].width}}px
 {% endif -%}
 {% endblock data_png %}
 
 {% block data_jpg %}
 .. image:: {{ output.metadata.filenames['image/jpeg'] | urlencode }}
-{%- if output.metadata['image/jpeg'].get('width', '') %}
+{%- if 'image/jpeg' in output.metadata and output.metadata['image/jpeg'].get('width', '') %}
    :width: {{ output.metadata['image/jpeg'].width}}px
 {% endif -%}
 {% endblock data_jpg %}

--- a/nbconvert/templates/rst.tpl
+++ b/nbconvert/templates/rst.tpl
@@ -50,16 +50,26 @@
 
 {% block data_png %}
 .. image:: {{ output.metadata.filenames['image/png'] | urlencode }}
-{%- if 'image/png' in output.metadata and output.metadata['image/png'].get('width', '') %}
-   :width: {{ output.metadata['image/png'].width}}px
-{% endif -%}
+{%- set width=output | get_metadata('width', 'image/png') -%}
+{%- if width is not none %}
+   :width: {{ width }}px
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/png') -%}
+{%- if height is not none %}
+   :height: {{ height }}px
+{%- endif %}
 {% endblock data_png %}
 
 {% block data_jpg %}
 .. image:: {{ output.metadata.filenames['image/jpeg'] | urlencode }}
-{%- if 'image/jpeg' in output.metadata and output.metadata['image/jpeg'].get('width', '') %}
-   :width: {{ output.metadata['image/jpeg'].width}}px
-{% endif -%}
+{%- set width=output | get_metadata('width', 'image/jpeg') -%}
+{%- if width is not none %}
+   :width: {{ width }}px
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/jpeg') -%}
+{%- if height is not none %}
+   :height: {{ height }}px
+{%- endif %}
 {% endblock data_jpg %}
 
 {% block data_markdown %}

--- a/nbconvert/templates/rst.tpl
+++ b/nbconvert/templates/rst.tpl
@@ -50,10 +50,16 @@
 
 {% block data_png %}
 .. image:: {{ output.metadata.filenames['image/png'] | urlencode }}
+{%- if output.metadata['image/png'].get('width', '') %}
+   :width: {{ output.metadata['image/png'].width}}px
+{% endif -%}
 {% endblock data_png %}
 
 {% block data_jpg %}
 .. image:: {{ output.metadata.filenames['image/jpeg'] | urlencode }}
+{%- if output.metadata['image/jpeg'].get('width', '') %}
+   :width: {{ output.metadata['image/jpeg'].width}}px
+{% endif -%}
 {% endblock data_jpg %}
 
 {% block data_markdown %}


### PR DESCRIPTION
The display(Image(..., retina=True)) command creates metadata about the image explaining the size that it should be displayed at in the notebook.  This information, if present, can be carried into the notebook and converted to rst for use in documenters such as Sphinx.  If not present, retina images appear in .rst (and from there to other formats such as HTML) as twice their intended size.