### PR TITLE
DOC: Add missing language specification to code-block

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -59,7 +59,7 @@ Raw Templates
 
 Template exporters can now be assigned raw templates as string attributes by setting the ``raw_template`` variable.
 
-.. code-block::
+.. code-block:: python
 
   class AttrExporter(TemplateExporter):
       # If the class has a special template and you want it defined within the class


### PR DESCRIPTION
See http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block

I'm actually wondering why this is only a Sphinx warning (rather than an error), because it seems to silently remove the code block from the resulting page: https://nbconvert.readthedocs.io/en/5.4/changelog.html#raw-templates