### PR TITLE
[WIP] Export markdown cells as block strings instead of comments

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -40,6 +40,7 @@ default_filters = {
         'markdown2latex': filters.markdown2latex,
         'markdown2rst': filters.markdown2rst,
         'comment_lines': filters.comment_lines,
+        'block_string_lines': filters.block_string_lines,
         'strip_ansi': filters.strip_ansi,
         'strip_dollars': filters.strip_dollars,
         'strip_files_prefix': filters.strip_files_prefix,

--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -32,6 +32,7 @@ __all__ = [
     'strip_dollars',
     'strip_files_prefix',
     'comment_lines',
+    'block_string_lines',
     'get_lines',
     'ipython2python',
     'posix_path',
@@ -43,10 +44,10 @@ __all__ = [
 
 
 def wrap_text(text, width=100):
-    """ 
+    """
     Intelligently wrap text.
     Wrap text without breaking words if possible.
-    
+
     Parameters
     ----------
     text : str
@@ -63,7 +64,7 @@ def wrap_text(text, width=100):
 
 def html2text(element):
     """extract inner text from html
-    
+
     Analog of jQuery's $(element).text()
     """
     if isinstance(element, py3compat.string_types):
@@ -72,7 +73,7 @@ def html2text(element):
         except Exception:
             # failed to parse, just return it unmodified
             return element
-    
+
     text = element.text or ""
     for child in element:
         text += html2text(child)
@@ -82,7 +83,7 @@ def html2text(element):
 
 def _convert_header_id(header_contents):
     """Convert header contents to valid id value. Takes string as input, returns string.
-    
+
     Note: this may be subject to change in the case of changes to how we wish to generate ids.
 
     For use on markdown headings.
@@ -91,7 +92,7 @@ def _convert_header_id(header_contents):
 
 def add_anchor(html, anchor_link_text=u'¶'):
     """Add an id and an anchor-link to an html header
-    
+
     For use on markdown headings
     """
     try:
@@ -120,11 +121,11 @@ def add_prompts(code, first='>>> ', cont='... '):
         new_code.append(cont + line)
     return '\n'.join(new_code)
 
-    
+
 def strip_dollars(text):
     """
     Remove all dollar symbols from text
-    
+
     Parameters
     ----------
     text : str
@@ -141,7 +142,7 @@ def strip_files_prefix(text):
     """
     Fix all fake URLs that start with `files/`, stripping out the `files/` prefix.
     Applies to both urls (for html) and relative paths (for markdown paths).
-    
+
     Parameters
     ----------
     text : str
@@ -155,7 +156,7 @@ def strip_files_prefix(text):
 def comment_lines(text, prefix='# '):
     """
     Build a Python comment line from input text.
-    
+
     Parameters
     ----------
     text : str
@@ -163,18 +164,34 @@ def comment_lines(text, prefix='# '):
     prefix : str
         Character to append to the start of each line.
     """
-    
+
     #Replace line breaks with line breaks and comment symbols.
     #Also add a comment symbol at the beginning to comment out
     #the first line.
-    return prefix + ('\n'+prefix).join(text.split('\n')) 
+    return prefix + ('\n'+prefix).join(text.split('\n'))
 
+
+def block_string_lines(text, prefix='# '):
+    """
+    Wrap text in a block text quotes.
+
+    Parameters
+    ----------
+    text : str
+        Text to comment out.
+    """
+    quotes = '"""'
+
+    if quotes in text:
+        quotes = "'''"
+
+    return '\n'.join((quotes+text, quotes))
 
 def get_lines(text, start=None,end=None):
     """
-    Split the input text into separate lines and then return the 
+    Split the input text into separate lines and then return the
     lines that the caller is interested in.
-    
+
     Parameters
     ----------
     text : str
@@ -184,10 +201,10 @@ def get_lines(text, start=None,end=None):
     end : int, optional
         Last line to grab from.
     """
-    
+
     # Split the input into lines.
     lines = text.split("\n")
-    
+
     # Return the right lines.
     return "\n".join(lines[start:end]) #re-join
 
@@ -214,7 +231,7 @@ def ipython2python(code):
 
 def posix_path(path):
     """Turn a path into posix-style path/to/etc
-    
+
     Mainly for use in latex on Windows,
     where native Windows paths are not allowed.
     """

--- a/nbconvert/templates/python.tpl
+++ b/nbconvert/templates/python.tpl
@@ -16,5 +16,5 @@
 {% endblock input %}
 
 {% block markdowncell scoped %}
-{{ cell.source | comment_lines }}
+{{ cell.source | block_string_lines }}
 {% endblock markdowncell %}


### PR DESCRIPTION
This pull request changes how markdown cells are written from the Python exporter.  Currently, nbconvert creates Python comments which are not captured by the ast.  This change wraps markdown cells in block quotes when exported to python.

The advantage of this change is that the first markdown cell may be used as both a module docstring and doctest.

<img width="734" alt="screen shot 2018-05-21 at 1 58 22 pm" src="https://user-images.githubusercontent.com/4236275/40322303-ef87f68c-5cff-11e8-8c5a-4830ed73b1bb.png">
