### PR TITLE
Fix Jinja syntax in custom template example.

### DIFF
--- a/docs/source/external_exporters.rst
+++ b/docs/source/external_exporters.rst
@@ -204,7 +204,7 @@ And the template file, that inherits from the html `full` template and prepend/a
 
 
     ## this is a markdown cell
-    {super()}
+    {{ super() }}
     ## THIS IS THE END
 
 


### PR DESCRIPTION
The custom template example doesn't work as intended: it needs double `{{ }}` to call a Jinja2 function, otherwise it's just treated as literal content.