### PR TITLE
add log silencing command line flag

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -114,6 +114,14 @@ nbconvert_flags.update({
         },
         "Exclude input and output prompts from converted document."
         ),
+    'silent':(
+        {'NbConvertApp':{
+            'log_level':0
+            }
+        },
+        "Suppress all log messages."
+        ),
+
 })
 
 


### PR DESCRIPTION
Was using nbconvert as part of a demo and it was useful to have a concise way of specifying that there should be no log output.

Errors should still raise, but I figure that other people have wanted this even though I didn't see any issues asking for it.