### PR TITLE
add step to validate preprocessors that relies on jupyter/nbformat#103

### DIFF
--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -308,4 +308,5 @@ class Exporter(LoggingConfigurable):
         #to each preprocessor
         for preprocessor in self._preprocessors:
             nbc, resc = preprocessor(nbc, resc)
+            nbformat.validate(nbc, relax_add_props=True)
         return nbc, resc

--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -13,9 +13,10 @@ import copy
 import collections
 import datetime
 
+import nbformat
+
 from traitlets.config.configurable import LoggingConfigurable
 from traitlets.config import Config
-import nbformat
 from traitlets import HasTraits, Unicode, List, TraitError
 from traitlets.utils.importstring import import_item
 from ipython_genutils import text, py3compat
@@ -308,5 +309,11 @@ class Exporter(LoggingConfigurable):
         #to each preprocessor
         for preprocessor in self._preprocessors:
             nbc, resc = preprocessor(nbc, resc)
-            nbformat.validate(nbc, relax_add_props=True)
+            try: 
+                nbformat.validate(nbc, relax_add_props=True)
+            except nbformat.ValidationError:
+                self.log.error('Notebook is invalid after preprocessor {}',
+                               preprocessor)
+                raise
+
         return nbc, resc

--- a/setup.py
+++ b/setup.py
@@ -190,11 +190,11 @@ install_requires = setuptools_args['install_requires'] = [
     'pygments',
     'traitlets>=4.2',
     'jupyter_core',
-    'nbformat',
+    'nbformat>=4.4',
     'entrypoints>=0.2.2',
     'bleach',
     'pandocfilters>=1.4.1',
-    'testpath', 
+    'testpath',
 ]
 
 extra_requirements = {


### PR DESCRIPTION
This PR will break not pass on travis until https://github.com/jupyter/nbformat/pull/103 is changed.

We had thought (in our discussion in #643) that preprocessors currently would not be able to violate the NotebookNode format… turns out, that isn't the case!

Lo, behold the [`PizzaPreprocessor`](https://github.com/jupyter/nbconvert/blame/master/nbconvert/exporters/tests/test_exporter.py#L28-L35):

```python
class PizzaPreprocessor(Preprocessor):
    """Simple preprocessor that adds a 'pizza' entry to the NotebookNode.  Used 
    to test Exporter.
    """

    def preprocess(self, nb, resources):
        nb['pizza'] = 'cheese'
        return nb, resources
```

which is part of our `TestExporter` tests and is almost 4 years old. 

This is definitely not a valid attribute, so it seems we've not been strict about enforcing the "nb→nb" aspect of Preprocessors for a while.

This change would enforce the constraint that @minrk suggested in #643, that we allow only additional attributes to be added to the intermediate representation of the notebook. 

That would mean that the PizzaPreprocessor would now be ok (at least as far as the intermediate representation goes), as well as the `cell.transient` field used in #643. 

It also would enforce this constraint on 3rd-party extensions relying on the native preprocessor support in the core Exporter (which is probably going to break some extensions but we probably want to know what extensions actually cause non-valid notebooks to be written).