### PR TITLE
Fixes for traitlets 4.1 deprecation warnings

### DIFF
--- a/nbconvert/preprocessors/regexremove.py
+++ b/nbconvert/preprocessors/regexremove.py
@@ -38,7 +38,7 @@ class RegexRemovePreprocessor(Preprocessor):
     documentation in python.
     """
 
-    patterns = List(Unicode, default_value=[r'\Z']).tag(config=True)
+    patterns = List(Unicode(), default_value=[r'\Z']).tag(config=True)
 
     def check_conditions(self, cell):
         """

--- a/nbconvert/preprocessors/tagremove.py
+++ b/nbconvert/preprocessors/tagremove.py
@@ -25,17 +25,17 @@ class TagRemovePreprocessor(ClearOutputPreprocessor):
 
     """
 
-    remove_cell_tags = Set(Unicode, default_value=[],
+    remove_cell_tags = Set(Unicode(), default_value=[],
             help=("Tags indicating which cells are to be removed,"
                   "matches tags in `cell.metadata.tags`.")).tag(config=True)
-    remove_all_outputs_tags = Set(Unicode, default_value=[],
+    remove_all_outputs_tags = Set(Unicode(), default_value=[],
             help=("Tags indicating cells for which the outputs are to be removed,"
                   "matches tags in `cell.metadata.tags`.")).tag(config=True)
-    remove_single_output_tags = Set(Unicode, default_value=[],
+    remove_single_output_tags = Set(Unicode(), default_value=[],
             help=("Tags indicating which individual outputs are to be removed,"
                   "matches output *i* tags in `cell.outputs[i].metadata.tags`.")
             ).tag(config=True)
-    remove_input_tags = Set(Unicode, default_value=[],
+    remove_input_tags = Set(Unicode(), default_value=[],
             help=("Tags indicating cells for which input is to be removed,"
                   "matches tags in `cell.metadata.tags`.")).tag(config=True)
 


### PR DESCRIPTION
since 4.1, traitlets complains (issues `DeprecationWarning`s) about using `TraitType` classes to set the allowed trait types for container traits like `Set` and `List`. This PR switches to using instances, to avoid the warnings in the `RegexRemovePreprocessor` and `ClearOutputPreprocessor` classes.