### PR TITLE
If set, use `nb.metadata.authors` for LaTeX author line

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -152,7 +152,11 @@ This template does not define a docclass, the inheriting class must define this.
     \title{((( nb_title | ascii_only | escape_latex )))}
     ((*- endblock title *))
     ((* block date *))((* endblock date *))
-    ((* block author *))((* endblock author *))
+    ((* block author *))
+    ((* if 'authors' in nb.metadata *))
+    \author{((( nb.metadata.authors | join(', ', attribute='name') )))}
+    ((* endif *))
+    ((* endblock author *))
     ((* endblock definitions *))
 
     ((* block commands *))


### PR DESCRIPTION
There's an authors metadata field that's part of the Notebook spec. If it's set, this pull request uses it to set the author line for LaTeX export.