### PR TITLE
Save widget model state to notebook metadata

### DIFF
--- a/nbconvert/preprocessors/tests/files/widget-hello-world.ipynb
+++ b/nbconvert/preprocessors/tests/files/widget-hello-world.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c3f75dd69f3e4602989aaa3711d2977d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>Label</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "Label(value='Hello World')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets\n",
+    "ipywidgets.Label('Hello World')"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -54,6 +54,9 @@ class TestExecute(PreprocessorTestsBase):
         if 'text/plain' in output.get('data', {}):
             output['data']['text/plain'] = \
                 re.sub(addr_pat, '<HEXADDR>', output['data']['text/plain'])
+        if 'application/vnd.jupyter.widget-view+json' in output.get('data', {}):
+            output['data']['application/vnd.jupyter.widget-view+json'] \
+                ['model_id'] = '<MODEL_ID>'
         for key, value in output.get('data', {}).items():
             if isinstance(value, string_types):
                 output['data'][key] = _normalize_base64(value)
@@ -270,3 +273,33 @@ class TestExecute(PreprocessorTestsBase):
         original = copy.deepcopy(input_nb)
         executed = executenb(original, os.path.dirname(filename))
         self.assert_notebooks_equal(original, executed)
+
+    def test_widgets(self):
+        """Runs a test notebook with widgets and checks the widget state is saved."""
+        input_file = os.path.join(current_dir, 'files', 'widget-hello-world.ipynb')
+        opts = dict(kernel_name="python")
+        res = self.build_resources()
+        res['metadata']['path'] = os.path.dirname(input_file)
+        input_nb, output_nb = self.run_notebook(input_file, opts, res)
+
+        output_data = [
+            output.get('data', {})
+            for cell in output_nb['cells']
+            for output in cell['outputs']
+        ]
+
+        model_ids = [
+            data['application/vnd.jupyter.widget-view+json']['model_id']
+            for data in output_data
+            if 'application/vnd.jupyter.widget-view+json' in data
+        ]
+
+        wdata = output_nb['metadata']['widgets'] \
+                ['application/vnd.jupyter.widget-state+json']
+        for k in model_ids:
+            d = wdata['state'][k]
+            assert 'model_name' in d
+            assert 'model_module' in d
+            assert 'state' in d
+        assert 'version_major' in wdata
+        assert 'version_minor' in wdata

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extra_requirements = {
-    'test': ['pytest', 'pytest-cov', 'ipykernel', 'jupyter_client>=4.2'],
+    'test': ['pytest', 'pytest-cov', 'ipykernel', 'jupyter_client>=4.2', 'ipywidgets'],
     'serve': ['tornado>=4.0'],
     'execute': ['jupyter_client>=4.2'],
 }


### PR DESCRIPTION
As proposed in #718.

Known limitations:
1. Default values are saved (the JS widget code only saves non-default values)
2. Binary buffers are not dealt with

For (1), is there any way of getting the default values of the widgets in the Execute Preprocessor? When running in the notebook the JS default values are used...

For (2) I didn't know what was meant to happen for binary buffers, but if you can point me towards what should be done with them I'm happy to try to add that.

I'm [currently using this to build documentation from Jupyter notebooks including widgets](https://github.com/ricklupton/floweaver/blob/master/docs/requirements.txt#L3) and [it's working](https://floweaver.readthedocs.io/en/latest/tutorials/quickstart.html)