### PR TITLE
update font-awesome version for slides

### DIFF
--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -143,7 +143,7 @@ class SlidesExporter(HTMLExporter):
     ).tag(config=True)
 
     font_awesome_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css",
         help="""
         URL to load font awesome from.
 


### PR DESCRIPTION
Update font-awesome version when converting to slides in order to use that used by the notebook itself:
https://github.com/jupyter/notebook/blob/master/bower.json#L10
