### PR TITLE
Enable ANSI underline and inverse

### DIFF
--- a/nbconvert/filters/ansi.py
+++ b/nbconvert/filters/ansi.py
@@ -175,15 +175,6 @@ def _ansi2anything(text, converter):
     See https://en.wikipedia.org/wiki/ANSI_escape_code
 
     Accepts codes like '\x1b[32m' (red) and '\x1b[1;32m' (bold, red).
-    The codes 1 (bold) and 5 (blinking) are selecting a bold font, code
-    0 and an empty code ('\x1b[m') reset colors and bold-ness.
-    The codes 21 and 22 deselect "bold", the codes 39 and 49 deselect
-    the foreground and background color, respectively.
-    The codes 38 and 48 select the "extended" set of foreground and
-    background colors, respectively.
-    The code 4 underlines the following text and the code 7 inverts
-    foreground and background.  The codes 24 and 27 switch the underline
-    and inversion off, respectively.
 
     Non-color escape sequences (not ending with 'm') are filtered out.
 
@@ -203,6 +194,7 @@ def _ansi2anything(text, converter):
         if m:
             if m.group(2) == 'm':
                 try:
+                    # Empty code is same as code 0
                     numbers = [int(n) if n else 0
                                for n in m.group(1).split(';')]
                 except ValueError:
@@ -224,12 +216,16 @@ def _ansi2anything(text, converter):
         while numbers:
             n = numbers.pop(0)
             if n == 0:
+                # Code 0 (same as empty code): reset everything
                 fg = bg = None
                 bold = underline = inverse = False
-            elif n in (1, 5):
+            elif n == 1:
                 bold = True
             elif n == 4:
                 underline = True
+            elif n == 5:
+                # Code 5: blinking
+                bold = True
             elif n == 7:
                 inverse = True
             elif n in (21, 22):

--- a/nbconvert/filters/tests/test_ansi.py
+++ b/nbconvert/filters/tests/test_ansi.py
@@ -41,6 +41,9 @@ class TestAnsi(TestsBase):
             'hel\x1b[0;32mlo': 'hel<span class="ansi-green-fg">lo</span>',
             'hellø': 'hellø',
             '\x1b[1mhello\x1b[33mworld\x1b[0m': '<span class="ansi-bold">hello</span><span class="ansi-yellow-intense-fg ansi-bold">world</span>',
+            'he\x1b[4mll\x1b[24mo': 'he<span class="ansi-underline">ll</span>o',
+            '\x1b[35mhe\x1b[7mll\x1b[27mo': '<span class="ansi-magenta-fg">he</span><span class="ansi-default-inverse-fg ansi-magenta-bg">ll</span><span class="ansi-magenta-fg">o</span>',
+            '\x1b[44mhe\x1b[7mll\x1b[27mo': '<span class="ansi-blue-bg">he</span><span class="ansi-blue-fg ansi-default-inverse-bg">ll</span><span class="ansi-blue-bg">o</span>',
         }
 
         for inval, outval in correct_outputs.items():
@@ -61,6 +64,7 @@ class TestAnsi(TestsBase):
             'hello\x1b[01;34mthere': r'hello\textcolor{ansi-blue-intense}{\textbf{there}}',
             'hello\x1b[001;34mthere': r'hello\textcolor{ansi-blue-intense}{\textbf{there}}',
             '\x1b[1mhello\x1b[33mworld\x1b[0m': r'\textbf{hello}\textcolor{ansi-yellow-intense}{\textbf{world}}',
+            'he\x1b[4mll\x1b[24mo': 'he\\underline{ll}o',
         }
 
         for inval, outval in correct_outputs.items():

--- a/nbconvert/filters/tests/test_ansi.py
+++ b/nbconvert/filters/tests/test_ansi.py
@@ -65,6 +65,8 @@ class TestAnsi(TestsBase):
             'hello\x1b[001;34mthere': r'hello\textcolor{ansi-blue-intense}{\textbf{there}}',
             '\x1b[1mhello\x1b[33mworld\x1b[0m': r'\textbf{hello}\textcolor{ansi-yellow-intense}{\textbf{world}}',
             'he\x1b[4mll\x1b[24mo': 'he\\underline{ll}o',
+            '\x1b[35mhe\x1b[7mll\x1b[27mo': r'\textcolor{ansi-magenta}{he}\textcolor{ansi-default-inverse-fg}{\setlength{\fboxsep}{0pt}\colorbox{ansi-magenta}{ll\strut}}\textcolor{ansi-magenta}{o}',
+            '\x1b[44mhe\x1b[7mll\x1b[27mo': r'\setlength{\fboxsep}{0pt}\colorbox{ansi-blue}{he\strut}\textcolor{ansi-blue}{\setlength{\fboxsep}{0pt}\colorbox{ansi-default-inverse-bg}{ll\strut}}\setlength{\fboxsep}{0pt}\colorbox{ansi-blue}{o\strut}',
         }
 
         for inval, outval in correct_outputs.items():

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -89,6 +89,8 @@ This template does not define a docclass, the inheriting class must define this.
     \definecolor{ansi-cyan-intense}{HTML}{258F8F}
     \definecolor{ansi-white}{HTML}{C5C1B4}
     \definecolor{ansi-white-intense}{HTML}{A1A6B2}
+    \definecolor{ansi-default-inverse-fg}{HTML}{FFFFFF}
+    \definecolor{ansi-default-inverse-bg}{HTML}{000000}
 
     % commands and environments needed by pandoc snippets
     % extracted from the output of `pandoc -s`


### PR DESCRIPTION
This is a companion PR to https://github.com/jupyter/notebook/pull/2967.