### PR TITLE
Removing more nose remnants via dependencies.

### DIFF
--- a/nbconvert/exporters/tests/test_asciidoc.py
+++ b/nbconvert/exporters/tests/test_asciidoc.py
@@ -15,10 +15,10 @@
 import re
 
 from traitlets.config import Config
-from ipython_genutils.testing import decorators as dec
 
 from .base import ExportersTestsBase
 from ..asciidoc import ASCIIDocExporter
+from ...utils.io import onlyif_cmds_exist
 
 #-----------------------------------------------------------------------------
 # Class
@@ -38,7 +38,7 @@ class TestASCIIDocExporter(ExportersTestsBase):
         ASCIIDocExporter()
 
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_export(self):
         """
         Can a ASCIIDocExporter export something?
@@ -49,7 +49,7 @@ class TestASCIIDocExporter(ExportersTestsBase):
         assert re.findall(in_regex, output)
         assert re.findall(out_regex, output)
         
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_export_no_prompt(self):
         """
         Can a ASCIIDocExporter export something without prompts?

--- a/nbconvert/exporters/tests/test_latex.py
+++ b/nbconvert/exporters/tests/test_latex.py
@@ -9,11 +9,11 @@ import re
 
 from .base import ExportersTestsBase
 from ..latex import LatexExporter
+from ...utils.io import onlyif_cmds_exist
 
 from traitlets.config import Config
 from nbformat import write
 from nbformat import v4
-from ipython_genutils.testing.decorators import onlyif_cmds_exist
 from testpath.tempdir import TemporaryDirectory
 
 from jinja2 import DictLoader

--- a/nbconvert/exporters/tests/test_pdf.py
+++ b/nbconvert/exporters/tests/test_pdf.py
@@ -28,8 +28,7 @@ class TestPDF(ExportersTestsBase):
         self.exporter_class()
 
 
-    @onlyif_cmds_exist('xelatex')
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('xelatex', 'pandoc')
     def test_export(self):
         """Smoke test PDFExporter"""
         with tempdir.TemporaryDirectory() as td:

--- a/nbconvert/exporters/tests/test_pdf.py
+++ b/nbconvert/exporters/tests/test_pdf.py
@@ -7,11 +7,11 @@ import logging
 import os
 import shutil
 
-from ipython_genutils.testing import decorators as dec
 from testpath import tempdir
 
 from .base import ExportersTestsBase
 from ..pdf import PDFExporter
+from ...utils.io import onlyif_cmds_exist
 
 
 #-----------------------------------------------------------------------------
@@ -28,8 +28,8 @@ class TestPDF(ExportersTestsBase):
         self.exporter_class()
 
 
-    @dec.onlyif_cmds_exist('xelatex')
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('xelatex')
+    @onlyif_cmds_exist('pandoc')
     def test_export(self):
         """Smoke test PDFExporter"""
         with tempdir.TemporaryDirectory() as td:

--- a/nbconvert/exporters/tests/test_rst.py
+++ b/nbconvert/exporters/tests/test_rst.py
@@ -11,7 +11,7 @@ from nbformat import v4
 
 from .base import ExportersTestsBase
 from ..rst import RSTExporter
-from ipython_genutils.testing.decorators import onlyif_cmds_exist
+from ...utils.io import onlyif_cmds_exist
 
 
 class TestRSTExporter(ExportersTestsBase):

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -8,7 +8,6 @@ import re
 from copy import copy
 from functools import partial
 
-
 from ipython_genutils.py3compat import string_types
 
 from ...utils.io import onlyif_cmds_exist

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -8,9 +8,10 @@ import re
 from copy import copy
 from functools import partial
 
-from ipython_genutils.py3compat import string_types
-from ipython_genutils.testing import decorators as dec
 
+from ipython_genutils.py3compat import string_types
+
+from ...utils.io import onlyif_cmds_exist
 from ...tests.base import TestsBase
 from ..pandoc import convert_pandoc
 from ..markdown import markdown2html
@@ -48,7 +49,7 @@ class TestMarkdown(TestsBase):
         ('test', 'https://google.com/'),
     ]
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_markdown2latex(self):
         """markdown2latex test"""
         for index, test in enumerate(self.tests):
@@ -57,7 +58,7 @@ class TestMarkdown(TestsBase):
                     convert_pandoc, from_format='markdown', to_format='latex'),
                 test, self.tokens[index])
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_markdown2latex_markup(self):
         """markdown2latex with markup kwarg test"""
         # This string should be passed through unaltered with pandoc's
@@ -79,7 +80,7 @@ class TestMarkdown(TestsBase):
             convert_pandoc(s, 'markdown_strict+tex_math_dollars', 'latex'),
             expected)
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_pandoc_extra_args(self):
         # pass --no-wrap
         s = '\n'.join([
@@ -227,7 +228,7 @@ i.e. the $i^{th}$"""
             s = markdown2html(case)
             self.assertIn(case, self._unescape(s))
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_markdown2rst(self):
         """markdown2rst test"""
 

--- a/nbconvert/preprocessors/tests/test_svg2pdf.py
+++ b/nbconvert/preprocessors/tests/test_svg2pdf.py
@@ -3,7 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ipython_genutils.py3compat import which, PY3
 from nbformat import v4 as nbformat
 
 from .base import PreprocessorTestsBase

--- a/nbconvert/preprocessors/tests/test_svg2pdf.py
+++ b/nbconvert/preprocessors/tests/test_svg2pdf.py
@@ -3,11 +3,12 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ipython_genutils.testing import decorators as dec
+from ipython_genutils.py3compat import which, PY3
 from nbformat import v4 as nbformat
 
 from .base import PreprocessorTestsBase
 from ..svg2pdf import SVG2PDFPreprocessor
+from ...utils.io import onlyif_cmds_exist
 
 
 class Testsvg2pdf(PreprocessorTestsBase):
@@ -63,7 +64,7 @@ class Testsvg2pdf(PreprocessorTestsBase):
         self.build_preprocessor()
 
 
-    @dec.onlyif_cmds_exist('inkscape')
+    @onlyif_cmds_exist('inkscape')
     def test_output(self):
         """Test the output of the SVG2PDFPreprocessor"""
         nb = self.build_notebook()
@@ -71,3 +72,4 @@ class Testsvg2pdf(PreprocessorTestsBase):
         preprocessor = self.build_preprocessor()
         nb, res = preprocessor(nb, res)
         self.assertIn('application/pdf', nb.cells[0].outputs[0].data)
+        

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -118,8 +118,7 @@ class TestNbConvertApp(TestsBase):
                 text = f.read()
             assert text == test_output
 
-    @onlyif_cmds_exist('xelatex')
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc', 'xelatex')
     def test_filename_spaces(self):
         """
         Generate PDFs with graphics if notebooks have spaces in the name?
@@ -134,8 +133,7 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile('notebook with spaces.pdf')
 
 
-    @onlyif_cmds_exist('xelatex')
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc', 'xelatex')
     def test_pdf(self):
         """
         Check to see if pdfs compile, even if strikethroughs are included. 
@@ -409,8 +407,7 @@ class TestNbConvertApp(TestsBase):
                 assert '```python' not in output1 # shouldn't have language
                 assert "```" in output1 # but should have fenced blocks
 
-    @onlyif_cmds_exist('xelatex')
-    @onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc', 'xelatex')
     def test_linked_images(self):
         """
         Generate PDFs with an image linked in a markdown cell

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -9,11 +9,12 @@ import io
 
 from .base import TestsBase
 from ..postprocessors import PostProcessorBase
+from ..utils.io import onlyif_cmds_exist
 from nbconvert import nbconvertapp
 from nbconvert.exporters import Exporter
 
+
 from traitlets.tests.utils import check_help_all_output
-from ipython_genutils.testing import decorators as dec
 from testpath import tempdir
 import pytest
 
@@ -117,8 +118,8 @@ class TestNbConvertApp(TestsBase):
                 text = f.read()
             assert text == test_output
 
-    @dec.onlyif_cmds_exist('xelatex')
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('xelatex')
+    @onlyif_cmds_exist('pandoc')
     def test_filename_spaces(self):
         """
         Generate PDFs with graphics if notebooks have spaces in the name?
@@ -133,8 +134,8 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile('notebook with spaces.pdf')
 
 
-    @dec.onlyif_cmds_exist('xelatex')
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('xelatex')
+    @onlyif_cmds_exist('pandoc')
     def test_pdf(self):
         """
         Check to see if pdfs compile, even if strikethroughs are included. 
@@ -154,7 +155,7 @@ class TestNbConvertApp(TestsBase):
                       '--post nbconvert.tests.test_nbconvertapp.DummyPost')
             self.assertIn('Dummy:notebook1.py', out)
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_spurious_cr(self):
         """Check for extra CR characters"""
         with self.create_temp_cwd(['notebook2.ipynb']):
@@ -169,7 +170,7 @@ class TestNbConvertApp(TestsBase):
         self.assertEqual(tex.count('\r'), tex.count('\r\n'))
         self.assertEqual(html.count('\r'), html.count('\r\n'))
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_png_base64_html_ok(self):
         """Is embedded png data well formed in HTML?"""
         with self.create_temp_cwd(['notebook2.ipynb']):
@@ -179,7 +180,7 @@ class TestNbConvertApp(TestsBase):
             with open('notebook2.html') as f:
                 assert "data:image/png;base64,b'" not in f.read()
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_template(self):
         """
         Do export templates work?
@@ -254,7 +255,7 @@ class TestNbConvertApp(TestsBase):
             self.nbconvert('--log-level 0 --to Python nb1_*')
             assert os.path.isfile(u'nb1_análisis.py')
 
-    @dec.onlyif_cmds_exist('xelatex', 'pandoc')
+    @onlyif_cmds_exist('xelatex', 'pandoc')
     def test_filename_accent_pdf(self):
         """
         Generate PDFs if notebooks have an accent in their name?
@@ -408,8 +409,8 @@ class TestNbConvertApp(TestsBase):
                 assert '```python' not in output1 # shouldn't have language
                 assert "```" in output1 # but should have fenced blocks
 
-    @dec.onlyif_cmds_exist('xelatex')
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('xelatex')
+    @onlyif_cmds_exist('pandoc')
     def test_linked_images(self):
         """
         Generate PDFs with an image linked in a markdown cell
@@ -418,7 +419,7 @@ class TestNbConvertApp(TestsBase):
             self.nbconvert('--to pdf latex-linked-image.ipynb')
             assert os.path.isfile('latex-linked-image.pdf')
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_embedded_jpeg(self):
         """
         Verify that latex conversion succeeds
@@ -429,7 +430,7 @@ class TestNbConvertApp(TestsBase):
             self.nbconvert('--to latex notebook4_jpeg.ipynb')
             assert os.path.isfile('notebook4_jpeg.tex')
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_markdown_display_priority(self):
         """
         Check to see if markdown conversion embedds PNGs,
@@ -444,7 +445,7 @@ class TestNbConvertApp(TestsBase):
                 assert ("markdown_display_priority_files/"
                         "markdown_display_priority_0_1.png") in markdown_output
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_write_figures_to_custom_path(self):
         """
         Check if figure files are copied to configured path.

--- a/nbconvert/utils/io.py
+++ b/nbconvert/utils/io.py
@@ -6,8 +6,10 @@
 
 import codecs
 import sys
-from ipython_genutils.py3compat import PY3
 
+import pytest
+
+from ipython_genutils.py3compat import PY3, which
 
 def unicode_std_stream(stream='stdout'):
     u"""Get a wrapper to write unicode to stdout/stderr as UTF-8.
@@ -51,3 +53,13 @@ def unicode_stdin_stream():
         stream_b = stream
 
     return codecs.getreader('utf-8')(stream_b)
+
+def onlyif_cmds_exist(*commands):
+    """
+    Decorator to skip test when at least one of `commands` is not found.
+    """
+    for cmd in commands:
+        if not which(cmd):
+            return pytest.mark.skip("This test runs only if command '{0}' "
+                        "is installed".format(cmd))
+    return lambda f: f

--- a/nbconvert/utils/tests/test_io.py
+++ b/nbconvert/utils/tests/test_io.py
@@ -7,7 +7,8 @@
 import io as stdlib_io
 import sys
 
-from ipython_genutils.testing.decorators import skipif
+import pytest
+
 from ..io import unicode_std_stream
 from ipython_genutils.py3compat import PY3
 
@@ -36,7 +37,8 @@ def test_UnicodeStdStream():
     finally:
         sys.stdout = orig_stdout
 
-@skipif(not PY3, "Not applicable on Python 2")
+@pytest.mark.skipif(not PY3, 
+                    reason = "Not applicable on Python 2")
 def test_UnicodeStdStream_nowrap():
     # If we replace stdout with a StringIO, it shouldn't get wrapped.
     orig_stdout = sys.stdout

--- a/nbconvert/utils/tests/test_pandoc.py
+++ b/nbconvert/utils/tests/test_pandoc.py
@@ -12,7 +12,7 @@
 import os
 import warnings
 
-from ipython_genutils.testing import decorators as dec
+from ..io import onlyif_cmds_exist
 
 from nbconvert.tests.base import TestsBase
 from .. import pandoc
@@ -27,7 +27,7 @@ class TestPandoc(TestsBase):
         super(TestPandoc, self).__init__(*args, **kwargs)
         self.original_env = os.environ.copy()
 
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_pandoc_available(self):
         """ Test behaviour that pandoc functions raise PandocMissing as documented """
         pandoc.clean_cache()
@@ -48,7 +48,7 @@ class TestPandoc(TestsBase):
             pandoc.pandoc("", "markdown", "html")
         self.assertEqual(w, [])
         
-    @dec.onlyif_cmds_exist('pandoc')
+    @onlyif_cmds_exist('pandoc')
     def test_minimal_version(self):
         original_minversion = pandoc._minimal_version
         

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extra_requirements = {
-    'test': ['pytest', 'pytest-cov', 'ipykernel', 'jupyter_client>=4.2', 'nose'],
+    'test': ['pytest', 'pytest-cov', 'ipykernel', 'jupyter_client>=4.2'],
     'serve': ['tornado>=4.0'],
     'execute': ['jupyter_client>=4.2'],
 }


### PR DESCRIPTION
It was revealed in #757 super helpfully by @HagaiHargil that we were implicitly relying on nose because we were using ipython_genutils test decorators. 

This removes those `ipython_genutils` versions by porting the `@onlyif_cmds_exist` decorator and using `pytest.mark` inside of it instead of a bunch of different `nose` bits. 