### PR TITLE
Add support for adding custom exporters to the "Download as" menu.

### DIFF
--- a/docs/source/external_exporters.rst
+++ b/docs/source/external_exporters.rst
@@ -175,6 +175,11 @@ We are going to write an exporter that:
         My custom exporter
         """
 
+        # If this custom exporter should add an entry to the
+        # "File -> Download as" menu in the notebook, give it a name here in the
+        # `export_from_notebook` class member
+        export_from_notebook = "My format"
+
         def _file_extension_default(self):
             """
             The new file extension is `.test_ext`

--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -61,6 +61,10 @@ class Exporter(LoggingConfigurable):
     # the class, not just on instances.
     output_mimetype = ''
 
+    # Should this converter be accessible from the notebook front-end?
+    # If so, should be a friendly name to display (and possibly translated).
+    export_from_notebook = None
+
     #Configurability, allows the user to easily add filters and preprocessors.
     preprocessors = List(
         help="""List of preprocessors, by name or namespace, to enable."""


### PR DESCRIPTION
This is a companion PR to https://github.com/jupyter/notebook/pull/3323.  It isn't strictly necessary for that PR to function, but it seems logical to document it over here.