### PR TITLE
Release changelog 5.4

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,31 +14,72 @@ Significant Changes
 Deprecations
 ++++++++++++
 
+Python 3.3 support was dropped. The version of python is no longer common and new versions have many fixes and interface improvements that warrant the change in support.
+
+See :ghpull:`843` for implementation details.
+
 Changes in how we handle metadata
 +++++++++++++++++++++++++++++++++
 
-# NOTE describe metadata changes (867, 703, 685, 672)
-## 685 allows you to set image filename on export
-## 684 force_raise_errors
+There were a few new metadata fields which are now respected in nbconvert.
+
+``nb.metadata.authors`` metadata attribute will be respected in latex exports. Multiple authers will be added with ``,`` separation against their names.
+
+``nb.metadata.title`` will be respected ahead of ``nb.metadata.name`` for title assignment. This better matches with the notebook format.
+
+``nb.metadata.filename`` will override the default output_filename_template when extracting notebook resources in the ``ExtractOutputPreprocessor``. Helpful for when you want to consistently fix to a particular output filename, espcially when you need to set image filenames for your exports.
+
+The ``raises-exception`` cell tag (``nb.cells[].metadata.tags[raises-exception]``), or ``nb.metadata.allow_errors`` for all ells, now allows for cell exceptions to not halt execution as respected in nbval and other notebook interfaces. This feature is toggleable with the ``force_raise_errors`` configuration option.
+Errors from executing the notebook can be allowed with a ``raises-exception`` tag on a single cell, or the ``allow_errors`` configurable option for all cells. An allowed error will be recorded in notebook output, and execution will continue.
+If an error occurs when it is not explicitly allowed, a ``CellExecutionError`` will be raised.
+If ``force_raise_errors`` is True, ``CellExecutionError`` will be raised for any error that occurs while executing the notebook. This overrides both the ``allow_errors`` option and the `raises-exception` cell tag.
+
+See :ghpull:`867`, :ghpull:`703`, :ghpull:`685`, :ghpull:`672`, and :ghpull:`684` for implementation changes.
 
 Configurable kernel managers when executing notebooks
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-# Pass configurable kernel manager to execute nbfunc + preprocessor (852)
+
+The kernel manager can now be optinally passed into the ``ExecutePreprocessor.preprocess`` and the ``executenb`` functions as the kwarg ``km``. This means that the kernel can be configured as desired before beginning preprocessing.
+
+This is useful for executing in a context where the kernel has external dependencies that need to be set to non-default values. An example of this might be a Spark kernel where you wish to configure the spark cluster location ahead of time without building a new kernel.
+
+See :ghpull:`852` for implementation changes.
 
 Surfacing exporters in front-ends
 +++++++++++++++++++++++++++++++++
- 
-# Export from notebook + custom exporters allows classic notebook to expose download as (759, 864)
+
+Custom exporters are now exposed for front-ends, including classic notebook, to consume. As an example, this means that latex exporter will be made available for latex 'text/latex' mimetype for the Download As interface.
+
+See :ghpull:`759` and :ghpull:`864` for implementation changes.
 
 Raw Templates
 +++++++++++++
 
-# Raw template (675)
+Template exporters can now be assigned raw templates as string attributes by setting the raw_template variable.
+
+.. code-block::
+
+  class AttrExporter(TemplateExporter):
+      # If the class has a special template and you want it defined within the class
+      raw_template = """{%- extends 'rst.tpl' -%}
+  {%- block in_prompt -%}
+  raw template
+  {%- endblock in_prompt -%}
+      """
+  exporter_attr = AttrExporter()
+  output_attr, _ = exporter_attr.from_notebook_node(nb)
+  assert "raw template" in output_attr
+
+See :ghpull:`675` for implementation changes.
 
 New command line flags
 ++++++++++++++++++++++
-- No input flag (``--no-input``) :ghpull:`825`
-- Add alias ``--to ipynb`` for notebook exporter :ghpull:`873`
+
+The ``--no-input`` flag will apply metadata changes to input cells to mark them as hidden. This is great for notebooks which generate "reports" where you want the code that was executed to not appear by default.
+
+An alias for ``notebook`` was added to exporter commands. Now ``--to ipynb`` will behave as ``--to notebook`` does.
+
+See :ghpull:`825` and :ghpull:`873` for implementation changes.
 
 Comprehensive notes
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -43,6 +43,8 @@ The kernel manager can now be optionally passed into the ``ExecutePreprocessor.p
 
 This is useful for executing in a context where the kernel has external dependencies that need to be set to non-default values. An example of this might be a Spark kernel where you wish to configure the Spark cluster location ahead of time without building a new kernel.
 
+Overall the ExecutePreprocessor has been reworked to make it easier to use. Future releases will continue this trend to make this section of the code more inheritable and reusable by others. We encourage you read the source code for this version if you're interested in the detailed improvements.
+
 See :ghpull:`852` for implementation changes.
 
 Surfacing exporters in front-ends

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,23 +23,23 @@ Changes in how we handle metadata
 
 There were a few new metadata fields which are now respected in nbconvert.
 
-``nb.metadata.authors`` metadata attribute will be respected in latex exports. Multiple authers will be added with ``,`` separation against their names.
+``nb.metadata.authors`` metadata attribute will be respected in latex exports. Multiple authors will be added with ``,`` separation against their names.
 
 ``nb.metadata.title`` will be respected ahead of ``nb.metadata.name`` for title assignment. This better matches with the notebook format.
 
-``nb.metadata.filename`` will override the default output_filename_template when extracting notebook resources in the ``ExtractOutputPreprocessor``. Helpful for when you want to consistently fix to a particular output filename, espcially when you need to set image filenames for your exports.
+``nb.metadata.filename`` will override the default output_filename_template when extracting notebook resources in the ``ExtractOutputPreprocessor``. The attribute is helpful for when you want to consistently fix to a particular output filename, especially when you need to set image filenames for your exports.
 
-The ``raises-exception`` cell tag (``nb.cells[].metadata.tags[raises-exception]``), or ``nb.metadata.allow_errors`` for all ells, now allows for cell exceptions to not halt execution as respected in nbval and other notebook interfaces. This feature is toggleable with the ``force_raise_errors`` configuration option.
+The ``raises-exception`` cell tag (``nb.cells[].metadata.tags[raises-exception]``) allows for cell exceptions to not halt execution. The tag is respected in the same way by nbval and other notebook interfaces. ``nb.metadata.allow_errors`` will apply this rule for all cells. This feature is toggleable with the ``force_raise_errors`` configuration option.
 Errors from executing the notebook can be allowed with a ``raises-exception`` tag on a single cell, or the ``allow_errors`` configurable option for all cells. An allowed error will be recorded in notebook output, and execution will continue.
 If an error occurs when it is not explicitly allowed, a ``CellExecutionError`` will be raised.
-If ``force_raise_errors`` is True, ``CellExecutionError`` will be raised for any error that occurs while executing the notebook. This overrides both the ``allow_errors`` option and the `raises-exception` cell tag.
+If ``force_raise_errors`` is True, ``CellExecutionError`` will be raised for any error that occurs while executing the notebook. This overrides both the ``allow_errors`` option and the `raises-exception` cell tags.
 
 See :ghpull:`867`, :ghpull:`703`, :ghpull:`685`, :ghpull:`672`, and :ghpull:`684` for implementation changes.
 
 Configurable kernel managers when executing notebooks
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-The kernel manager can now be optinally passed into the ``ExecutePreprocessor.preprocess`` and the ``executenb`` functions as the kwarg ``km``. This means that the kernel can be configured as desired before beginning preprocessing.
+The kernel manager can now be optionally passed into the ``ExecutePreprocessor.preprocess`` and the ``executenb`` functions as the kwarg ``km``. This means that the kernel can be configured as desired before beginning preprocessing.
 
 This is useful for executing in a context where the kernel has external dependencies that need to be set to non-default values. An example of this might be a Spark kernel where you wish to configure the spark cluster location ahead of time without building a new kernel.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -40,9 +40,11 @@ New command line flags
 - No input flag (``--no-input``) :ghpull:`825`
 - Add alias ``--to ipynb`` for notebook exporter :ghpull:`873`
 
+Comprehensive notes
+~~~~~~~~~~~~~~~~~~~
 
 New Features
-~~~~~~~~~~~~
+++++++++++++
 - No input flag (``--no-input``) :ghpull:`825`
 - Add alias ``--to ipynb`` for notebook exporter :ghpull:`873`
 - Add ``export_from_notebook`` :ghpull:`864`
@@ -65,11 +67,11 @@ New Features
 - If ``nb.metadata.title`` is set, default to that for notebook :ghpull:`672`
 
 Deprecations
-~~~~~~~~~~~~
+++++++++++++
 - Drop support for python 3.3 :ghpull:`843`
 
 Fixing Problems
-~~~~~~~~~~~~~~~
++++++++++++++++
 - Fix api break :ghpull:`872`
 - Don't remove empty cells by default :ghpull:`784`
 - Handle attached images in html converter :ghpull:`780`
@@ -88,7 +90,7 @@ Fixing Problems
 - Fixes for traitlets 4.1 deprecation warnings :ghpull:`695`
 
 Testing, Docs, and Builds
-~~~~~~~~~~~~~~~~~~~~~~~~~
++++++++++++++++++++++++++
 - A couple of typos :ghpull:`870`
 - Add python_requires metadata. :ghpull:`871`
 - Document ``--inplace`` command line flag. :ghpull:`839`

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,21 +27,21 @@ There were a few new metadata fields which are now respected in nbconvert.
 
 ``nb.metadata.title`` will be respected ahead of ``nb.metadata.name`` for title assignment. This better matches with the notebook format.
 
-``nb.metadata.filename`` will override the default output_filename_template when extracting notebook resources in the ``ExtractOutputPreprocessor``. The attribute is helpful for when you want to consistently fix to a particular output filename, especially when you need to set image filenames for your exports.
+``nb.metadata.filename`` will override the default ``output_filename_template`` when extracting notebook resources in the ``ExtractOutputPreprocessor``. The attribute is helpful for when you want to consistently fix to a particular output filename, especially when you need to set image filenames for your exports.
 
-The ``raises-exception`` cell tag (``nb.cells[].metadata.tags[raises-exception]``) allows for cell exceptions to not halt execution. The tag is respected in the same way by nbval and other notebook interfaces. ``nb.metadata.allow_errors`` will apply this rule for all cells. This feature is toggleable with the ``force_raise_errors`` configuration option.
+The ``raises-exception`` cell tag (``nb.cells[].metadata.tags[raises-exception]``) allows for cell exceptions to not halt execution. The tag is respected in the same way by `nbval <https://github.com/computationalmodelling/nbval>`_ and other notebook interfaces. ``nb.metadata.allow_errors`` will apply this rule for all cells. This feature is toggleable with the ``force_raise_errors`` configuration option.
 Errors from executing the notebook can be allowed with a ``raises-exception`` tag on a single cell, or the ``allow_errors`` configurable option for all cells. An allowed error will be recorded in notebook output, and execution will continue.
 If an error occurs when it is not explicitly allowed, a ``CellExecutionError`` will be raised.
-If ``force_raise_errors`` is True, ``CellExecutionError`` will be raised for any error that occurs while executing the notebook. This overrides both the ``allow_errors`` option and the `raises-exception` cell tags.
+If ``force_raise_errors`` is True, ``CellExecutionError`` will be raised for any error that occurs while executing the notebook. This overrides both the ``allow_errors`` option and the ``raises-exception`` cell tags.
 
 See :ghpull:`867`, :ghpull:`703`, :ghpull:`685`, :ghpull:`672`, and :ghpull:`684` for implementation changes.
 
 Configurable kernel managers when executing notebooks
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-The kernel manager can now be optionally passed into the ``ExecutePreprocessor.preprocess`` and the ``executenb`` functions as the kwarg ``km``. This means that the kernel can be configured as desired before beginning preprocessing.
+The kernel manager can now be optionally passed into the ``ExecutePreprocessor.preprocess`` and the ``executenb`` functions as the keyword argument ``km``. This means that the kernel can be configured as desired before beginning preprocessing.
 
-This is useful for executing in a context where the kernel has external dependencies that need to be set to non-default values. An example of this might be a Spark kernel where you wish to configure the spark cluster location ahead of time without building a new kernel.
+This is useful for executing in a context where the kernel has external dependencies that need to be set to non-default values. An example of this might be a Spark kernel where you wish to configure the Spark cluster location ahead of time without building a new kernel.
 
 See :ghpull:`852` for implementation changes.
 
@@ -55,7 +55,7 @@ See :ghpull:`759` and :ghpull:`864` for implementation changes.
 Raw Templates
 +++++++++++++
 
-Template exporters can now be assigned raw templates as string attributes by setting the raw_template variable.
+Template exporters can now be assigned raw templates as string attributes by setting the ``raw_template`` variable.
 
 .. code-block::
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,16 +9,40 @@ Changes in nbconvert
 `5.4 on Github <https://github.com/jupyter/nbconvert/milestones/5.4>`__
 
 Significant Changes
-+++++++++++++++++++
-# NOTE describe metadata changes (867, 703, 685)
+~~~~~~~~~~~~~~~~~~~
+
+Deprecations
+++++++++++++
+
+Changes in how we handle metadata
++++++++++++++++++++++++++++++++++
+
+# NOTE describe metadata changes (867, 703, 685, 672)
 ## 685 allows you to set image filename on export
 ## 684 force_raise_errors
+
+Configurable kernel managers when executing notebooks
++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Pass configurable kernel manager to execute nbfunc + preprocessor (852)
+
+Surfacing exporters in front-ends
++++++++++++++++++++++++++++++++++
+ 
 # Export from notebook + custom exporters allows classic notebook to expose download as (759, 864)
+
+Raw Templates
++++++++++++++
+
 # Raw template (675)
 
+New command line flags
+++++++++++++++++++++++
+- No input flag (``--no-input``) :ghpull:`825`
+- Add alias ``--to ipynb`` for notebook exporter :ghpull:`873`
+
+
 New Features
-++++++++++++
+~~~~~~~~~~~~
 - No input flag (``--no-input``) :ghpull:`825`
 - Add alias ``--to ipynb`` for notebook exporter :ghpull:`873`
 - Add ``export_from_notebook`` :ghpull:`864`
@@ -39,14 +63,13 @@ New Features
 - Simple API for in-memory templates :ghpull:`674` :ghpull:`675`
 - Set BIBINPUTS and BSTINPUTS environment variables when making PDF :ghpull:`676`
 - If ``nb.metadata.title`` is set, default to that for notebook :ghpull:`672`
-- Explicitly exclude or include all files in Manifest. :ghpull:`670`
 
 Deprecations
-++++++++++++
+~~~~~~~~~~~~
 - Drop support for python 3.3 :ghpull:`843`
 
 Fixing Problems
-+++++++++++++++
+~~~~~~~~~~~~~~~
 - Fix api break :ghpull:`872`
 - Don't remove empty cells by default :ghpull:`784`
 - Handle attached images in html converter :ghpull:`780`
@@ -65,7 +88,7 @@ Fixing Problems
 - Fixes for traitlets 4.1 deprecation warnings :ghpull:`695`
 
 Testing, Docs, and Builds
-+++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~
 - A couple of typos :ghpull:`870`
 - Add python_requires metadata. :ghpull:`871`
 - Document ``--inplace`` command line flag. :ghpull:`839`
@@ -82,6 +105,7 @@ Testing, Docs, and Builds
 - Upgrade mistune dependency :ghpull:`705`
 - add feature to improve docs by having links to prs :ghpull:`662`
 - Update notebook CSS from version 4.3.0 to 5.1.0 :ghpull:`682`
+- Explicitly exclude or include all files in Manifest. :ghpull:`670`
 
 5.3.1
 -----

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -48,7 +48,7 @@ See :ghpull:`852` for implementation changes.
 Surfacing exporters in front-ends
 +++++++++++++++++++++++++++++++++
 
-Custom exporters are now exposed for front-ends, including classic notebook, to consume. As an example, this means that latex exporter will be made available for latex 'text/latex' mimetype for the Download As interface.
+Exporters are now exposed for front-ends to consume, including classic notebook. As an example, this means that latex exporter will be made available for latex 'text/latex' media type from the Download As interface.
 
 See :ghpull:`759` and :ghpull:`864` for implementation changes.
 
@@ -75,7 +75,7 @@ See :ghpull:`675` for implementation changes.
 New command line flags
 ++++++++++++++++++++++
 
-The ``--no-input`` flag will apply metadata changes to input cells to mark them as hidden. This is great for notebooks which generate "reports" where you want the code that was executed to not appear by default.
+The ``--no-input`` will hide input cells on export. This is great for notebooks which generate "reports" where you want the code that was executed to not appear by default in the extracts.
 
 An alias for ``notebook`` was added to exporter commands. Now ``--to ipynb`` will behave as ``--to notebook`` does.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,55 +8,80 @@ Changes in nbconvert
 ---
 `5.4 on Github <https://github.com/jupyter/nbconvert/milestones/5.4>`__
 
-- Document ``--inplace`` command line flag. :ghpull:`839`
-- Don't remove empty cells by default :ghpull:`784`
-- Handle embedded images in html converter :ghpull:`780`
-- If set, use ``nb.metadata.authors`` for LaTeX author line :ghpull:`867`
+Significant Changes
++++++++++++++++++++
+# NOTE describe metadata changes (867, 703, 685)
+## 685 allows you to set image filename on export
+## 684 force_raise_errors
+# Pass configurable kernel manager to execute nbfunc + preprocessor (852)
+# Export from notebook + custom exporters allows classic notebook to expose download as (759, 864)
+# Raw template (675)
+
+New Features
+++++++++++++
+- No input flag (``--no-input``) :ghpull:`825`
+- Add alias ``--to ipynb`` for notebook exporter :ghpull:`873`
 - Add ``export_from_notebook`` :ghpull:`864`
-- Fix minor typo in ``usage.rst`` :ghpull:`863`
+- If set, use ``nb.metadata.authors`` for LaTeX author line :ghpull:`867`
 - Populate language_info metadata when executing :ghpull:`860`
-- No need to check for the channels already running :ghpull:`862`
-- Update ``font-awesome`` version for slides :ghpull:`793`
 - Support for ``\mathscr`` :ghpull:`830`
-- Add note about local ``reveal_url_prefix`` :ghpull:`844`
-- Properly treat JSON data :ghpull:`847`
-- Move ``onlyif_cmds_exist`` decorator to test-specific utils :ghpull:`854`
 - Allow the execute preprocessor to make use of an existing kernel :ghpull:`852`
+- Refactor ExecutePreprocessor :ghpull:`816`
 - Update widgets CDN for ipywidgets 7 w/fallback :ghpull:`792`
-- Pass config to kernel from ExecutePreprocessor for configurable kernels :ghpull:`816`
-- Drop support for python 3.3 :ghpull:`843`
-- Include LICENSE file in wheels :ghpull:`827`
-- Check for too recent of pandoc version :ghpull:`814`
-- Ppdate log.warn (deprecated) to log.warning :ghpull:`804`
-- Cleanup notebook.tex during PDF generation :ghpull:`768`
 - Add support for adding custom exporters to the "Download as" menu. :ghpull:`759`
-- Removing more nose remnants via dependencies. :ghpull:`758`
-- Windows unicode error fixed, nosetest added to setup.py :ghpull:`757`
-- Added Ubuntu Linux Instructions :ghpull:`724`
 - Enable ANSI underline and inverse :ghpull:`696`
-- Remove offline statement and add some clarifications in slides docs :ghpull:`743`
 - Update notebook css to 5.4.0 :ghpull:`748`
 - Change default for slides to direct to the reveal cdn rather than locally :ghpull:`732`
-- Better content hiding; template & testing improvements :ghpull:`734`
-- Skip executing empty code cells :ghpull:`739`
-- Fix Jinja syntax in custom template example. :ghpull:`738`
-- Fix for an issue with empty math block :ghpull:`729`
 - Use "title" instead of "name" for metadata to match the notebook format :ghpull:`703`
-- Linkify PR number :ghpull:`710`
 - Img filename metadata :ghpull:`685`
-- Added shebang for python :ghpull:`694`
-- Upgrade mistune dependency :ghpull:`705`
 - Added MathJax compatibility definitions :ghpull:`687`
-- Fixes for traitlets 4.1 deprecation warnings :ghpull:`695`
 - Per cell exception :ghpull:`684`
-- add feature to improve docs by having links to prs :ghpull:`662`
-- Raw template as settable attribute :ghpull:`675`
-- Update notebook CSS from version 4.3.0 to 5.1.0 :ghpull:`682`
-- Update notebook CSS from 4.3.0 to 5.1.0 :ghpull:`1`
+- Simple API for in-memory templates :ghpull:`674` :ghpull:`675`
 - Set BIBINPUTS and BSTINPUTS environment variables when making PDF :ghpull:`676`
 - If ``nb.metadata.title`` is set, default to that for notebook :ghpull:`672`
 - Explicitly exclude or include all files in Manifest. :ghpull:`670`
 
+Deprecations
+++++++++++++
+- Drop support for python 3.3 :ghpull:`843`
+
+Fixing Problems
++++++++++++++++
+- Fix api break :ghpull:`872`
+- Don't remove empty cells by default :ghpull:`784`
+- Handle attached images in html converter :ghpull:`780`
+- No need to check for the channels already running :ghpull:`862`
+- Update ``font-awesome`` version for slides :ghpull:`793`
+- Properly treat JSON data :ghpull:`847`
+- Skip executing empty code cells :ghpull:`739`
+- Ppdate log.warn (deprecated) to log.warning :ghpull:`804`
+- Cleanup notebook.tex during PDF generation :ghpull:`768`
+- Windows unicode error fixed, nosetest added to setup.py :ghpull:`757`
+- Better content hiding; template & testing improvements :ghpull:`734`
+- Fix Jinja syntax in custom template example. :ghpull:`738`
+- Fix for an issue with empty math block :ghpull:`729`
+- Add parser for Multiline math for LaTeX blocks :ghpull:`716` :ghpull:`717`
+- Use defusedxml to parse potentially untrusted XML :ghpull:`708`
+- Fixes for traitlets 4.1 deprecation warnings :ghpull:`695`
+
+Testing, Docs, and Builds
++++++++++++++++++++++++++
+- A couple of typos :ghpull:`870`
+- Add python_requires metadata. :ghpull:`871`
+- Document ``--inplace`` command line flag. :ghpull:`839`
+- Fix minor typo in ``usage.rst`` :ghpull:`863`
+- Add note about local ``reveal_url_prefix`` :ghpull:`844`
+- Move ``onlyif_cmds_exist`` decorator to test-specific utils :ghpull:`854`
+- Include LICENSE file in wheels :ghpull:`827`
+- Added Ubuntu Linux Instructions :ghpull:`724`
+- Check for too recent of pandoc version :ghpull:`814` :ghpull:`872`
+- Removing more nose remnants via dependencies. :ghpull:`758`
+- Remove offline statement and add some clarifications in slides docs :ghpull:`743`
+- Linkify PR number :ghpull:`710`
+- Added shebang for python :ghpull:`694`
+- Upgrade mistune dependency :ghpull:`705`
+- add feature to improve docs by having links to prs :ghpull:`662`
+- Update notebook CSS from version 4.3.0 to 5.1.0 :ghpull:`682`
 
 5.3.1
 -----


### PR DESCRIPTION
Changelog improvements for release. We added a few missing additions from the release PR https://github.com/jupyter/nbconvert/pull/869 and are working to describe the major changes more in-depth. This will be the contents of the google group email as well.

Added a few reviewers because there's some some limitations on bandwidth for reviewing and getting it finalized.