### PR TITLE
Latex ipython template: draw a vertical line left of ipython code

### DIFF
--- a/nbconvert/templates/latex/document_contents.tplx
+++ b/nbconvert/templates/latex/document_contents.tplx
@@ -13,7 +13,7 @@
 
 % Display python error text as-is
 ((* block error *))
-    \begin{Verbatim}[commandchars=\\\{\}]
+    \begin{Verbatim}[commandchars=\\\{\},frame=leftline,framerule=1pt,rulecolor=\color{red}]
 ((( super() )))
     \end{Verbatim}
 ((* endblock error *))
@@ -23,7 +23,7 @@
 
 % Display stream ouput with coloring
 ((* block stream *))
-    \begin{Verbatim}[commandchars=\\\{\}]
+    \begin{Verbatim}[commandchars=\\\{\},frame=leftline,framerule=1pt,rulecolor=\color{gray}]
 ((( output.text | escape_latex | ansi2latex )))
     \end{Verbatim}
 ((* endblock stream *))

--- a/nbconvert/templates/latex/style_ipython.tplx
+++ b/nbconvert/templates/latex/style_ipython.tplx
@@ -64,7 +64,7 @@
     ((*- set execution_count = " " -*))
     ((*- endif -*))
     ((*- set indention =  " " * (execution_count | length + 7) -*))
-\begin{Verbatim}[commandchars=\\\{\}]
+\begin{Verbatim}[commandchars=\\\{\},frame=leftline,framerule=1pt,rulecolor=\color{((( prompt_color )))}]
 ((( text | add_prompts(first='{\color{' ~ prompt_color ~ '}' ~ prompt ~ '[{\\color{' ~ prompt_color ~ '}' ~ execution_count ~ '}]:} ', cont=indention) )))
 \end{Verbatim}
 ((*- endmacro *))


### PR DESCRIPTION
This PR adds vertical lines to the left of code blocks in Latex output. The lines are colored in the respective input/output color.

IMHO this greatly improves readability as it's easier to distinguish between code and text and between input and output. Also it helps to see which code was originally grouped in the cells.

See the following example:

![grafik](https://user-images.githubusercontent.com/2836374/37982860-078491ca-31f2-11e8-9c23-77cc3257ec22.png)

![grafik](https://user-images.githubusercontent.com/2836374/37982891-1a502ada-31f2-11e8-84a9-d6264d9b1d2e.png)
