### PR TITLE
if nb.metadata.title is set, default to that for notebook

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -139,7 +139,14 @@ This template does not define a docclass, the inheriting class must define this.
     \def\gt{>}
     \def\lt{<}
     % Document parameters
-    ((* block title *))\title{((( resources.metadata.name | ascii_only | escape_latex )))}((* endblock title *))
+    % Document title
+    ((* block title -*))
+    ((*- if "title" in nb.metadata *))
+    \title{((( nb.metadata.get("title", "") | ascii_only | escape_latex )))}
+    ((*- else *))
+    \title{((( resources.metadata.name | ascii_only | escape_latex )))}
+    ((*- endif -*))
+    ((*- endblock title *))
     ((* block date *))((* endblock date *))
     ((* block author *))((* endblock author *))
     ((* endblock definitions *))


### PR DESCRIPTION
There is a title field in the notebook metadata as part of the nbformat v4 spec. We should use this feature if it is available.

This should solve #249.