### PR TITLE
WIP Recreate old behaviour of ExecutePreprocessor(kernel_name="")

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -254,13 +254,15 @@ class ExecutePreprocessor(Preprocessor):
         # Because of an old API, an empty kernel string should be interpreted as indicating
         # that you want to use the notebook's metadata specified kernel.
         # We use find_kernel_name to do this.
-        if self.kernel_name == u"":
-            self.kernel_name = find_kernel_name(self.nb)
+        if not self.kernel_name:
+            kernel_name = find_kernel_name(self.nb)
             warnings.warn("Setting kernel_name to '' as a way to use the kernel in a notebook metadata's is deprecated as of 5.4. \n"
                           "Instead, do not set kernel_name, this is now default behaviour.", DeprecationWarning, stacklevel=2)
+        else:
+            kernel_name = self.kernel_name
             
             
-        km = self.kernel_manager_class(kernel_name=self.kernel_name,
+        km = self.kernel_manager_class(kernel_name=kernel_name,
                                        config=self.config)
         km.start_kernel(extra_arguments=self.extra_arguments, **kwargs)
 

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -556,20 +556,6 @@ class ExecutePreprocessor(Preprocessor):
 
         return exec_reply, outs
 
-def find_kernel_name(nb):
-    """This is a utility that finds kernel names from notebook metadata.
-    
-    Parameters
-    ----------
-    nb : NotebookNode
-        The notebook that has a kernelspec defined in its metadata.
-
-    Returns
-    -------
-    kernel_name: str
-        The string representing the kernel name found in the metadata.
-    """
-    return nb.metadata.get('kernelspec', {}).get('name', 'python')
 
 def executenb(nb, cwd=None, km=None, **kwargs):
     """Execute a notebook's code, updating outputs within the notebook object.

--- a/nbconvert/preprocessors/tests/files/UnicodePy3.ipynb
+++ b/nbconvert/preprocessors/tests/files/UnicodePy3.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u2603\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('\u2603')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -21,6 +21,8 @@ import pytest
 from .base import PreprocessorTestsBase
 from ..execute import ExecutePreprocessor, CellExecutionError, executenb, find_kernel_name
 
+from jupyter_client.kernelspec import KernelSpecManager
+
 from nbconvert.filters import strip_ansi
 from testpath import modified_env
 from ipython_genutils.py3compat import string_types
@@ -150,6 +152,19 @@ class TestExecute(PreprocessorTestsBase):
         res = self.build_resources()
         res['metadata']['path'] = ''
         input_nb, output_nb = self.run_notebook(filename, {}, res)
+        self.assert_notebooks_equal(input_nb, output_nb)
+    
+    @pytest.mark.xfail("python3" not in KernelSpecManager().find_kernel_specs(),
+                        reason="requires a python3 kernelspec")
+    def test_empty_kernel_name(self):
+        """Can kernel in nb metadata be found when an empty string is passed?
+        
+        Note: this pattern should be discouraged in practice.
+        Passing in no kernel_name to ExecutePreprocessor is preferable.
+        """
+        filename = os.path.join(current_dir, 'files', 'UnicodePy3.ipynb')
+        res = self.build_resources()
+        input_nb, output_nb = self.run_notebook(filename, {"kernel_name": ""}, res)
         self.assert_notebooks_equal(input_nb, output_nb)
 
     def test_disable_stdin(self):

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -19,7 +19,7 @@ import sys
 import pytest
 
 from .base import PreprocessorTestsBase
-from ..execute import ExecutePreprocessor, CellExecutionError, executenb
+from ..execute import ExecutePreprocessor, CellExecutionError, executenb, find_kernel_name
 
 from nbconvert.filters import strip_ansi
 from testpath import modified_env
@@ -265,6 +265,15 @@ class TestExecute(PreprocessorTestsBase):
         for method, call_count in expected:
             self.assertNotEqual(call_count, 0, '{} was called'.format(method))
 
+    def test_find_kernel_name(self):
+        current_dir = os.path.dirname(__file__)
+        filename = os.path.join(current_dir, 'files', 'UnicodePy3.ipynb')
+
+        with io.open(filename) as f:
+            input_nb = nbformat.read(f, 4)
+        
+        assert find_kernel_name(input_nb) == "python3"
+        
     def test_execute_function(self):
         # Test the executenb() convenience API
         current_dir = os.path.dirname(__file__)

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -19,7 +19,7 @@ import sys
 import pytest
 
 from .base import PreprocessorTestsBase
-from ..execute import ExecutePreprocessor, CellExecutionError, executenb, find_kernel_name
+from ..execute import ExecutePreprocessor, CellExecutionError, executenb
 
 from testpath import modified_env
 from traitlets import TraitError
@@ -283,15 +283,6 @@ class TestExecute(PreprocessorTestsBase):
         for method, call_count in expected:
             self.assertNotEqual(call_count, 0, '{} was called'.format(method))
 
-    def test_find_kernel_name(self):
-        current_dir = os.path.dirname(__file__)
-        filename = os.path.join(current_dir, 'files', 'UnicodePy3.ipynb')
-
-        with io.open(filename) as f:
-            input_nb = nbformat.read(f, 4)
-        
-        assert find_kernel_name(input_nb) == "python3"
-        
     def test_execute_function(self):
         # Test the executenb() convenience API
         current_dir = os.path.dirname(__file__)

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -21,11 +21,12 @@ import pytest
 from .base import PreprocessorTestsBase
 from ..execute import ExecutePreprocessor, CellExecutionError, executenb, find_kernel_name
 
+from testpath import modified_env
+from traitlets import TraitError
 from jupyter_client.kernelspec import KernelSpecManager
+from ipython_genutils.py3compat import string_types
 
 from nbconvert.filters import strip_ansi
-from testpath import modified_env
-from ipython_genutils.py3compat import string_types
 
 addr_pat = re.compile(r'0x[0-9a-f]{7,9}')
 ipython_input_pat = re.compile(r'<ipython-input-\d+-[0-9a-f]+>')
@@ -160,12 +161,14 @@ class TestExecute(PreprocessorTestsBase):
         """Can kernel in nb metadata be found when an empty string is passed?
         
         Note: this pattern should be discouraged in practice.
-        Passing in no kernel_name to ExecutePreprocessor is preferable.
+        Passing in no kernel_name to ExecutePreprocessor is recommended instead.
         """
         filename = os.path.join(current_dir, 'files', 'UnicodePy3.ipynb')
         res = self.build_resources()
         input_nb, output_nb = self.run_notebook(filename, {"kernel_name": ""}, res)
         self.assert_notebooks_equal(input_nb, output_nb)
+        with pytest.raises(TraitError):
+            input_nb, output_nb = self.run_notebook(filename, {"kernel_name": None}, res)
 
     def test_disable_stdin(self):
         """Test disabling standard input"""


### PR DESCRIPTION
This fixes #878 and https://github.com/spatialaudio/nbsphinx/issues/202.

We had an API before that allowed passing an empty string as your kernel name, which it would then fall back on getting the kernel name from the notebook metadata.

This is now the actual default behaviour, and before this PR setting `kernel_name=""` would overwrite this default. This reintroduces the fall-back as well as a warning that this behaviour shouldn't be used (you can pass no value to `kernel_name` and you will get the same behaviour). 

To ensure the same behaviour in both cases, it introduces the `find_kernel_name` API, which is then used in both the default and fallback mechanisms. 

This also introduces 2 tests and a new notebook file to be tested. In order to ensure that the functionality works I'm specifying a python3 kernel, which cannot be guaranteed to exist, so we have an expected fail in the case where there is no python3 kernel.