### PR TITLE
Pass config to kernel from ExecutePreprocessor for configurable kernels

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -249,7 +249,8 @@ class ExecutePreprocessor(Preprocessor):
         # from jupyter_client.manager import start_new_kernel
 
         def start_new_kernel(startup_timeout=60, kernel_name='python', **kwargs):
-            km = self.kernel_manager_class(kernel_name=kernel_name)
+            km = self.kernel_manager_class(kernel_name=kernel_name,
+                                           config=self.config)
             km.start_kernel(**kwargs)
             kc = km.client()
             kc.start_channels()

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -12,12 +12,12 @@ try:
 except ImportError:
     from Queue import Empty  # Py 2
 
-from traitlets import List, Unicode, Bool, Enum, Any, Type, Dict, default
+from traitlets import List, Unicode, Bool, Enum, Any, Type, Dict, Integer, default
 
 from nbformat.v4 import output_from_msg
+
 from .base import Preprocessor
 from ..utils.exceptions import ConversionException
-from traitlets import Integer
 
 
 class CellExecutionError(ConversionException):
@@ -219,15 +219,18 @@ class ExecutePreprocessor(Preprocessor):
             raise ImportError("`nbconvert --execute` requires the jupyter_client package: `pip install jupyter_client`")
         return KernelManager
 
-    # mapping of locations of outputs with a given display_id
-    # tracks cell index and output index within cell.outputs for
-    # each appearance of the display_id
-    # {
-    #   'display_id': {
-    #     cell_idx: [output_idx,]
-    #   }
-    # }
-    _display_id_map = Dict()
+    _display_id_map = Dict(
+        help=dedent(
+              """
+              mapping of locations of outputs with a given display_id
+              tracks cell index and output index within cell.outputs for
+              each appearance of the display_id
+              {
+                   'display_id': {
+                  cell_idx: [output_idx,]
+                   }
+              }
+              """))
 
     def start_new_kernel(self, **kwargs):
         """Creates a new kernel manager and kernel client.

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -300,7 +300,8 @@ class ExecutePreprocessor(Preprocessor):
 
         self.km, self.kc = self.start_new_kernel(cwd=path)
         try:
-            yield
+            # Yielding unbound args for more easier understanding and downstream consumption 
+            yield nb, self.km, self.kc
         finally:
             self.kc.stop_channels()
             self.km.shutdown_kernel(now=self.shutdown_kernel == 'immediate')


### PR DESCRIPTION
This became a much larger PR due to my efforts to write tests for the original PR.

Most notably, this does the refactor that I proposed in @MSeal's #811 to make it easier to overwrite the `preprocess` method without allowing people to override the reliance on the superclass preprocess method on its own. This way all the overriding can occur without relying on the implementer recreating all the complex internal state logic (as was the case before).

It creates 2 new public methods, and adds a dynamic default to an existing traitlet:
- new dynamic default for `kernel_name`:
   Now if no kernel_name has been supplied as a traitlet value, it internally checks for whether `self.nb` has been set, and raises an AttributeError if `self.nb` has not been set. The logic is that if you don't set it directly, then there is no meaningful way to describe what an `ExecutePreprocessor`'s kernel should be other than if a notebook is already being processed. Previously this logic was inside the preprocess method. It gives the same priority to the traitlet defined value.
- `start_new_kernel`: previously a callback inside `preprocess`; it has been reworked to rely on the dynamic default of `kernel_name` to decide which kernel to create. It also passes through any configuration from ExecutePreprocessor. 
- `setup_preprocessor`: a context manager that sets up the `self.nb`, `self.km`, and `self.kc` values and ensures that they are cleaned up after the execution is done. It also resets the `self._display_id_map` value which was previously being done in `preprocess`. 

This also changes the value of the default `kernel_manager_class` function to match the older convention where its name should be `_default_kernel_manager_class`.

Smaller original PR: 
## Pass config to kernel from ExecutePreprocessor for configurable kernels

Right now, the way that we're instantiating the kernels means any configuration that can be passed to those kernels stops at the point where we actually create the Kernel.

If you want any custom Kernels to be configurable (e.g., to use a different `kernel_spec_manager`) then you need to be able to pass this through at instantiation.

@rgbkrk @takluyver @Carreau