### PR TITLE
Support for \mathscr

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -64,6 +64,7 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage[inline]{enumitem} % IRkernel/repr support (it uses the enumerate* environment)
     \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
                                 % normalem makes italics be italics, not underlines
+    \usepackage{mathrsfs}
     ((* endblock packages *))
 
     ((* block definitions *))


### PR DESCRIPTION
MathJax supports \mathscr command according to http://docs.mathjax.org/en/latest/tex.html
It works in notebook however exporting to PDF reports "! Undefined control sequence".
I added commonly used package "mathrsfs" to base template to support it.

This command provides a script font for capital Latin letters.
Description of font itself is here https://ctan.org/pkg/rsfs