### PR TITLE
Use defusedxml to parse potentially untrusted XML

### DIFF
--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -17,7 +17,10 @@ try:
     from urllib.parse import quote  # Py 3
 except ImportError:
     from urllib2 import quote  # Py 2
-from xml.etree import ElementTree
+
+# defusedxml does safe(r) parsing of untrusted XML data
+from defusedxml import cElementTree as ElementTree
+from xml.etree.cElementTree import Element
 
 from ipython_genutils import py3compat
 
@@ -98,7 +101,7 @@ def add_anchor(html, anchor_link_text=u'¶'):
         return html
     link = _convert_header_id(html2text(h))
     h.set('id', link)
-    a = ElementTree.Element("a", {"class" : "anchor-link", "href" : "#" + link})
+    a = Element("a", {"class" : "anchor-link", "href" : "#" + link})
     a.text = anchor_link_text
     h.append(a)
 

--- a/setup.py
+++ b/setup.py
@@ -195,6 +195,7 @@ install_requires = setuptools_args['install_requires'] = [
     'bleach',
     'pandocfilters>=1.4.1',
     'testpath',
+    'defusedxml',
 ]
 
 extra_requirements = {


### PR DESCRIPTION
Untrusted XML data can cause havoc with unprepared parsers. I'm not sure whether our default templates are vulnerable to this, but it makes sense for the filters to be defensive in handling it.

Closes gh-706