### PR TITLE
Skip executing empty code cells

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -290,7 +290,7 @@ class ExecutePreprocessor(Preprocessor):
 
         To execute all cells see :meth:`preprocess`.
         """
-        if cell.cell_type != 'code':
+        if cell.cell_type != 'code' or not cell.source.strip():
             return cell, resources
 
         reply, outputs = self.run_cell(cell, cell_index)

--- a/nbconvert/preprocessors/tests/files/Empty Cell.ipynb
+++ b/nbconvert/preprocessors/tests/files/Empty Cell.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test that executing skips over an empty cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Code 1'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"Code 1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Code 2'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"Code 2\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This matches the behaviour of the notebook itself: empty code cells are not executed.

Closes #657.