### PR TITLE
Added import to handling example in the execute_api

### DIFF
--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -132,7 +132,7 @@ Handling errors
 ~~~~~~~~~~~~~~~
 A useful pattern to execute notebooks while handling errors is the following::
 
-    from nbconvert.preprocessors.execute import CellExecutionError
+    from nbconvert.preprocessors import CellExecutionError
 
     try:
         out = ep.preprocess(nb, {'metadata': {'path': run_path}})

--- a/docs/source/execute_api.rst
+++ b/docs/source/execute_api.rst
@@ -132,9 +132,12 @@ Handling errors
 ~~~~~~~~~~~~~~~
 A useful pattern to execute notebooks while handling errors is the following::
 
+    from nbconvert.preprocessors.execute import CellExecutionError
+
     try:
         out = ep.preprocess(nb, {'metadata': {'path': run_path}})
     except CellExecutionError:
+        out = None
         msg = 'Error executing the notebook "%s".\n\n' % notebook_filename
         msg += 'See notebook "%s" for the traceback.' % notebook_filename_out
         print(msg)

--- a/nbconvert/preprocessors/__init__.py
+++ b/nbconvert/preprocessors/__init__.py
@@ -7,7 +7,7 @@ from .latex import LatexPreprocessor
 from .csshtmlheader import CSSHTMLHeaderPreprocessor
 from .highlightmagics import HighlightMagicsPreprocessor
 from .clearoutput import ClearOutputPreprocessor
-from .execute import ExecutePreprocessor
+from .execute import ExecutePreprocessor, CellExecutionError
 from .regexremove import RegexRemovePreprocessor
 from .tagremove import TagRemovePreprocessor
 


### PR DESCRIPTION
Added 
```python
from nbconvert.preprocessors.execute import CellExecutionError
```
and defined `out` under the `except` in the [Handling errors](https://nbconvert.readthedocs.io/en/stable/execute_api.html#handling-errors) example in the execute_api.