### PR TITLE
Specify default template files with extension

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -36,7 +36,7 @@ class HTMLExporter(TemplateExporter):
 
     @default('template_file')
     def _template_file_default(self):
-        return 'full'
+        return 'full.tpl'
     
     output_mimetype = 'text/html'
     

--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -28,7 +28,7 @@ class LatexExporter(TemplateExporter):
 
     @default('template_file')
     def _template_file_default(self):
-        return 'article'
+        return 'article.tplx'
 
     # Latex constants
     @default('default_template_path')

--- a/nbconvert/exporters/markdown.py
+++ b/nbconvert/exporters/markdown.py
@@ -20,7 +20,7 @@ class MarkdownExporter(TemplateExporter):
 
     @default('template_file')
     def _template_file_default(self):
-        return 'markdown'
+        return 'markdown.tpl'
 
     output_mimetype = 'text/markdown'
 

--- a/nbconvert/exporters/python.py
+++ b/nbconvert/exporters/python.py
@@ -18,6 +18,6 @@ class PythonExporter(TemplateExporter):
 
     @default('template_file')
     def _template_file_default(self):
-        return 'python'
+        return 'python.tpl'
 
     output_mimetype = 'text/x-python'

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -20,7 +20,7 @@ class RSTExporter(TemplateExporter):
 
     @default('template_file')
     def _template_file_default(self):
-        return 'rst'
+        return 'rst.tpl'
 
     output_mimetype = 'text/restructuredtext'
 

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -17,7 +17,7 @@ class ScriptExporter(TemplateExporter):
     
     @default('template_file')
     def _template_file_default(self):
-        return 'script'
+        return 'script.tpl'
 
     def _get_language_exporter(self, lang_name):
         """Find an exporter for the language name from notebook metadata.

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -151,7 +151,7 @@ class SlidesExporter(HTMLExporter):
 
     @default('template_file')
     def _template_file_default(self):
-        return 'slides_reveal'
+        return 'slides_reveal.tpl'
 
     output_mimetype = 'text/html'
 


### PR DESCRIPTION
This should make issues like ipython/ipython#10731 less likely. At present, if you have a file in the working directory called `python` or `rst` or `article` (and so on) with no extension, nbconvert will try to use that as the template. Honestly, I'm surprised this hasn't come up more.

With this change, it will only look for the default template files with their extension. So you can still override it with a file called `python.tpl`, for instance. But that's less likely to be there accidentally than `python`.