### PR TITLE
Raw template as settable attribute

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -141,6 +141,9 @@ class TemplateExporter(Exporter):
             help="Name of the template file to use"
     ).tag(config=True, affects_template=True)
 
+    raw_template = Unicode('', help="raw template string"
+    ).tag(affects_template=True, affects_environment=True)
+
     @observe('template_file')
     def _template_file_changed(self, change):
         new = change['new']
@@ -160,24 +163,20 @@ class TemplateExporter(Exporter):
     def _template_file_default(self):
         return self.default_template
 
-    self._raw_template = ''
+    def _register_raw_template(self, value):
+        _template_name = "<memory>"
+        raw_loader = DictLoader({
+            _template_name: value
+        })
+        self.extra_loaders.append(raw_loader)
+        self.template_file = _template_name
 
-    @property
-    def raw_template(self):
-        return self._raw_template
-
-
-    @raw_template.setter
-    def raw_template(self, value):
-        if value:
-            _template_name = "<memory>"
-            raw_loader = DictLoader({
-                _template_name: value
-            })
-            self.extra_loaders.append(raw_loader)
-            self.template_file = _template_name
+    @observe('raw_template')
+    def _raw_template_changed(self, change):
+        if change['new']:
+            self._register_raw_template(change['new'])
         else:
-            self._raw_template = ''
+            self.raw_template = ''
 
 
     default_template = Unicode(u'').tag(affects_template=True)

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -164,12 +164,6 @@ class TemplateExporter(Exporter):
     def _template_file_default(self):
         return self.default_template
 
-    def _load_raw_template(self, name):
-        if name == self._raw_template_key:
-            return self.raw_template, None, False
-        else:
-            return None
-
     @observe('raw_template')
     def _raw_template_changed(self, change):
         if not change['new']:

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -144,6 +144,8 @@ class TemplateExporter(Exporter):
     raw_template = Unicode('', help="raw template string"
     ).tag(affects_environment=True)
 
+    _raw_template_key = "<memory>"
+
     @observe('template_file')
     def _template_file_changed(self, change):
         new = change['new']
@@ -165,14 +167,13 @@ class TemplateExporter(Exporter):
 
     def _register_raw_template(self, value):
         if value:
-            _template_name = "<memory>"
             raw_loader = DictLoader({
-                _template_name: value
+                self._raw_template_key: value
             })
             self.extra_loaders.append(raw_loader)
             if self.template_file != self.default_template:
                 self._default_template = self.template_file
-            self.template_file = _template_name
+            self.template_file = self._raw_template_key
         else:
             self.template_file = self.default_template or self._default_template
 
@@ -276,6 +277,7 @@ class TemplateExporter(Exporter):
         This is triggered by various trait changes that would change the template.
         """
 
+        # this gives precedence to a raw_template if present
         if self.raw_template:
             self._register_raw_template(self.raw_template)
 

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -143,11 +143,7 @@ class TemplateExporter(Exporter):
     raw_template = Unicode('', help="raw template string").tag(affects_environment=True)
 
     _last_template_file = ""
-    raw_template_key = Unicode("<memory>",
-        help=("pseudo filename for in-memory template assignment. "
-              "It is suggested that you do not change this unless you run into "
-              "conflicts with the default value.")
-    ).tag(config=True)
+    _raw_template_key = "<memory>"
 
     @observe('template_file')
     def _template_file_changed(self, change):
@@ -169,7 +165,7 @@ class TemplateExporter(Exporter):
         return self.default_template
 
     def _load_raw_template(self, name):
-        if name == self.raw_template_key:
+        if name == self._raw_template_key:
             return self.raw_template, None, False
         else:
             return None
@@ -279,7 +275,7 @@ class TemplateExporter(Exporter):
         with self.hold_trait_notifications():
             if self.raw_template:
                 self._last_template_file = self.template_file
-                self.template_file = self.raw_template_key
+                self.template_file = self._raw_template_key
 
         if not self.template_file:
             raise ValueError("No template_file specified!")
@@ -405,7 +401,7 @@ class TemplateExporter(Exporter):
 
         loaders = self.extra_loaders + [
             ExtensionTolerantLoader(FileSystemLoader(paths), self.template_extension),
-            DictLoader({self.raw_template_key: self.raw_template})
+            DictLoader({self._raw_template_key: self.raw_template})
         ]
         environment = Environment(
             loader=ChoiceLoader(loaders),

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -273,8 +273,9 @@ class TemplateExporter(Exporter):
 
         # this gives precedence to a raw_template if present
         with self.hold_trait_notifications():
-            if self.raw_template:
+            if self.template_file != self._raw_template_key:
                 self._last_template_file = self.template_file
+            if self.raw_template:
                 self.template_file = self._raw_template_key
 
         if not self.template_file:

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -154,11 +154,9 @@ class TemplateExporter(Exporter):
             help="Name of the template file to use"
     ).tag(config=True, affects_template=True)
 
-    raw_template = Unicode('',
-        help="raw template string"
-    ).tag(affects_environment=True)
+    raw_template = Unicode('', help="raw template string")
 
-    _last_template_file = Unicode("", help="holder for last template_file")
+    _last_template_file = ""
     raw_template_key = Unicode("<memory>",
         help=("pseudo filename for in-memory template assignment. "
               "It is suggested that you do not change this unless you run into "
@@ -190,12 +188,11 @@ class TemplateExporter(Exporter):
         else:
             return None
 
-
     @observe('raw_template')
     def _raw_template_changed(self, change):
         if not change['new']:
             self.template_file = self.default_template or self._last_template_file
-
+        self._invalidate_template_cache()
 
     default_template = Unicode(u'').tag(affects_template=True)
 

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -16,7 +16,8 @@ from traitlets.config import Config
 from traitlets.utils.importstring import import_item
 from ipython_genutils import py3compat
 from jinja2 import (
-    TemplateNotFound, Environment, ChoiceLoader, FileSystemLoader, BaseLoader
+    TemplateNotFound, Environment, ChoiceLoader, FileSystemLoader, BaseLoader,
+    DictLoader
 )
 
 from nbconvert import filters
@@ -158,6 +159,26 @@ class TemplateExporter(Exporter):
     @default('template_file')
     def _template_file_default(self):
         return self.default_template
+
+    self._raw_template = ''
+
+    @property
+    def raw_template(self):
+        return self._raw_template
+
+
+    @raw_template.setter
+    def raw_template(self, value):
+        if value:
+            _template_name = "<memory>"
+            raw_loader = DictLoader({
+                _template_name: value
+            })
+            self.extra_loaders.append(raw_loader)
+            self.template_file = _template_name
+        else:
+            self._raw_template = ''
+
 
     default_template = Unicode(u'').tag(affects_template=True)
 

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -192,10 +192,10 @@ class TemplateExporter(Exporter):
         os.path.join("..", "templates", "skeleton"),
         help="Path where the template skeleton files are located.",
     ).tag(affects_environment=True)
-    
+
     #Extension that the template files use.
     template_extension = Unicode(".tpl").tag(config=True, affects_environment=True)
-    
+
     exclude_input = Bool(False,
         help = "This allows you to exclude code cell inputs from all templates if set to True."
         ).tag(config=True)
@@ -227,7 +227,7 @@ class TemplateExporter(Exporter):
     exclude_unknown = Bool(False,
         help = "This allows you to exclude unknown cells from all templates if set to True."
         ).tag(config=True)
-    
+
     extra_loaders = List(
         help="Jinja loaders to find templates. Will be tried in order "
              "before the default FileSystem ones.",
@@ -249,7 +249,7 @@ class TemplateExporter(Exporter):
     def __init__(self, config=None, **kw):
         """
         Public constructor
-    
+
         Parameters
         ----------
         config : config
@@ -270,7 +270,7 @@ class TemplateExporter(Exporter):
 
     def _load_template(self):
         """Load the Jinja template object from the template file
-        
+
         This is triggered by various trait changes that would change the template.
         """
 

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -274,6 +274,9 @@ class TemplateExporter(Exporter):
         This is triggered by various trait changes that would change the template.
         """
 
+        if self.raw_template:
+            self._register_raw_template(self.raw_template)
+
         if not self.template_file:
             raise ValueError("No template_file specified!")
 

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -154,11 +154,16 @@ class TemplateExporter(Exporter):
             help="Name of the template file to use"
     ).tag(config=True, affects_template=True)
 
-    raw_template = Unicode('', help="raw template string"
+    raw_template = Unicode('',
+        help="raw template string"
     ).tag(affects_environment=True)
 
-    _raw_template_key = "<memory>"
     _last_template_file = Unicode("", help="holder for last template_file")
+    raw_template_key = Unicode("<memory>",
+        help=("pseudo filename for in-memory template assignment. "
+              "It is suggested that you do not change this unless you run into "
+              "conflicts with the default value.")
+    ).tag(config=True)
 
     @observe('template_file')
     def _template_file_changed(self, change):
@@ -180,7 +185,7 @@ class TemplateExporter(Exporter):
         return self.default_template
 
     def _load_raw_template(self, name):
-        if name == self._raw_template_key:
+        if name == self.raw_template_key:
             return self.raw_template, None, False
         else:
             return None
@@ -291,7 +296,7 @@ class TemplateExporter(Exporter):
         with self.hold_trait_notifications():
             if self.raw_template:
                 self._last_template_file = self.template_file
-                self.template_file = self._raw_template_key
+                self.template_file = self.raw_template_key
 
         if not self.template_file:
             raise ValueError("No template_file specified!")
@@ -418,7 +423,7 @@ class TemplateExporter(Exporter):
         loaders = self.extra_loaders + [
             ExtensionTolerantLoader(FileSystemLoader(paths), self.template_extension),
             ExplicitFunctionLoader(self._load_raw_template,
-                                  template_list=[self._raw_template_key])
+                                  template_list=[self.raw_template_key])
         ]
         environment = Environment(
             loader=ChoiceLoader(loaders),

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -142,7 +142,7 @@ class TemplateExporter(Exporter):
     ).tag(config=True, affects_template=True)
 
     raw_template = Unicode('', help="raw template string"
-    ).tag(affects_template=True, affects_environment=True)
+    ).tag(affects_environment=True)
 
     @observe('template_file')
     def _template_file_changed(self, change):
@@ -164,19 +164,21 @@ class TemplateExporter(Exporter):
         return self.default_template
 
     def _register_raw_template(self, value):
-        _template_name = "<memory>"
-        raw_loader = DictLoader({
-            _template_name: value
-        })
-        self.extra_loaders.append(raw_loader)
-        self.template_file = _template_name
+        if value:
+            _template_name = "<memory>"
+            raw_loader = DictLoader({
+                _template_name: value
+            })
+            self.extra_loaders.append(raw_loader)
+            if self.template_file != self.default_template:
+                self._default_template = self.template_file
+            self.template_file = _template_name
+        else:
+            self.template_file = self.default_template or self._default_template
 
     @observe('raw_template')
     def _raw_template_changed(self, change):
-        if change['new']:
-            self._register_raw_template(change['new'])
-        else:
-            self.raw_template = ''
+        self._register_raw_template(change['new'])
 
 
     default_template = Unicode(u'').tag(affects_template=True)

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -274,6 +274,25 @@ class TestExporter(ExportersTestsBase):
         output_deassign, _ = exporter_deassign.from_notebook_node(nb)
         assert "blah" not in output_deassign
 
+    def test_raw_template_dereassignment(self):
+        """
+        Test `raw_template` does not overwrite template_file if deassigned after
+        being assigned to a non-custom Exporter.
+        """
+        nb = v4.new_notebook()
+        nb.cells.append(v4.new_code_cell("some_text"))
+        exporter_dereassign = RSTExporter()
+        exporter_dereassign.raw_template = raw_template
+        output_dereassign, _ = exporter_dereassign.from_notebook_node(nb)
+        assert "blah" in output_dereassign
+        exporter_dereassign.raw_template = raw_template.replace("blah", "baz")
+        output_dereassign, _ = exporter_dereassign.from_notebook_node(nb)
+        assert "baz" in output_dereassign
+        exporter_dereassign.raw_template = ''
+        assert exporter_dereassign.template_file == 'rst.tpl'
+        output_dereassign, _ = exporter_dereassign.from_notebook_node(nb)
+        assert "blah" not in output_dereassign
+
     def test_fail_to_find_template_file(self):
         # Create exporter with invalid template file, check that it doesn't
         # exist in the environment, try to convert empty notebook. Failure is

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -153,17 +153,22 @@ class TestExporter(ExportersTestsBase):
         output_attr, _ = exporter_attr.from_notebook_node(nb)
         assert "blah" in output_attr
 
-        class AttrRemovedExporter(TemplateExporter):
-            raw_template = raw_template
+        class AttrDynamicExporter(TemplateExporter):
+            @default('raw_template')
+            def _raw_template_default(self):
+                return raw_template
 
             @default('template_file')
-            def _raw_template_default(self):
+            def _template_file_default(self):
                 return "rst.tpl"
 
-        exporter_attr_removed = AttrRemovedExporter()
-        exporter_attr_removed.raw_template = ''
-        output_attr_removed, _ = exporter_attr_removed.from_notebook_node(nb)
-        assert "blah" not in output_attr_removed
+        exporter_attr_dynamic = AttrDynamicExporter()
+        output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
+        assert exporter_attr_dynamic.template_file != "rst.tpl"
+        exporter_attr_dynamic.raw_template = ''
+        assert exporter_attr_dynamic.template_file == "rst.tpl"
+        output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
+        assert "blah" not in output_attr_dynamic
 
         output_constructor, _ = TemplateExporter(
             raw_template=raw_template).from_notebook_node(nb)

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -127,19 +127,6 @@ class TestExporter(ExportersTestsBase):
             assert os.path.abspath(exporter.template.filename) == template
             assert os.path.dirname(template) in [os.path.abspath(d) for d in exporter.template_path]
 
-    def test_in_memory_template(self):
-        # Loads in an in memory template using jinja2.DictLoader
-        # creates a class that uses this template with the template_file argument
-        # converts an empty notebook using this mechanism
-        my_loader = DictLoader({'my_template': "{%- extends 'rst.tpl' -%}"})
-
-        class MyExporter(TemplateExporter):
-            template_file = 'my_template'
-
-        exporter = MyExporter(extra_loaders=[my_loader])
-        nb = v4.new_notebook()
-        out, resources = exporter.from_notebook_node(nb)
-
 
     def test_raw_template_attr_overwrite(self):
 
@@ -166,22 +153,19 @@ class TestExporter(ExportersTestsBase):
             def _raw_template_default(self):
                 return raw_template
 
-
         exporter_attr_dynamic = AttrDynamicExporter()
-        # import pdb; pdb.set_trace()
         output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
-        # assert exporter_attr_dynamic.template_file != "rst.tpl"
         assert "blah" in output_attr_dynamic
         exporter_attr_dynamic.raw_template = ''
         assert exporter_attr_dynamic.template_file == "rst.tpl"
         output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
         assert "blah" not in output_attr_dynamic
 
-    def test_raw_template_dynamic_attr_2(self):
+    def test_raw_template_dynamic_attr_reversed(self):
         nb = v4.new_notebook()
         nb.cells.append(v4.new_code_cell("some_text"))
 
-        class AttrDynamicExporter_2(TemplateExporter):
+        class AttrDynamicExporter(TemplateExporter):
             @default('raw_template')
             def _raw_template_default(self):
                 return raw_template
@@ -190,17 +174,15 @@ class TestExporter(ExportersTestsBase):
             def _template_file_default(self):
                 return "rst.tpl"
 
-
-
-        exporter_attr_dynamic = AttrDynamicExporter_2()
-        # import pdb; pdb.set_trace()
+        exporter_attr_dynamic = AttrDynamicExporter()
         output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
-        # assert exporter_attr_dynamic.template_file != "rst.tpl"
         assert "blah" in output_attr_dynamic
         exporter_attr_dynamic.raw_template = ''
         assert exporter_attr_dynamic.template_file == "rst.tpl"
         output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
         assert "blah" not in output_attr_dynamic
+
+
     def test_raw_template_constructor(self):
         nb = v4.new_notebook()
         nb.cells.append(v4.new_code_cell("some_text"))

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -246,7 +246,7 @@ class TestExporter(ExportersTestsBase):
 
     def test_raw_template_reassignment(self):
         """
-        Test `raw_template` assigned after the fact on non-custom Exporter.
+        Test `raw_template` reassigned after the fact on non-custom Exporter.
         """
         nb = v4.new_notebook()
         nb.cells.append(v4.new_code_cell("some_text"))
@@ -257,6 +257,22 @@ class TestExporter(ExportersTestsBase):
         exporter_reassign.raw_template = raw_template.replace("blah", "baz")
         output_reassign, _ = exporter_reassign.from_notebook_node(nb)
         assert "baz" in output_reassign
+
+    def test_raw_template_deassignment(self):
+        """
+        Test `raw_template` does not overwrite template_file if deassigned after
+        being assigned to a non-custom Exporter.
+        """
+        nb = v4.new_notebook()
+        nb.cells.append(v4.new_code_cell("some_text"))
+        exporter_deassign = RSTExporter()
+        exporter_deassign.raw_template = raw_template
+        output_deassign, _ = exporter_deassign.from_notebook_node(nb)
+        assert "blah" in output_deassign
+        exporter_deassign.raw_template = ''
+        assert exporter_deassign.template_file == 'rst.tpl'
+        output_deassign, _ = exporter_deassign.from_notebook_node(nb)
+        assert "blah" not in output_deassign
 
     def test_fail_to_find_template_file(self):
         # Create exporter with invalid template file, check that it doesn't

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -128,8 +128,11 @@ class TestExporter(ExportersTestsBase):
             assert os.path.dirname(template) in [os.path.abspath(d) for d in exporter.template_path]
 
 
-    def test_raw_template_attr_overwrite(self):
-
+    def test_raw_template_attr(self):
+        """
+        Verify that you can assign a in memory template string by overwriting
+        `raw_template` as simple(non-traitlet) attribute
+        """
         nb = v4.new_notebook()
         nb.cells.append(v4.new_code_cell("some_text"))
 
@@ -141,6 +144,12 @@ class TestExporter(ExportersTestsBase):
         assert "blah" in output_attr
 
     def test_raw_template_dynamic_attr(self):
+        """
+        Test that template_file and raw_template traitlets play nicely together.
+        - source assigns template_file default first, then raw_template
+        - checks that the raw_template overrules template_file if set
+        - checks that once raw_template is set to '', template_file returns
+        """
         nb = v4.new_notebook()
         nb.cells.append(v4.new_code_cell("some_text"))
 
@@ -162,6 +171,12 @@ class TestExporter(ExportersTestsBase):
         assert "blah" not in output_attr_dynamic
 
     def test_raw_template_dynamic_attr_reversed(self):
+        """
+        Test that template_file and raw_template traitlets play nicely together.
+        - source assigns raw_template default first, then template_file
+        - checks that the raw_template overrules template_file if set
+        - checks that once raw_template is set to '', template_file returns
+        """
         nb = v4.new_notebook()
         nb.cells.append(v4.new_code_cell("some_text"))
 
@@ -184,6 +199,9 @@ class TestExporter(ExportersTestsBase):
 
 
     def test_raw_template_constructor(self):
+        """
+        Test `raw_template` as a keyword argument in the exporter constructor.
+        """
         nb = v4.new_notebook()
         nb.cells.append(v4.new_code_cell("some_text"))
 
@@ -192,6 +210,9 @@ class TestExporter(ExportersTestsBase):
         assert "blah" in output_constructor
 
     def test_raw_template_assignment(self):
+        """
+        Test `raw_template` assigned after the fact on non-custom Exporter.
+        """
         nb = v4.new_notebook()
         nb.cells.append(v4.new_code_cell("some_text"))
         exporter_assign = TemplateExporter()

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -153,6 +153,18 @@ class TestExporter(ExportersTestsBase):
         output_attr, _ = exporter_attr.from_notebook_node(nb)
         assert "blah" in output_attr
 
+        class AttrRemovedExporter(TemplateExporter):
+            raw_template = raw_template
+
+            @default('template_file')
+            def _raw_template_default(self):
+                return "rst.tpl"
+
+        exporter_attr_removed = AttrRemovedExporter()
+        exporter_attr_removed.raw_template = ''
+        output_attr_removed, _ = exporter_attr_removed.from_notebook_node(nb)
+        assert "blah" not in output_attr_removed
+
         output_constructor, _ = TemplateExporter(
             raw_template=raw_template).from_notebook_node(nb)
         assert "blah" in output_constructor

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -141,7 +141,7 @@ class TestExporter(ExportersTestsBase):
         out, resources = exporter.from_notebook_node(nb)
 
 
-    def test_raw_template(self):
+    def test_raw_template_attr_overwrite(self):
 
         nb = v4.new_notebook()
         nb.cells.append(v4.new_code_cell("some_text"))
@@ -153,7 +153,35 @@ class TestExporter(ExportersTestsBase):
         output_attr, _ = exporter_attr.from_notebook_node(nb)
         assert "blah" in output_attr
 
+    def test_raw_template_dynamic_attr(self):
+        nb = v4.new_notebook()
+        nb.cells.append(v4.new_code_cell("some_text"))
+
         class AttrDynamicExporter(TemplateExporter):
+            @default('template_file')
+            def _template_file_default(self):
+                return "rst.tpl"
+
+            @default('raw_template')
+            def _raw_template_default(self):
+                return raw_template
+
+
+        exporter_attr_dynamic = AttrDynamicExporter()
+        # import pdb; pdb.set_trace()
+        output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
+        # assert exporter_attr_dynamic.template_file != "rst.tpl"
+        assert "blah" in output_attr_dynamic
+        exporter_attr_dynamic.raw_template = ''
+        assert exporter_attr_dynamic.template_file == "rst.tpl"
+        output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
+        assert "blah" not in output_attr_dynamic
+
+    def test_raw_template_dynamic_attr_2(self):
+        nb = v4.new_notebook()
+        nb.cells.append(v4.new_code_cell("some_text"))
+
+        class AttrDynamicExporter_2(TemplateExporter):
             @default('raw_template')
             def _raw_template_default(self):
                 return raw_template
@@ -162,31 +190,32 @@ class TestExporter(ExportersTestsBase):
             def _template_file_default(self):
                 return "rst.tpl"
 
-        exporter_attr_dynamic = AttrDynamicExporter()
+
+
+        exporter_attr_dynamic = AttrDynamicExporter_2()
+        # import pdb; pdb.set_trace()
         output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
-        assert exporter_attr_dynamic.template_file != "rst.tpl"
+        # assert exporter_attr_dynamic.template_file != "rst.tpl"
+        assert "blah" in output_attr_dynamic
         exporter_attr_dynamic.raw_template = ''
         assert exporter_attr_dynamic.template_file == "rst.tpl"
         output_attr_dynamic, _ = exporter_attr_dynamic.from_notebook_node(nb)
         assert "blah" not in output_attr_dynamic
+    def test_raw_template_constructor(self):
+        nb = v4.new_notebook()
+        nb.cells.append(v4.new_code_cell("some_text"))
 
         output_constructor, _ = TemplateExporter(
             raw_template=raw_template).from_notebook_node(nb)
         assert "blah" in output_constructor
 
+    def test_raw_template_assignment(self):
+        nb = v4.new_notebook()
+        nb.cells.append(v4.new_code_cell("some_text"))
         exporter_assign = TemplateExporter()
         exporter_assign.raw_template = raw_template
         output_assign, _ = exporter_assign.from_notebook_node(nb)
         assert "blah" in output_assign
-
-        class DefaultExporter(TemplateExporter):
-            @default('raw_template')
-            def _raw_template_default(self):
-                return raw_template
-
-        exporter_default = DefaultExporter()
-        output_default, _ = exporter_default.from_notebook_node(nb)
-        assert "blah" in output_default
 
     def test_fail_to_find_template_file(self):
         # Create exporter with invalid template file, check that it doesn't


### PR DESCRIPTION
So, the two models of use that seem as simple as possible are: 


```python
from nbconvert.preprocessors import RSTExporter
class AttrExporter(RSTExporter):
    raw_template = """{%- extends 'rst.tpl' -%}
{%- block in_prompt -%}
blah
{%- endblock in_prompt -%}
"""
```
and
```python
from nbconvert.preprocessors import RSTExporter
exp = RSTExporter()
exp.raw_template = """{%- extends 'rst.tpl' -%}
{%- block in_prompt -%}
blah
{%- endblock in_prompt -%}
```

But if you overwrite the traitlet, you lose access to all the nice traitlet features. So the following wouldn't work: 
```python
from nbconvert.preprocessors import RSTExporter
class AttrExporter(RSTExporter):
    raw_template = """{%- extends 'rst.tpl' -%}
{%- block in_prompt -%}
blah
{%- endblock in_prompt -%}

exp = AttrExporter()
exp.raw_template = ""
exp.template_file == RSTExporter().template_file #returns False
"""
```

But if you set raw_template to the empty string after defining it as a traitlet default, then it the template_file will revert to the classes' previous `template_file` traitlet default (or, technically, its `default_template`, if that is also set as a nonzero value). So this would work

```python
from nbconvert.preprocessors import RSTExporter
from traitlets import  #default
class AttrExporter(RSTExporter):
    @default('raw_template')
    def _raw_template_default(self):
        raw_template = """{%- extends 'rst.tpl' -%}
{%- block in_prompt -%}
blah
{%- endblock in_prompt -%}

exp = AttrExporter()
exp.raw_template = ""
exp.template_file == RSTExporter().template_file #returns True
"""
```

edits for clarity & @takluyver's comments 