### PR TITLE
Multiline math

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -60,7 +60,7 @@ class MathBlockLexer(mistune.BlockLexer):
         """Add token to pass through mutiline math."""
         self.tokens.append({
             "type": "multiline_math",
-            "text": m.group(1) or m.group(2) or m.group(3)
+            "text": m.group(0)
         })
 
 

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -21,12 +21,43 @@ from pygments.util import ClassNotFound
 from nbconvert.filters.strings import add_anchor
 
 
+class MathBlockGrammar(mistune.BlockGrammar):
+    block_math = re.compile(r"^\$\$(.*?)\$\$|^\\\\\[(.*?)\\\\\]", re.DOTALL)
+    latex_environment = re.compile(r"^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}",
+                                   re.DOTALL)
+
+
 class MathInlineGrammar(mistune.InlineGrammar):
     inline_math = re.compile(r"^\$(.+?)\$|^\\\\\((.+?)\\\\\)", re.DOTALL)
     block_math = re.compile(r"^\$\$(.*?)\$\$|^\\\\\[(.*?)\\\\\]", re.DOTALL)
     latex_environment = re.compile(r"^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}",
                                    re.DOTALL)
     text = re.compile(r'^[\s\S]+?(?=[\\<!\[_*`~$]|https?://| {2,}\n|$)')
+
+
+class MathBlockLexer(mistune.BlockLexer):
+    default_rules = (['block_math', 'latex_environment']
+                     + mistune.BlockLexer.default_rules)
+
+    def __init__(self, rules=None, **kwargs):
+        if rules is None:
+            rules = MathBlockGrammar()
+        super(MathBlockLexer, self).__init__(rules, **kwargs)
+
+    def parse_block_math(self, m):
+        """Add token for a $$math$$ block"""
+        self.tokens.append({
+            'type': 'block_math',
+            'text': m.group(1) or m.group(2)
+        })
+
+    def parse_latex_environment(self, m):
+        """Add token for a \begin{.} ...LaTeX stuff... \end{.} block"""
+        self.tokens.append({
+            'type': 'latex_environment',
+            'name': m.group(1),
+            'text': m.group(2)
+        })
 
 
 class MathInlineLexer(mistune.InlineLexer):
@@ -53,7 +84,16 @@ class MarkdownWithMath(mistune.Markdown):
     def __init__(self, renderer, **kwargs):
         if 'inline' not in kwargs:
             kwargs['inline'] = MathInlineLexer
+        if 'block' not in kwargs:
+            kwargs['block'] = MathBlockLexer
         super(MarkdownWithMath, self).__init__(renderer, **kwargs)
+
+    def output_block_math(self):
+        return self.renderer.block_math(self.token["text"])
+
+    def output_latex_environment(self):
+        return self.renderer.latex_environment(self.token["name"],
+                                               self.token["text"])
 
 
 class IPythonRenderer(mistune.Renderer):

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -49,7 +49,7 @@ class MathBlockLexer(mistune.BlockLexer):
         """Add token to pass through mutiline math."""
         self.tokens.append({
             "type": "multiline_math",
-            "text": m.string
+            "text": m.group(0)
         })
 
 

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -26,21 +26,10 @@ class MathBlockGrammar(mistune.BlockGrammar):
     identify math content spanning multiple lines. These are used by the 
     MathBlockLexer.
     """
-    multi_math_str = "|".join([r"(^\$\$.*?\$\$)",
-                               r"(^\\\\\[.*?\\\\\])",
-                               r"(^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\4\})"])
+    multi_math_str = "|".join([r"^\$\$.*?\$\$",
+                               r"^\\\\\[.*?\\\\\]",
+                               r"^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}"])
     multiline_math = re.compile(multi_math_str, re.DOTALL)
-
-
-class MathInlineGrammar(mistune.InlineGrammar):
-    """This defines different ways of declaring math objects that should be 
-    passed through to mathjax unaffected. These are used by the MathInlineLexer.
-    """
-    inline_math = re.compile(r"^\$(.+?)\$|^\\\\\((.+?)\\\\\)", re.DOTALL)
-    block_math = re.compile(r"^\$\$(.*?)\$\$|^\\\\\[(.*?)\\\\\]", re.DOTALL)
-    latex_environment = re.compile(r"^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}",
-                                   re.DOTALL)
-    text = re.compile(r'^[\s\S]+?(?=[\\<!\[_*`~$]|https?://| {2,}\n|$)')
 
 
 class MathBlockLexer(mistune.BlockLexer):
@@ -60,8 +49,19 @@ class MathBlockLexer(mistune.BlockLexer):
         """Add token to pass through mutiline math."""
         self.tokens.append({
             "type": "multiline_math",
-            "text": m.group(0)
+            "text": m.string
         })
+
+
+class MathInlineGrammar(mistune.InlineGrammar):
+    """This defines different ways of declaring math objects that should be 
+    passed through to mathjax unaffected. These are used by the MathInlineLexer.
+    """
+    inline_math = re.compile(r"^\$(.+?)\$|^\\\\\((.+?)\\\\\)", re.DOTALL)
+    block_math = re.compile(r"^\$\$(.*?)\$\$|^\\\\\[(.*?)\\\\\]", re.DOTALL)
+    latex_environment = re.compile(r"^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}",
+                                   re.DOTALL)
+    text = re.compile(r'^[\s\S]+?(?=[\\<!\[_*`~$]|https?://| {2,}\n|$)')
 
 
 class MathInlineLexer(mistune.InlineLexer):

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -22,6 +22,10 @@ from nbconvert.filters.strings import add_anchor
 
 
 class MathBlockGrammar(mistune.BlockGrammar):
+    """This defines a single regex comprised of the different patterns that 
+    identify math content spanning multiple lines. These are used by the 
+    MathBlockLexer.
+    """
     multi_math_str = "|".join([r"(^\$\$.*?\$\$)",
                                r"(^\\\\\[.*?\\\\\])",
                                r"(^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\4\})"])
@@ -29,6 +33,9 @@ class MathBlockGrammar(mistune.BlockGrammar):
 
 
 class MathInlineGrammar(mistune.InlineGrammar):
+    """This defines different ways of declaring math objects that should be 
+    passed through to mathjax unaffected. These are used by the MathInlineLexer.
+    """
     inline_math = re.compile(r"^\$(.+?)\$|^\\\\\((.+?)\\\\\)", re.DOTALL)
     block_math = re.compile(r"^\$\$(.*?)\$\$|^\\\\\[(.*?)\\\\\]", re.DOTALL)
     latex_environment = re.compile(r"^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}",
@@ -37,6 +44,10 @@ class MathInlineGrammar(mistune.InlineGrammar):
 
 
 class MathBlockLexer(mistune.BlockLexer):
+    """ This acts as a pass-through to the MathInlineLexer. It is needed in 
+    order to avoid other block level rules splitting math sections apart. 
+    """
+    
     default_rules = (['multiline_math']
                      + mistune.BlockLexer.default_rules)
 
@@ -54,6 +65,14 @@ class MathBlockLexer(mistune.BlockLexer):
 
 
 class MathInlineLexer(mistune.InlineLexer):
+    """This interprets the content of LaTeX style math objects using the rules 
+    defined by the MathInlineGrammar. 
+    
+    In particular this grabs ``$$...$$``, ``\\[...\\]``, ``\\(...\\)``, ``$...$``, 
+    and ``\begin{foo}...\end{foo}`` styles for declaring mathematics. It strips 
+    delimiters from all these varieties, and extracts the type of environment 
+    in the last case (``foo`` in this example).
+    """
     default_rules = (['block_math', 'inline_math', 'latex_environment']
                      + mistune.InlineLexer.default_rules)
 

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -137,6 +137,18 @@ class TestMarkdown(TestsBase):
             "$$a<b&b<lt$$",
             "$$a<b&lt;b>a;a-b<0$$",
             "$$<k'>$$",
+            """$$x
+=
+2$$""",
+            r"""$$
+ b_{l_1,l_2,l_3}^{\phi\phi\omega} = -8\, l_1\times l_2 \,l_1\cdot l_2 \int_0^{\chi_*} d\chi \frac{W(\chi,\chi_*)^2}{\chi^2} \int_0^{\chi}d\chi' \frac{W(\chi',\chi)W(\chi',\chi_*)}{{\chi'}^2} \left[
+ P_\psi\left(\frac{l_1}{\chi},z(\chi)\right) P_\Psi\left(\frac{l_2}{\chi'},z(\chi')\right)
+- (l_1\leftrightarrow l_2)
+\right]
+$$""",
+            r"""\begin{equation*}
+x = 2 *55* 7
+\end{equation*}""",
             """$
 \\begin{tabular}{ l c r }
   1 & 2 & 3 \\

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -137,18 +137,18 @@ class TestMarkdown(TestsBase):
             "$$a<b&b<lt$$",
             "$$a<b&lt;b>a;a-b<0$$",
             "$$<k'>$$",
-            """$$x
-=
-2$$""",
-            r"""$$
- b_{l_1,l_2,l_3}^{\phi\phi\omega} = -8\, l_1\times l_2 \,l_1\cdot l_2 \int_0^{\chi_*} d\chi \frac{W(\chi,\chi_*)^2}{\chi^2} \int_0^{\chi}d\chi' \frac{W(\chi',\chi)W(\chi',\chi_*)}{{\chi'}^2} \left[
- P_\psi\left(\frac{l_1}{\chi},z(\chi)\right) P_\Psi\left(\frac{l_2}{\chi'},z(\chi')\right)
-- (l_1\leftrightarrow l_2)
-\right]
-$$""",
-            r"""\begin{equation*}
-x = 2 *55* 7
-\end{equation*}""",
+            ("$$x\n"
+             "=\n"
+             "2$$"),
+            ("$$\n"
+             "b =  \\left[\n"
+             "P\\left(\\right)\n"
+             "- (l_1\\leftrightarrow l_2\n)"
+             "\\right]\n"
+             "$$"),
+            ("\\begin{equation*}\n"
+             "x = 2 *55* 7\n"
+             "\\end{equation*}"),
             """$
 \\begin{tabular}{ l c r }
   1 & 2 & 3 \\


### PR DESCRIPTION
This is a modification of the logic #715 (now #716) that takes the approach I suggested in https://github.com/jupyter/nbconvert/pull/715#issuecomment-349505394. 

In particular it uses the MathBlockLexer as a way to pass the multiline sections of math blocks through to the MathInlineLexer, which will do the actual parsing.

I don't want this to be merged until we can figure out how to simplify the test examples as they are making a set of already hard-to-read tests even more hard-to-read.

I also really want to know why our previous test with a LaTeX environment with a `*` in its name (the first instance of the test) didn't work to catch this. 
Specifically, that test case is:
https://github.com/jupyter/nbconvert/blob/3e203ce4c5989192908720e646f3c41cd2dea038/nbconvert/filters/tests/test_markdown.py#L124-L128