### PR TITLE
added shebang for python

### DIFF
--- a/nbconvert/exporters/tests/test_python.py
+++ b/nbconvert/exporters/tests/test_python.py
@@ -21,4 +21,4 @@ class TestPythonExporter(ExportersTestsBase):
         """Can a PythonExporter export something?"""
         (output, resources) = self.exporter_class().from_filename(self._get_notebook())
         self.assertIn("coding: utf-8", output)
-        self.assertIn("#!/usr/bin/env ipython", output)
+        self.assertIn("#!/usr/bin/env python", output)

--- a/nbconvert/exporters/tests/test_python.py
+++ b/nbconvert/exporters/tests/test_python.py
@@ -21,3 +21,4 @@ class TestPythonExporter(ExportersTestsBase):
         """Can a PythonExporter export something?"""
         (output, resources) = self.exporter_class().from_filename(self._get_notebook())
         self.assertIn("coding: utf-8", output)
+        self.assertIn("#!/usr/bin/env ipython", output)

--- a/nbconvert/templates/python.tpl
+++ b/nbconvert/templates/python.tpl
@@ -1,6 +1,7 @@
 {%- extends 'null.tpl' -%}
 
-{% block header %}#!/usr/bin/env python
+{%- block header -%}
+#!/usr/bin/env python
 # coding: utf-8
 {% endblock header %}
 

--- a/nbconvert/templates/python.tpl
+++ b/nbconvert/templates/python.tpl
@@ -1,7 +1,7 @@
 {%- extends 'null.tpl' -%}
 
 {%- block header -%}
-#!/usr/bin/env python
+#!/usr/bin/env ipython
 # coding: utf-8
 {% endblock header %}
 

--- a/nbconvert/templates/python.tpl
+++ b/nbconvert/templates/python.tpl
@@ -1,6 +1,6 @@
 {%- extends 'null.tpl' -%}
 
-{% block header %}
+{% block header %}#!/usr/bin/env python
 # coding: utf-8
 {% endblock header %}
 

--- a/nbconvert/templates/python.tpl
+++ b/nbconvert/templates/python.tpl
@@ -1,7 +1,7 @@
 {%- extends 'null.tpl' -%}
 
 {%- block header -%}
-#!/usr/bin/env ipython
+#!/usr/bin/env python
 # coding: utf-8
 {% endblock header %}
 


### PR DESCRIPTION
fixes #690.
The shebang should start on the first line,
and that is why there is no newline between the template and the shebang
