### PR TITLE
Use "title" instead of "name" for metadata to match the notebook format

### DIFF
--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -164,7 +164,7 @@ class Exporter(LoggingConfigurable):
             resources['metadata'] = ResourcesDict()
         path, basename = os.path.split(filename)
         notebook_name = basename[:basename.rfind('.')]
-        resources['metadata']['title'] = notebook_name
+        resources['metadata']['name'] = notebook_name
         resources['metadata']['path'] = path
 
         modified_date = datetime.datetime.fromtimestamp(os.path.getmtime(filename))
@@ -277,8 +277,8 @@ class Exporter(LoggingConfigurable):
                 resources['metadata'] = new_metadata
         else:
             resources['metadata'] = ResourcesDict()
-            if not resources['metadata']['title']:
-                resources['metadata']['title'] = 'Notebook'
+            if not resources['metadata']['name']:
+                resources['metadata']['name'] = 'Notebook'
 
         #Set the output extension
         resources['output_extension'] = self.file_extension

--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -164,7 +164,7 @@ class Exporter(LoggingConfigurable):
             resources['metadata'] = ResourcesDict()
         path, basename = os.path.split(filename)
         notebook_name = basename[:basename.rfind('.')]
-        resources['metadata']['name'] = notebook_name
+        resources['metadata']['title'] = notebook_name
         resources['metadata']['path'] = path
 
         modified_date = datetime.datetime.fromtimestamp(os.path.getmtime(filename))
@@ -277,8 +277,8 @@ class Exporter(LoggingConfigurable):
                 resources['metadata'] = new_metadata
         else:
             resources['metadata'] = ResourcesDict()
-            if not resources['metadata']['name']:
-                resources['metadata']['name'] = 'Notebook'
+            if not resources['metadata']['title']:
+                resources['metadata']['title'] = 'Notebook'
 
         #Set the output extension
         resources['output_extension'] = self.file_extension

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -8,7 +8,7 @@
 <head>
 {%- block html_head -%}
 <meta charset="utf-8" />
-<title>{{resources['metadata']['name']}}</title>
+<title>{{resources['metadata']['title']}}</title>
 
 {%- if "widgets" in nb.metadata -%}
 <script src="https://unpkg.com/jupyter-js-widgets@2.0.*/dist/embed.js"></script>

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -1,6 +1,5 @@
 {%- extends 'basic.tpl' -%}
 {% from 'mathjax.tpl' import mathjax %}
-{% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 
 
 {%- block header -%}
@@ -9,6 +8,7 @@
 <head>
 {%- block html_head -%}
 <meta charset="utf-8" />
+{% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>{{nb_title}}</title>
 
 {%- if "widgets" in nb.metadata -%}

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -8,7 +8,11 @@
 <head>
 {%- block html_head -%}
 <meta charset="utf-8" />
+{%- if 'title' in resources['metadata'] -%}
+<title>{{resources['metadata']['title']}}</title>
+{%- else -%}
 <title>{{resources['metadata']['name']}}</title>
+{%- endif -%}
 
 {%- if "widgets" in nb.metadata -%}
 <script src="https://unpkg.com/jupyter-js-widgets@2.0.*/dist/embed.js"></script>

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -1,5 +1,6 @@
 {%- extends 'basic.tpl' -%}
 {% from 'mathjax.tpl' import mathjax %}
+{% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 
 
 {%- block header -%}
@@ -8,11 +9,7 @@
 <head>
 {%- block html_head -%}
 <meta charset="utf-8" />
-{%- if nb.metadata.get('title','') -%}
-<title>{{nb.metadata.get('title', '')}}</title>
-{%- else -%}
-<title>{{resources['metadata']['name']}}</title>
-{%- endif -%}
+<title>{{nb_title}}</title>
 
 {%- if "widgets" in nb.metadata -%}
 <script src="https://unpkg.com/jupyter-js-widgets@2.0.*/dist/embed.js"></script>

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -8,8 +8,8 @@
 <head>
 {%- block html_head -%}
 <meta charset="utf-8" />
-{%- if 'title' in resources['metadata'] -%}
-<title>{{resources['metadata']['title']}}</title>
+{%- if nb.metadata.get('title','') -%}
+<title>{{nb.metadata.get('title', '')}}</title>
 {%- else -%}
 <title>{{resources['metadata']['name']}}</title>
 {%- endif -%}

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -8,7 +8,7 @@
 <head>
 {%- block html_head -%}
 <meta charset="utf-8" />
-<title>{{resources['metadata']['title']}}</title>
+<title>{{resources['metadata']['name']}}</title>
 
 {%- if "widgets" in nb.metadata -%}
 <script src="https://unpkg.com/jupyter-js-widgets@2.0.*/dist/embed.js"></script>

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -44,7 +44,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
-<title>{{resources['metadata']['name']}} slides</title>
+<title>{{resources['metadata']['title']}} slides</title>
 
 <script src="{{resources.reveal.require_js_url}}"></script>
 <script src="{{resources.reveal.jquery_url}}"></script>

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -44,8 +44,8 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
-{%- if 'title' in resources['metadata'] -%}
-<title>{{resources['metadata']['title']}} slides</title>
+{%- if nb.metadata.get('title','') -%}
+<title>{{nb.metadata.get('title', '')}} slides</title>
 {%- else -%}
 <title>{{resources['metadata']['name']}} slides</title>
 {%- endif -%}

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -44,7 +44,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
-<title>{{resources['metadata']['title']}} slides</title>
+<title>{{resources['metadata']['name']}} slides</title>
 
 <script src="{{resources.reveal.require_js_url}}"></script>
 <script src="{{resources.reveal.jquery_url}}"></script>

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -44,7 +44,11 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
+{%- if 'title' in resources['metadata'] -%}
+<title>{{resources['metadata']['title']}} slides</title>
+{%- else -%}
 <title>{{resources['metadata']['name']}} slides</title>
+{%- endif -%}
 
 <script src="{{resources.reveal.require_js_url}}"></script>
 <script src="{{resources.reveal.jquery_url}}"></script>

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -1,5 +1,6 @@
 {%- extends 'basic.tpl' -%}
 {% from 'mathjax.tpl' import mathjax %}
+{% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 
 {%- block any_cell scoped -%}
 {%- if cell.metadata.get('slide_start', False) -%}
@@ -44,11 +45,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
-{%- if nb.metadata.get('title','') -%}
-<title>{{nb.metadata.get('title', '')}} slides</title>
-{%- else -%}
-<title>{{resources['metadata']['name']}} slides</title>
-{%- endif -%}
+<title>{{nb_title}} slides</title>
 
 <script src="{{resources.reveal.require_js_url}}"></script>
 <script src="{{resources.reveal.jquery_url}}"></script>

--- a/nbconvert/templates/html/slides_reveal.tpl
+++ b/nbconvert/templates/html/slides_reveal.tpl
@@ -1,6 +1,5 @@
 {%- extends 'basic.tpl' -%}
 {% from 'mathjax.tpl' import mathjax %}
-{% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 
 {%- block any_cell scoped -%}
 {%- if cell.metadata.get('slide_start', False) -%}
@@ -45,6 +44,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
+{% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>{{nb_title}} slides</title>
 
 <script src="{{resources.reveal.require_js_url}}"></script>

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -4,6 +4,7 @@ functions.  Figures, data_text,
 This template does not define a docclass, the inheriting class must define this.=))
 
 ((*- extends 'document_contents.tplx' -*))
+((*- set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] -*))
 
 %===============================================================================
 % Abstract overrides
@@ -145,11 +146,7 @@ This template does not define a docclass, the inheriting class must define this.
     % Document parameters
     % Document title
     ((* block title -*))
-    ((*- if "title" in nb.metadata *))
-    \title{((( nb.metadata.get("title", "") | ascii_only | escape_latex )))}
-    ((*- else *))
-    \title{((( resources.metadata.name | ascii_only | escape_latex )))}
-    ((*- endif -*))
+    \title{((( nb_title | ascii_only | escape_latex )))}
     ((*- endblock title *))
     ((* block date *))((* endblock date *))
     ((* block author *))((* endblock author *))

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -4,7 +4,6 @@ functions.  Figures, data_text,
 This template does not define a docclass, the inheriting class must define this.=))
 
 ((*- extends 'document_contents.tplx' -*))
-((*- set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] -*))
 
 %===============================================================================
 % Abstract overrides
@@ -146,6 +145,7 @@ This template does not define a docclass, the inheriting class must define this.
     % Document parameters
     % Document title
     ((* block title -*))
+    ((*- set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] -*))
     \title{((( nb_title | ascii_only | escape_latex )))}
     ((*- endblock title *))
     ((* block date *))((* endblock date *))


### PR DESCRIPTION
The notebook format has a metadata field for the "title" of the notebook: https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json#L63
I think it should be used instead of the field "name".