### PR TITLE
Add export_from_notebook

### DIFF
--- a/nbconvert/exporters/asciidoc.py
+++ b/nbconvert/exporters/asciidoc.py
@@ -23,6 +23,7 @@ class ASCIIDocExporter(TemplateExporter):
         return 'asciidoc'
 
     output_mimetype = 'text/asciidoc'
+    export_from_notebook = "asciidoc"
 
     @default('raw_mimetypes')
     def _raw_mimetypes_default(self):

--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -21,6 +21,7 @@ class LatexExporter(TemplateExporter):
     'template_file' config option.  Place your template in the special "/latex" 
     subfolder of the "../templates" folder.
     """
+    export_from_notebook = "latex"
 
     @default('file_extension')
     def _file_extension_default(self):

--- a/nbconvert/exporters/markdown.py
+++ b/nbconvert/exporters/markdown.py
@@ -13,6 +13,7 @@ class MarkdownExporter(TemplateExporter):
     """
     Exports to a markdown document (.md)
     """
+    export_from_notebook = "markdown"
 
     @default('file_extension')
     def _file_extension_default(self):

--- a/nbconvert/exporters/notebook.py
+++ b/nbconvert/exporters/notebook.py
@@ -26,6 +26,7 @@ class NotebookExporter(Exporter):
         return '.ipynb'
 
     output_mimetype = 'application/json'
+    export_from_notebook = "notebook"
 
     def from_notebook_node(self, nb, resources=None, **kw):
         nb_copy, resources = super(NotebookExporter, self).from_notebook_node(nb, resources, **kw)

--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -44,6 +44,7 @@ class PDFExporter(LatexExporter):
     a temporary directory using the template machinery, and then runs LaTeX
     to create a pdf.
     """
+    export_from_notebook="pdf"
 
     latex_count = Integer(3,
         help="How many times latex will be called."

--- a/nbconvert/exporters/python.py
+++ b/nbconvert/exporters/python.py
@@ -21,3 +21,4 @@ class PythonExporter(TemplateExporter):
         return 'python.tpl'
 
     output_mimetype = 'text/x-python'
+    export_from_notebook = "python"

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -23,6 +23,7 @@ class RSTExporter(TemplateExporter):
         return 'rst.tpl'
 
     output_mimetype = 'text/restructuredtext'
+    export_from_notebook = "rst"
 
     @property
     def default_config(self):

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -14,6 +14,7 @@ class ScriptExporter(TemplateExporter):
     # Caches of already looked-up and instantiated exporters for delegation:
     _exporters = Dict()
     _lang_exporters = Dict()
+    export_form_notebook = "script"
     
     @default('template_file')
     def _template_file_default(self):

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -75,6 +75,8 @@ def prepare(nb):
 class SlidesExporter(HTMLExporter):
     """Exports HTML slides with reveal.js"""
 
+    export_from_notebook = "slides"
+
     reveal_url_prefix = Unicode(
         help="""The URL prefix for reveal.js (version 3.x).
         This defaults to the reveal CDN, but can be any url pointing to a copy 

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -102,6 +102,8 @@ class TemplateExporter(Exporter):
 
     _template_cached = None
 
+    export_from_notebook = "custom"
+
     def _invalidate_template_cache(self, change=None):
         self._template_cached = None
 


### PR DESCRIPTION
I was working on https://github.com/jupyter/notebook/pull/3879 and it
looks like the intended way to determine whether the exporter should
show up in the list generated by the notebook server was by checking
`export_from_notebook`, but it isn't defined for any of the builtin
exporters.

The docs also say this specifies a friendly name for the exporter. In
the PR mentioned above, I used the name defined by the entrypoint to key
the exporter. It sounds like maybe we should use the value in
`export_from_notebook` instead, so I've made them match, but perhaps
it's confusing to have a "name" for the entrypoint in two places.