### PR TITLE
Set BIBINPUTS and BSTINPUTS environment variables when making PDF

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -27,6 +27,18 @@ class LatexFailed(IOError):
         u = self.__unicode__()
         return cast_bytes_py2(u)
 
+def prepend_to_env_search_path(varname, value, envdict):
+    """Add value to the environment variable varname in envdict
+
+    e.g. prepend_to_env_search_path('BIBINPUTS', '/home/sally/foo', os.environ)
+    """
+    if not value:
+        return  # Nothing to add
+
+    if varname not in envdict:
+        envdict[varname] = cast_bytes_py2(value)
+    else:
+        envdict[varname] = cast_bytes_py2(value) + os.pathsep + envdict[varname]
 
 class PDFExporter(LatexExporter):
     """Writer designed to write to PDF files.
@@ -105,10 +117,8 @@ class PDFExporter(LatexExporter):
         if shell:
             command = subprocess.list2cmdline(command)
         env = os.environ.copy()
-        env['TEXINPUTS'] = os.pathsep.join([
-            cast_bytes_py2(self.texinputs),
-            env.get('TEXINPUTS', ''),
-        ])
+        prepend_to_env_search_path('TEXINPUTS', self.texinputs, env)
+
         with open(os.devnull, 'rb') as null:
             stdout = subprocess.PIPE if not self.verbose else None
             for index in range(count):

--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -118,6 +118,8 @@ class PDFExporter(LatexExporter):
             command = subprocess.list2cmdline(command)
         env = os.environ.copy()
         prepend_to_env_search_path('TEXINPUTS', self.texinputs, env)
+        prepend_to_env_search_path('BIBINPUTS', self.texinputs, env)
+        prepend_to_env_search_path('BSTINPUTS', self.texinputs, env)
 
         with open(os.devnull, 'rb') as null:
             stdout = subprocess.PIPE if not self.verbose else None

--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -35,10 +35,7 @@ def prepend_to_env_search_path(varname, value, envdict):
     if not value:
         return  # Nothing to add
 
-    if varname not in envdict:
-        envdict[varname] = cast_bytes_py2(value)
-    else:
-        envdict[varname] = cast_bytes_py2(value) + os.pathsep + envdict[varname]
+    envdict[varname] = cast_bytes_py2(value) + os.pathsep + envdict.get(varname, '')
 
 class PDFExporter(LatexExporter):
     """Writer designed to write to PDF files.


### PR DESCRIPTION
@sobester had some difficulties converting a notebook to PDF using bibtex references. Converting to tex and then running latex manually worked. My guess is that bibtex couldn't find the .bib file because nbconvert doesn't copy it to the temporary directory from which it runs latex.

While looking through this code today, I noticed that we use an environment variable `TEXINPUTS` to tell Latex to look for related files in the directory where the original notebook is. A bit of searching reveals that bibtex uses two similar environment variables, `BIBINPUTS` (for bibliography files) and `BSTINPUTS` (for style files). If my guess is correct, adding the notebook directory to these should resolve the problem with using bibtex.