### PR TITLE
Added Ubuntu Linux Instructions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -57,6 +57,7 @@ Fortunately, there are packages that make this much easier. These
 packages are specific to different operating systems: 
 
 * Linux: `TeX Live <http://tug.org/texlive/>`_
+   * For Installing Xelatex on Ubuntu: https://tex.stackexchange.com/questions/179778/xelatex-under-ubuntu
 * macOS (OS X): `MacTeX <http://tug.org/mactex/>`_.
 * Windows: `MikTex <http://www.miktex.org/>`_
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -57,7 +57,9 @@ Fortunately, there are packages that make this much easier. These
 packages are specific to different operating systems: 
 
 * Linux: `TeX Live <http://tug.org/texlive/>`_
-   * For Installing Xelatex on Ubuntu: https://tex.stackexchange.com/questions/179778/xelatex-under-ubuntu
+
+  * E.g. on Debian or Ubuntu: ``sudo apt-get install texlive-xetex``
+
 * macOS (OS X): `MacTeX <http://tug.org/mactex/>`_.
 * Windows: `MikTex <http://www.miktex.org/>`_
 


### PR DESCRIPTION
I've linked to a TeX Stackexchange article which has a straightforward answer on installing Xelatex on Ubuntu Linux (essential for saving Jupyter notebooks as PDFs).