### PR TITLE
test for the width and height attributes inside the image in the output

### DIFF
--- a/nbconvert/exporters/tests/test_html.py
+++ b/nbconvert/exporters/tests/test_html.py
@@ -66,7 +66,11 @@ class TestHTMLExporter(ExportersTestsBase):
         """
         (output, resources) = HTMLExporter(template_file='basic').from_filename(
             self._get_notebook(nb_name="pngmetadata.ipynb"))
-        assert len(output) > 0
+        check_for_png = re.compile(r'<img src="[^"]*?"([^>]*?)>')
+        result = check_for_png.search(output)
+        attr_string = result.group(1)
+        assert 'width' in attr_string
+        assert 'height' in attr_string
 
     def test_javascript_output(self):
         nb = v4.new_notebook(


### PR DESCRIPTION
This is in part a test improvement and in part meant to be an exposition on how to modify the tests in relation to #589 for @mscuthbert. 

So, you want to check the content of the output, specifically we want to check whether there is a image element that has width and height attributes set. The `'<img`  part is going to pick up the image `src="[^"]*?"` handles the base64 encoded data uri and `([^>]*?)>'` grabs the remainder of the content until the tag is closed (which will include all of the attributes).  

To run just this test it's easiest to run `py.test nbconvert/exporters/tests/test_html.py` from the top level directory of nbconvert. 

To be able to inspect the state of the objects in the test, if you inject a python debugging trace (`import pdb; pdb.set_trace()`) that will inject you into a python interpreter at that point in the process and then you can play around with the actual content. So my first step was to insert that before the `assert len(output)>0` and then got a handle on the converted content. I then dumped that into https://regex101.com/ (which I find to be a nice interface for testing regular expressions) until I got something that worked to capture the group that I wanted.

Then it's a matter of writing the assert statements that directly address what you about, in this case that there are width and height attributes that are present.