### PR TITLE
Add remove regex default to TemplateExporter, don't remove cells with outputs but no source

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -12,6 +12,7 @@ import uuid
 import json
 
 from traitlets import HasTraits, Unicode, List, Dict, Bool, default, observe
+from traitlets.config import Config
 from traitlets.utils.importstring import import_item
 from ipython_genutils import py3compat
 from jinja2 import (
@@ -21,7 +22,7 @@ from jinja2 import (
 from nbconvert import filters
 from .exporter import Exporter
 
-#Jinja2 extensions to load.
+# Jinja2 extensions to load.
 JINJA_EXTENSIONS = ['jinja2.ext.loopcontrols']
 
 default_filters = {
@@ -68,7 +69,6 @@ class ExtensionTolerantLoader(BaseLoader):
     def __init__(self, loader, extension):
         self.loader = loader
         self.extension = extension
-   
 
     def get_source(self, environment, template):
         try:
@@ -123,6 +123,15 @@ class TemplateExporter(Exporter):
             self._environment_cached = self._create_environment()
         return self._environment_cached
 
+    @property
+    def default_config(self):
+        c = Config({
+            'RegexRemovePreprocessor':{
+                'enabled': True
+                }
+            })
+        c.merge(super(TemplateExporter, self).default_config)
+        return c
 
     template_file = Unicode(
             help="Name of the template file to use"

--- a/nbconvert/exporters/tests/files/prompt_numbers.ipynb
+++ b/nbconvert/exporters/tests/files/prompt_numbers.ipynb
@@ -56,18 +56,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": "*",
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "from time import sleep\n",
-    "sleep(10)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 0,
    "metadata": {
     "collapsed": true

--- a/nbconvert/exporters/tests/files/prompt_numbers.ipynb
+++ b/nbconvert/exporters/tests/files/prompt_numbers.ipynb
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": "*",
    "metadata": {
     "collapsed": true
    },

--- a/nbconvert/exporters/tests/files/prompt_numbers.ipynb
+++ b/nbconvert/exporters/tests/files/prompt_numbers.ipynb
@@ -1,81 +1,102 @@
 {
- "metadata": {
-  "name": "notebook2"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import numpy as np"
-     ],
-     "language": "python",
+     "data": {
+      "text/plain": [
+       "(100,)"
+      ]
+     },
+     "execution_count": 10,
      "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "evs = np.zeros(100)",
-      "evs.shape"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 10,
-       "text": [
-        "(100,)"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": "*"
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 0
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "evs = np.zeros(100)\n",
+    "evs.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    " "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    " "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from time import sleep\n",
+    "sleep(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    " "
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/nbconvert/exporters/tests/test_html.py
+++ b/nbconvert/exporters/tests/test_html.py
@@ -54,7 +54,7 @@ class TestHTMLExporter(ExportersTestsBase):
         in_regex = r"In&nbsp;\[(.*)\]:"
         out_regex = r"Out\[(.*)\]:"
 
-        ins = ["2", "10", "&nbsp;", "&nbsp;", "*", "0"]
+        ins = ["2", "10", "&nbsp;", "&nbsp;", "0"]
         outs = ["10"]
 
         assert re.findall(in_regex, output) == ins

--- a/nbconvert/exporters/tests/test_latex.py
+++ b/nbconvert/exporters/tests/test_latex.py
@@ -111,7 +111,7 @@ class TestLatexExporter(ExportersTestsBase):
         in_regex = r"In \[\{\\color\{incolor\}(.*)\}\]:"
         out_regex = r"Out\[\{\\color\{outcolor\}(.*)\}\]:"
 
-        ins = ["2", "10", " ", " ", "*", "0"]
+        ins = ["2", "10", " ", " ",  "0"]
         outs = ["10"]
 
         assert re.findall(in_regex, output) == ins

--- a/nbconvert/preprocessors/regexremove.py
+++ b/nbconvert/preprocessors/regexremove.py
@@ -55,11 +55,8 @@ class RegexRemovePreprocessor(Preprocessor):
         pattern = re.compile('|'.join('(?:%s)' % pattern
                              for pattern in self.patterns))
 
-        # check that output is not present if it is a code cell
-        code_w_output = cell.cell_type == 'code' and cell.get('outputs',[]) != []
-
-        # Filter out cells that meet the pattern and have no output
-        return code_w_output or not pattern.match(cell.source)
+        # Filter out cells that meet the pattern and have no outputs
+        return cell.get('outputs') or not pattern.match(cell.source)
 
     def preprocess(self, nb, resources):
         """

--- a/nbconvert/preprocessors/regexremove.py
+++ b/nbconvert/preprocessors/regexremove.py
@@ -44,6 +44,9 @@ class RegexRemovePreprocessor(Preprocessor):
         """
         Checks that a cell matches the pattern and that (if a code cell)
         it does not have any outputs.
+
+        Returns: Boolean.
+        True means cell should *not* be removed.
         """
 
         # Compile all the patterns into one: each pattern is first wrapped
@@ -53,7 +56,7 @@ class RegexRemovePreprocessor(Preprocessor):
                              for pattern in self.patterns))
 
         # check that output is not present if it is a code cell
-        code_w_output = cell.get('cell_type', {}) and cell.outputs != []
+        code_w_output = cell.cell_type == 'code' and cell.get('outputs',[]) != []
 
         # Filter out cells that meet the pattern and have no output
         return code_w_output or not pattern.match(cell.source)

--- a/nbconvert/preprocessors/regexremove.py
+++ b/nbconvert/preprocessors/regexremove.py
@@ -10,6 +10,7 @@ import re
 from traitlets import List, Unicode
 from .base import Preprocessor
 
+
 class RegexRemovePreprocessor(Preprocessor):
     """
     Removes cells from a notebook that match one or more regular expression.
@@ -39,6 +40,24 @@ class RegexRemovePreprocessor(Preprocessor):
 
     patterns = List(Unicode, default_value=[r'\Z']).tag(config=True)
 
+    def check_conditions(self, cell):
+        """
+        Checks that a cell matches the pattern and that (if a code cell)
+        it does not have any outputs.
+        """
+
+        # Compile all the patterns into one: each pattern is first wrapped
+        # by a non-capturing group to ensure the correct order of precedence
+        # and the patterns are joined with a logical or
+        pattern = re.compile('|'.join('(?:%s)' % pattern
+                             for pattern in self.patterns))
+
+        # check that output is not present if it is a code cell
+        code_w_output = cell.get('cell_type', {}) and cell.outputs != []
+
+        # Filter out cells that meet the pattern and have no output
+        return code_w_output or not pattern.match(cell.source)
+
     def preprocess(self, nb, resources):
         """
         Preprocessing to apply to each notebook. See base.py for details.
@@ -46,12 +65,8 @@ class RegexRemovePreprocessor(Preprocessor):
         # Skip preprocessing if the list of patterns is empty
         if not self.patterns:
             return nb, resources
-        # Compile all the patterns into one: each pattern is first wrapped
-        # by a non-capturing group to ensure the correct order of precedence
-        # and the patterns are joined with a logical or
-        pattern = re.compile('|'.join('(?:%s)' % pattern
-                             for pattern in self.patterns))
-        # Filter out cells that match any of the patterns
-        nb.cells = [cell for cell in nb.cells
-                    if not pattern.match(cell.source)]
+
+        # Filter out cells that meet the conditions
+        nb.cells = [cell for cell in nb.cells if self.check_conditions(cell)]
+
         return nb, resources

--- a/nbconvert/preprocessors/tests/test_regexremove.py
+++ b/nbconvert/preprocessors/tests/test_regexremove.py
@@ -6,7 +6,7 @@ Module with tests for the RegexRemovePreprocessor.
 # Distributed under the terms of the Modified BSD License.
 
 import re
-from nbformat import v4 as nbformat
+from nbformat import v4 as nbformat, from_dict
 
 from .base import PreprocessorTestsBase
 from ..regexremove import RegexRemovePreprocessor
@@ -46,7 +46,7 @@ class TestRegexRemove(PreprocessorTestsBase):
         expected_cell_count = {
             'default': 5,  # only strictly empty cells
             'disallow_whitespace': 2,  # all "empty" cells are removed
-            'disallow_tab_newline': 3, # all "empty" cells but the single space
+            'disallow_tab_newline': 3,  # all "empty" cells but the single space
             'none': 6,
         }
         for method in ['default', 'disallow_whitespace', 'disallow_tab_newline', 'none']:
@@ -68,3 +68,25 @@ class TestRegexRemove(PreprocessorTestsBase):
             for cell in nb.cells:
                 for pattern in patterns:
                     self.assertFalse(pattern.match(cell.source))
+
+    def test_nosource_with_output(self):
+        """
+        Test that the check_conditions returns true when given a code-cell
+        that has non-empty outputs but no source.
+        """
+
+        cell = {
+            'cell_type': 'code',
+            'execution_count': 2,
+            'metadata': {},
+            'outputs': [{
+                'name': 'stdout',
+                'output_type': 'stream',
+                'text': 'I exist.\n'
+            }],
+            'source': ''
+        }
+        preprocessor = self.build_preprocessor()
+        node = from_dict(cell)
+        assert preprocessor.check_conditions(node)
+


### PR DESCRIPTION
Closes #615. 

This enables RegexRemovePreprocessor in the TemplateExporter. 

It also changes its behaviour to not remove cells that _do_ have output even if they match the regular expression (which, by default, is the empty string).

@tillahoffmann is this consistent with your original intended use of this preprocessor (keeping in mind that tag-based input filtering should also be possible soon)?