### PR TITLE
Fixed AttributeError when getting slide_type

### DIFF
--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -16,7 +16,12 @@ def prepare(nb):
 
     for cell in nb.cells:
         # Make sure every cell has a slide_type
-        cell.metadata.slide_type = cell.metadata.get('slideshow', {}).get('slide_type', '-')
+        try:
+            slide_type = cell.metadata.get('slideshow', {}).get(
+                'slide_type', '-')
+        except AttributeError:
+            slide_type = '-'
+        cell.metadata.slide_type = slide_type
 
     # Find the first visible cell
     for index, cell in enumerate(nb.cells):


### PR DESCRIPTION
To reproduce this AttributeError:
1. Run jupyterlab: `jupyter lab`
2. Create an ipynb
3. Edit a cell and choose **Cell Tools** from the leftmost panel
4. Set the cell to **slide** type

Now, the metadata looks like this:
```json
{
  "collapsed": true,
  "slideshow": "slide"
}
```

Now, it's obvious that the original code would raise an `AttributeError`.

I got this all the time when using jupyterlab.
Maybe this should be fixed in jupyterlab, but I think adding a safe guard can't be harmful.
After all, you never know maybe one day it can become `"slideshow": None`