### PR TITLE
use pandoc's tex_math_double_backslash extension

### DIFF
--- a/nbconvert/templates/latex/document_contents.tplx
+++ b/nbconvert/templates/latex/document_contents.tplx
@@ -35,7 +35,7 @@
 
 % Display markdown
 ((* block data_markdown -*))
-    ((( output.data['text/markdown'] | citation2latex | strip_files_prefix | convert_pandoc('markdown', 'latex'))))
+    ((( output.data['text/markdown'] | citation2latex | strip_files_prefix | convert_pandoc('markdown+tex_math_double_backslash', 'latex'))))
 ((* endblock data_markdown *))
 
 % Default mechanism for rendering figures
@@ -64,7 +64,7 @@
 
 % Render markdown
 ((* block markdowncell scoped *))
-    ((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex'))))
+    ((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown+tex_math_double_backslash', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex'))))
 ((* endblock markdowncell *))
 
 % Don't display unknown types

--- a/nbconvert/templates/latex/report.tplx
+++ b/nbconvert/templates/latex/report.tplx
@@ -22,5 +22,5 @@
 ((* endblock docclass *))
 
 ((* block markdowncell scoped *))
-((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex', extra_args=["--chapters"]) )))
+((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown+tex_math_double_backslash', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex', extra_args=["--chapters"]) )))
 ((* endblock markdowncell *))


### PR DESCRIPTION
This addresses issues related to how we process `\\(\\)` and `\\[\\]` for LaTeX and PDF output.

I think this closes an outsized number of issues given the number of lines that needed to be changed, but I'd need to track down those individually later.