### PR TITLE
Windows unicode error fixed, nosetest added to setup.py

### DIFF
--- a/nbconvert/preprocessors/csshtmlheader.py
+++ b/nbconvert/preprocessors/csshtmlheader.py
@@ -10,7 +10,6 @@ import hashlib
 import nbconvert.resources
 
 from traitlets import Unicode
-from ipython_genutils.py3compat import str_to_bytes
 from .base import Preprocessor
 
 
@@ -132,6 +131,6 @@ class CSSHTMLHeaderPreprocessor(Preprocessor):
     def _hash(self, filename):
         """Compute the hash of a file."""
         md5 = hashlib.md5()
-        with open(filename) as f:
-            md5.update(str_to_bytes(f.read()))
+        with open(filename, 'rb') as f:
+            md5.update(f.read())
         return md5.digest()

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extra_requirements = {
-    'test': ['pytest', 'pytest-cov', 'ipykernel', 'jupyter_client>=4.2'],
+    'test': ['pytest', 'pytest-cov', 'ipykernel', 'jupyter_client>=4.2', 'nose'],
     'serve': ['tornado>=4.0'],
     'execute': ['jupyter_client>=4.2'],
 }


### PR DESCRIPTION
@takluyver Your suggestion at #742 was spot on.

I've also added `nose` to the test dependencies, since running `py.test --pyargs nbconvert` doesn't work when `nose` isn't installed (seems like iPython has this dependency).

