### PR TITLE
No input flag

### DIFF
--- a/nbconvert/filters/tests/test_highlight.py
+++ b/nbconvert/filters/tests/test_highlight.py
@@ -75,8 +75,6 @@ class TestHighlight(TestsBase):
                 ( ht, ('def', )),
                 ( rb, ('def','end'  ) )
                 ]:
-            print(tkns)
-            print(lang)
             root = xml.etree.ElementTree.fromstring(lang)
             self.assertEqual(self._extract_tokens(root,'k'), set(tkns))
 

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -83,7 +83,7 @@ class TestMarkdown(TestsBase):
     def test_pandoc_extra_args(self):
         # pass --no-wrap
         s = '\n'.join([
-            "#latex {{long_line | md2l(['--no-wrap'])}}",
+            "#latex {{long_line | md2l(['--wrap=none'])}}",
             "#rst {{long_line | md2r(['--columns', '5'])}}",
         ])
         long_line = ' '.join(['long'] * 30)

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -114,6 +114,15 @@ nbconvert_flags.update({
         },
         "Exclude input and output prompts from converted document."
         ),
+    'no-input' : (
+        {'TemplateExporter' : {
+            'exclude_input_prompt' : True,
+            'exclude_output_prompt' : True,
+            'exclude_input': True,
+            }
+        },
+        "Exclude input and output prompts from converted document."
+        ),
 })
 
 

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -116,12 +116,12 @@ nbconvert_flags.update({
         ),
     'no-input' : (
         {'TemplateExporter' : {
-            'exclude_input_prompt' : True,
             'exclude_output_prompt' : True,
             'exclude_input': True,
             }
         },
-        "Exclude input and output prompts from converted document."
+        """Exclude input cells and output prompts from converted document. 
+        This mode is ideal for generating code-free reports."""
         ),
 })
 

--- a/nbconvert/templates/latex/report.tplx
+++ b/nbconvert/templates/latex/report.tplx
@@ -22,5 +22,5 @@
 ((* endblock docclass *))
 
 ((* block markdowncell scoped *))
-((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown+tex_math_double_backslash', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex', extra_args=["--chapters"]) )))
+((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown+tex_math_double_backslash', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex', extra_args=["--top-level-division=chapter"]) )))
 ((* endblock markdowncell *))

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -308,7 +308,7 @@ class TestNbConvertApp(TestsBase):
     
     def test_no_prompt(self):
         """
-        Verify that the notebook is converted in place
+        Verify that the html has no prompts when given --no-prompt.
         """
         with self.create_temp_cwd(["notebook1.ipynb"]):
             self.nbconvert('notebook1.ipynb --log-level 0 --no-prompt --to html')
@@ -321,9 +321,46 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile('notebook1.html')
             with open("notebook1.html",'r') as f:
                 text2 = f.read()
-                print(text2)
                 assert "In&nbsp;[" in text2
                 assert "Out[" in text2
+                
+    def test_no_input(self):
+        """
+        Verify that the html has no input when given --no-input.
+        """
+        with self.create_temp_cwd(["notebook1.ipynb"]):
+            self.nbconvert('notebook1.ipynb --log-level 0 --no-input --to html')
+            assert os.path.isfile('notebook1.html')
+            with open("notebook1.html",'r') as f:
+                text = f.read()
+                assert "In&nbsp;[" not in text
+                assert "Out[" not in text
+                assert ('<span class="n">x</span>'
+                        '<span class="p">,</span>'
+                        '<span class="n">y</span>'
+                        '<span class="p">,</span>'
+                        '<span class="n">z</span> '
+                        '<span class="o">=</span> '
+                        '<span class="n">symbols</span>'
+                        '<span class="p">(</span>'
+                        '<span class="s1">&#39;x y z&#39;</span>'
+                        '<span class="p">)</span>') not in text
+            self.nbconvert('notebook1.ipynb --log-level 0 --to html')
+            assert os.path.isfile('notebook1.html')
+            with open("notebook1.html",'r') as f:
+                text2 = f.read()
+                assert "In&nbsp;[" in text2
+                assert "Out[" in text2
+                assert ('<span class="n">x</span>'
+                        '<span class="p">,</span>'
+                        '<span class="n">y</span>'
+                        '<span class="p">,</span>'
+                        '<span class="n">z</span> '
+                        '<span class="o">=</span> '
+                        '<span class="n">symbols</span>'
+                        '<span class="p">(</span>'
+                        '<span class="s1">&#39;x y z&#39;</span>'
+                        '<span class="p">)</span>') in text2
 
     def test_allow_errors(self):
         """
@@ -477,4 +514,3 @@ class TestNbConvertApp(TestsBase):
             self.nbconvert(
                 '--log-level 0 notebook4_jpeg.ipynb --to rst')
             assert fig_exists('notebook4_jpeg_files')
-


### PR DESCRIPTION
This adds a new `--no-input` as talked about in few places. This removes prompts and input areas, leaving only the outputs.

This also adds a new test for this feature and removes some of the warnings and extraneous printing that was being done in our tests. 