### PR TITLE
Add recent mistune release to avoid other people hitting #328

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ setup_args = dict(
 
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
-    'mistune!=0.6',
+    'mistune>=0.7.4',
     'jinja2',
     'pygments',
     'traitlets>=4.2',


### PR DESCRIPTION
mistune fixed a bug in html parsing (specifically with quotes around attributes) in 0.7.4 that caused some of the issues reported in #328 

This updates the dependency to require that version of mistune.