### PR TITLE
Add note about local reveal_url_prefix

### DIFF
--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -83,6 +83,9 @@ class SlidesExporter(HTMLExporter):
         For speaker notes to work, this must be a relative path to a local 
         copy of reveal.js: e.g., "reveal.js".
         
+        If a relative path is given, it must be a subdirectory of the
+        current directory (from which the server is run).
+        
         See the usage documentation
         (https://nbconvert.readthedocs.io/en/latest/usage.html#reveal-js-html-slideshow)
         for more details.


### PR DESCRIPTION
I noticed that absolute paths do not work since a URL is constructed from the directory, but this was not clear from the documentation. If someone has a better wording, I'll be glad to change it. 

Also, this should updated in https://nbconvert.readthedocs.io/en/latest/config_options.html but the 'Edit on Github' button is broken.