### PR TITLE
Add clear-output as a convenience flag per @rjleveque's in-person suggestion

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -94,6 +94,18 @@ nbconvert_flags.update({
         """Run nbconvert in place, overwriting the existing notebook (only 
         relevant when converting to notebook format)"""
         ),
+    'clear-output' : (
+        {
+            'NbConvertApp' : {
+                'use_output_suffix' : False,
+                'export_format' : 'notebook',
+            },
+            'FilesWriter' : {'build_directory': ''},
+            'ClearOutputPreprocessor' : {'enabled' : True},
+        },
+        """Clear output of current file and save in place, 
+        overwriting the existing notebook. """
+        ),
     'no-prompt' : (
         {'TemplateExporter' : {
             'exclude_input_prompt' : True,


### PR DESCRIPTION
Talking with @fperez and @rjleveque today pointed out that nbconvert should be able to apply the ClearOutputPreprocessor easily on a file. However doing so is unnecessarily verbose, e.g.:

```
jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace example.ipynb
```

This creates a flag that makes this much more concise.
```
jupyter nbconvert --clear-output example.ipynb
```
