### PR TITLE
Check for too recent of pandoc version

### DIFF
--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -1,3 +1,6 @@
+# trivial line added to run travis on this file
+# because, locally, 2 of the 9 tests fail
+
 # coding: utf-8
 """Tests for conversions from markdown to other formats"""
 

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -1,6 +1,3 @@
-# trivial line added to run travis on this file
-# because, locally, 2 of the 9 tests fail
-
 # coding: utf-8
 """Tests for conversions from markdown to other formats"""
 

--- a/nbconvert/utils/pandoc.py
+++ b/nbconvert/utils/pandoc.py
@@ -15,6 +15,7 @@ from ipython_genutils.py3compat import cast_bytes, which
 from .exceptions import ConversionException
 
 _minimal_version = "1.12.1"
+_maximal_version = "2.0.0"
 
 def pandoc(source, fmt, to, extra_args=None, encoding='utf-8'):
     """Convert an input string using pandoc.
@@ -100,11 +101,12 @@ def check_pandoc_version():
                       "output of pandoc --version.\nContinuing...",
                       RuntimeWarning, stacklevel=2)
         return False
-    ok = check_version(v , _minimal_version )
+    ok = check_version(v, _minimal_version, _maximal_version)
     if not ok:
-        warnings.warn( "You are using an old version of pandoc (%s)\n" % v + 
-                       "Recommended version is %s.\nTry updating." % _minimal_version + 
-                       "http://pandoc.org/installing.html.\nContinuing with doubts...",
+        warnings.warn( "You are using an unsupported version of pandoc (%s).\n" % v +
+                       "Your version must be at least (%s) " % _minimal_version +
+                       "but less than (%s).\n" % _maximal_version +
+                       "Refer to http://pandoc.org/installing.html.\nContinuing with doubts...",
                        RuntimeWarning, stacklevel=2)
     return ok
 

--- a/nbconvert/utils/version.py
+++ b/nbconvert/utils/version.py
@@ -11,23 +11,26 @@ It is a bit ridiculous that we need these.
 from distutils.version import LooseVersion
 
 
-def check_version(v, check):
-    """check version string v >= check
+def check_version(v, min_v, max_v):
+    """check version string v >= min_v and v < max_v
 
     Parameters
     ----------
     v : str
         version of the package
-    check : str
-        minimal version required
+    min_v : str
+        minimal version supported
+    max_v : str
+        earliest version not supported
 
     Note: If dev/prerelease tags result in TypeError for string-number
     comparison, it is assumed that the check passes and the version dependency
     is satisfied. Users on dev branches are responsible for keeping their own
     packages up to date.
     """
+
     try:
-        return LooseVersion(v) >= LooseVersion(check)
+        return LooseVersion(v) >= LooseVersion(min_v) and LooseVersion(v) < LooseVersion(max_v)
     except TypeError:
         return True
 


### PR DESCRIPTION
In researching how I can contribute to #610 at the PyCon Sprints, I noticed 2 of the 9 tests in unmodified `test_markdown.py` failed.

@ivanov suggested I make a trivial change and submit a PR so the code would run through Travis to see if the failures are replicated.