### PR TITLE
Cleanup notebook.tex during PDF generation

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -61,10 +61,6 @@ class PDFExporter(LatexExporter):
         help="Whether to display the output of latex commands."
     ).tag(config=True)
 
-    temp_file_exts = List(['.aux', '.bbl', '.blg', '.idx', '.log', '.out'],
-        help="File extensions of temp files to remove after running."
-    ).tag(config=True)
-    
     texinputs = Unicode(help="texinputs dir. A notebook's directory is added")
     writer = Instance("nbconvert.writers.FilesWriter", args=(), kw={'build_directory': '.'})
     
@@ -155,16 +151,6 @@ class PDFExporter(LatexExporter):
             self.log.debug(u"%s output: %s\n%s", command[0], command, out)
 
         return self.run_command(self.bib_command, filename, 1, log_error)
-
-    def clean_temp_files(self, filename):
-        """Remove temporary files created by xelatex/bibtex."""
-        self.log.info("Removing temporary LaTeX files")
-        filename = os.path.splitext(filename)[0]
-        for ext in self.temp_file_exts:
-            try:
-                os.remove(filename+ext)
-            except OSError:
-                pass
     
     def from_notebook_node(self, nb, resources=None, **kw):
         latex, resources = super(PDFExporter, self).from_notebook_node(

--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -66,7 +66,7 @@ class PDFExporter(LatexExporter):
     ).tag(config=True)
     
     texinputs = Unicode(help="texinputs dir. A notebook's directory is added")
-    writer = Instance("nbconvert.writers.FilesWriter", args=())
+    writer = Instance("nbconvert.writers.FilesWriter", args=(), kw={'build_directory': '.'})
     
     _captured_output = List()
 

--- a/nbconvert/exporters/tests/test_pdf.py
+++ b/nbconvert/exporters/tests/test_pdf.py
@@ -37,4 +37,6 @@ class TestPDF(ExportersTestsBase):
             (output, resources) = self.exporter_class(latex_count=1).from_filename(newpath)
             self.assertIsInstance(output, bytes)
             assert len(output) > 0
+            # tex file should be cleaned up
+            assert 'notebook.tex' not in os.listdir(td)
 

--- a/nbconvert/exporters/tests/test_pdf.py
+++ b/nbconvert/exporters/tests/test_pdf.py
@@ -32,11 +32,11 @@ class TestPDF(ExportersTestsBase):
     def test_export(self):
         """Smoke test PDFExporter"""
         with tempdir.TemporaryDirectory() as td:
-            newpath = os.path.join(td, os.path.basename(self._get_notebook()))
+            file_name = os.path.basename(self._get_notebook())
+            newpath = os.path.join(td, file_name)
             shutil.copy(self._get_notebook(), newpath)
             (output, resources) = self.exporter_class(latex_count=1).from_filename(newpath)
             self.assertIsInstance(output, bytes)
             assert len(output) > 0
-            # tex file should be cleaned up
-            assert 'notebook.tex' not in os.listdir(td)
-
+            # all temporary file should be cleaned up
+            assert {file_name} == set(os.listdir(td))


### PR DESCRIPTION
Currently, when I generate a PDF from a notebook it leaves behind the `notebook.tex` file in the directory that the notebook is in. This fixes that by generating the tex file in the same temporary directory as the rest of the latex files. It also removes some related dead code. Closes https://github.com/jupyter/nbconvert/issues/767