### PR TITLE
Img filename metadata

### DIFF
--- a/nbconvert/preprocessors/extractoutput.py
+++ b/nbconvert/preprocessors/extractoutput.py
@@ -88,6 +88,8 @@ class ExtractOutputPreprocessor(Preprocessor):
                         ext = '.' + mime_type.rsplit('/')[-1]
                     if out.metadata.get('filename', ''):
                         filename = out.metadata['filename']
+                        if not filename.endswith(ext):
+                            filename+=ext
                     else:
                         filename = self.output_filename_template.format(
                                     unique_key=unique_key,

--- a/nbconvert/preprocessors/extractoutput.py
+++ b/nbconvert/preprocessors/extractoutput.py
@@ -108,9 +108,13 @@ class ExtractOutputPreprocessor(Preprocessor):
 
                     if filename in resources['outputs']:
                         raise ValueError(
-                            "Your filename: {} appears more than once. "
-                            "Filenames must be unique across the notebook. The "
-                            "second time this filename appeared was in cell "
+                            "Your outputs have filename metadata associated "
+                            "with them. Nbconvert saves these outputs to "
+                            "external files using this filename metadata. "
+                            "Filenames need to be unique across the notebook, "
+                            "or images will be overwritten. The filename {} is "
+                            "associated with more than one output. The second "
+                            "output associated with this filename is in cell "
                             "{}.".format(filename, cell_index)
                             )
                     #In the resources, make the figure available via

--- a/nbconvert/preprocessors/extractoutput.py
+++ b/nbconvert/preprocessors/extractoutput.py
@@ -106,6 +106,13 @@ class ExtractOutputPreprocessor(Preprocessor):
                     out.metadata.setdefault('filenames', {})
                     out.metadata['filenames'][mime_type] = filename
 
+                    if filename in resources['outputs']:
+                        raise ValueError(
+                            "Your filename: {} appears more than once. "
+                            "Filenames must be unique across the notebook. The "
+                            "second time this filename appeared was in cell "
+                            "{}.".format(filename, cell_index)
+                            )
                     #In the resources, make the figure available via
                     #   resources['outputs']['filename'] = data
                     resources['outputs'][filename] = data

--- a/nbconvert/preprocessors/extractoutput.py
+++ b/nbconvert/preprocessors/extractoutput.py
@@ -86,8 +86,10 @@ class ExtractOutputPreprocessor(Preprocessor):
                     ext = guess_extension_without_jpe(mime_type)
                     if ext is None:
                         ext = '.' + mime_type.rsplit('/')[-1]
-                    
-                    filename = self.output_filename_template.format(
+                    if out.metadata.get('filename', ''):
+                        filename = out.metadata['filename']
+                    else:
+                        filename = self.output_filename_template.format(
                                     unique_key=unique_key,
                                     cell_index=cell_index,
                                     index=index,


### PR DESCRIPTION
closes #671 

this should overwrite files if they are already present.

It also will add an extension to the file if it is not already present.

I'm open to changing either of those behaviours.