### PR TITLE
Add option to overwrite the highlight_code filter

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -90,8 +90,11 @@ class HTMLExporter(TemplateExporter):
     def from_notebook_node(self, nb, resources=None, **kw):
         langinfo = nb.metadata.get('language_info', {})
         lexer = langinfo.get('pygments_lexer', langinfo.get('name', None))
-        self.register_filter('highlight_code',
-                             Highlight2HTML(pygments_lexer=lexer, parent=self))
+        highlight_code = Highlight2HTML(pygments_lexer=lexer, parent=self)
+        if "highlight_code" in self.filters:
+            highlight_code = self.filters["highlight_code"]
+        self.register_filter('highlight_code', highlight_code)
+        
         output, resources = super(HTMLExporter, self).from_notebook_node(nb, resources, **kw)
         att_output = self.process_attachments(nb, output)
         return att_output, resources

--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -78,8 +78,11 @@ class LatexExporter(TemplateExporter):
     def from_notebook_node(self, nb, resources=None, **kw):
         langinfo = nb.metadata.get('language_info', {})
         lexer = langinfo.get('pygments_lexer', langinfo.get('name', None))
-        self.register_filter('highlight_code',
-                             Highlight2Latex(pygments_lexer=lexer, parent=self))
+        highlight_code = Highlight2Latex(pygments_lexer=lexer, parent=self)
+        if "highlight_code" in self.filters:
+            highlight_code = self.filters["highlight_code"]
+        self.register_filter('highlight_code', highlight_code)
+        
         return super(LatexExporter, self).from_notebook_node(nb, resources, **kw)
 
     def _create_environment(self):


### PR DESCRIPTION
Currently the `highlight_code` filter is created on the exporter `from_notebook_node` function so it cannot be overwritten the `filters` trait.

