### PR TITLE
Simple API for in-memory templates

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -16,8 +16,8 @@ from traitlets.config import Config
 from traitlets.utils.importstring import import_item
 from ipython_genutils import py3compat
 from jinja2 import (
-    TemplateNotFound, Environment, ChoiceLoader, FileSystemLoader, BaseLoader
-)
+    TemplateNotFound, Environment, ChoiceLoader, FileSystemLoader, BaseLoader,
+    DictLoader)
 
 from nbconvert import filters
 from .exporter import Exporter
@@ -244,6 +244,15 @@ class TemplateExporter(Exporter):
         self.observe(self._invalidate_template_cache,
                      list(self.traits(affects_template=True)))
 
+        self._str_template_container = {}
+
+    def use_string_template(self, tpl):
+        """Use a template from a string instead of loading from a file.
+
+        Pass the template string into this method.
+        """
+        self._str_template_container['<memory>'] = tpl
+        self.template_file = '<memory>'
 
     def _load_template(self):
         """Load the Jinja template object from the template file
@@ -374,6 +383,7 @@ class TemplateExporter(Exporter):
              os.path.join(here, self.template_skeleton_path)]
 
         loaders = self.extra_loaders + [
+            DictLoader(self._str_template_container),
             ExtensionTolerantLoader(FileSystemLoader(paths), self.template_extension)
         ]
         environment = Environment(

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -133,6 +133,19 @@ class TestExporter(ExportersTestsBase):
         nb = v4.new_notebook()
         out, resources = exporter.from_notebook_node(nb)
 
+    def test_in_memory_template_simple(self):
+        # New simpler API for providing an in-memory template
+        tpl = ("{%- extends 'markdown.tpl' -%}\n"
+               "{% block markdowncell scoped %}\n"
+               "In-memory template\n"
+               "{% endblock markdowncell %}\n")
+        exporter = TemplateExporter()
+        exporter.use_string_template(tpl)
+
+        nb = v4.new_notebook()
+        nb.cells = [v4.new_markdown_cell("boo")]
+        out, resources = exporter.from_notebook_node(nb)
+        assert "In-memory template" in out
 
     def test_fail_to_find_template_file(self):
         # Create exporter with invalid template file, check that it doesn't


### PR DESCRIPTION
Closes #673.

The new API is a method `exporter.use_string_template(s)`, which you pass the string template into.

Example to use it with a subclass:

```python
import sys
from nbconvert.exporters import HTMLExporter

POPPING_TEMPLATE = """
{%- extends 'full.tpl' -%}

{%- block markdowncell -%}
<div style="background-color: hsl(85, 86%, 76%);">
{{ super() }}
</div>
{%- endblock markdowncell -%}
"""

class PopExporter(HTMLExporter):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.use_string_template(POPPING_TEMPLATE)

if __name__ == '__main__':
    out, res = PopExporter().from_filename(sys.argv[1])
    with open('pops.html', 'w') as f:
        f.write(out)
```