### PR TITLE
Log execution of notebooks.

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -4,7 +4,7 @@ and updates outputs"""
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from textwrap import dedent
+from textwrap import dedent, indent
 
 try:
     from queue import Empty  # Py 3
@@ -194,6 +194,15 @@ class ExecutePreprocessor(Preprocessor):
             )
     ).tag(config=True)
 
+    log_execution = Bool(False,
+        help=dedent(
+            """
+            If `False` (default), the output of executed cells is discarded.
+            If `True`, the output of executed cells is logged.
+            """
+        )
+    ).tag(config=True)
+
     kernel_manager_class = Type(
         config=True,
         help='The kernel manager class to use.'
@@ -299,12 +308,33 @@ class ExecutePreprocessor(Preprocessor):
         cell_allows_errors = (self.allow_errors or "raises-exception"
                               in cell.metadata.get("tags", []))
 
-        if self.force_raise_errors or not cell_allows_errors:
-            for out in outputs:
-                if out.output_type == 'error':
+        if self.log_execution:
+            prefix = "In [%d]: " % cell['execution_count']
+            source = indent(cell['source'], ' ' * len(prefix)).strip()
+            self.log.info(prefix + source)
+
+        for out in outputs:
+            if out['output_type'] == 'error':
+                if self.force_raise_errors or not cell_allows_errors:
                     raise CellExecutionError.from_cell_and_msg(cell, out)
-            if (reply is not None) and reply['content']['status'] == 'error':
-                raise CellExecutionError.from_cell_and_msg(cell, reply['content'])
+                elif self.log_execution:
+                    self.log.info("\n".join(out['traceback']))
+                    continue
+            if self.log_execution:
+                if out['output_type'] == 'stream':
+                    self.log.info(out['text'])
+                elif out['output_type'] == 'display_data':
+                    self.log.info(out['data']['text/plain'])
+                elif out['output_type'] == 'execute_result':
+                    self.log.info('Out[%d]: %s', out['execution_count'],
+                                  out['data']['text/plain'])
+                else:
+                    self.log.info(out)
+
+        if (self.force_raise_errors or not cell_allows_errors) and \
+                (reply is not None) and reply['content']['status'] == 'error':
+            raise CellExecutionError.from_cell_and_msg(cell, reply['content'])
+
         return cell, resources
 
     def _update_display_id(self, display_id, msg):


### PR DESCRIPTION
I sometimes want to see the internals of my notebooks when executing them as a batch job. 

This PR adds a `log_execution` traitlet to the `ExecutePreprocessor` which defaults to `False`. If `log_execution=True`, the input and output of the cells are logged when `nbconvert` is invoked with `--execute`. 

A few questions:
* I have only covered a few `output_type`s for logging. Did I miss any?
* The printed output looks a bit funny because the logger prepends `[NbConvertApp]` to each statement. That could be fixed manually by indenting by 14 characters, but it seems there must be a better way.

# Example

![screen shot 2017-10-18 at 16 33 31](https://user-images.githubusercontent.com/966348/31727698-2616ae96-b422-11e7-9ec6-7395733c3937.png)

```
$ jupyter nbconvert --execute --ExecutePreprocessor.log_execution=True --allow-errors Untitled.ipynb
[NbConvertApp] Converting notebook Untitled.ipynb to html
[NbConvertApp] Executing notebook with kernel: python3
[NbConvertApp] In [1]: print("Hello world.")
        1
[NbConvertApp] Hello world.

[NbConvertApp] Out[1]: 1
[NbConvertApp] In [2]: from matplotlib import pyplot as plt
        %matplotlib inline
        plt.plot((0, 1), (0, 1))
[NbConvertApp] Out[2]: [<matplotlib.lines.Line2D at 0x10dbe4828>]
[NbConvertApp] <matplotlib.figure.Figure at 0x10c311860>
[NbConvertApp] In [3]: assert False
[NbConvertApp] ---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-3-6e6df518a476> in <module>()
----> 1 assert False

AssertionError:
[NbConvertApp] Writing 283927 bytes to Untitled.html
```