### PR TITLE
Expose pygments styles

### DIFF
--- a/docs/source/highlighting.rst
+++ b/docs/source/highlighting.rst
@@ -1,0 +1,62 @@
+Customizing Syntax Highlighting
+===============================
+
+Under the hood, nbconvert uses pygments to highlight code. Both pdf and html exporting support 
+changing the highlighting style.
+
+Using Builtin styles
+--------------------
+Pygments has a number of builtin styles available. To use them, we just need to set the style setting 
+in the relevant preprocessor.
+
+To change the html highlighting export with:
+
+.. code-block:: bash
+
+    jupyter nbconvert --to html notebook.ipynb --CSSHTMLHeaderPreprocessor.style=<name>
+
+To change pdf and latex highlighting export with:
+
+.. code-block:: bash
+
+    jupyter nbconvert --to pdf notebook.ipynb --LatexPreprocessor.style=<name>
+
+where ``<name>`` is the name of the pygments style. Available styles may vary from system to system.
+You can find all available styles with:
+
+.. code-block:: bash
+
+    pygmentize -L styles
+
+from a terminal or
+
+.. code-block:: python
+
+    from pygments.styles import get_all_styles
+    print(list(get_all_styles()))
+
+from python.
+
+You can preview all the styles from an environment that can display html like jupyter notebook with:
+
+.. code-block:: python
+
+    from pygments.styles import get_all_styles
+    from pygments.formatters import Terminal256Formatter
+    from pygments.lexers import PythonLexer
+    from pygments import highlight
+
+    code = """
+    import os
+    def function(test=1):
+        if test in [3,4]:
+          print(test)
+    """
+    for style in get_all_styles():
+        highlighted_code = highlight(code, PythonLexer(), Terminal256Formatter(style=style))
+        print(f"{style}:\n{highlighted_code}")
+
+Making your own styles
+----------------------
+To make your own style you must subclass ``pygments.styles.Style``, and then you must register your new style with Pygments using
+their pluggin system. This is explained in detail in the `Pygments documentation <http://pygments.org/docs/styles/>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,7 @@ batch of notebook files to another format.
    config_options
    customizing
    external_exporters
+   highlighting
 
 .. toctree::
    :maxdepth: 2

--- a/nbconvert/preprocessors/csshtmlheader.py
+++ b/nbconvert/preprocessors/csshtmlheader.py
@@ -28,6 +28,10 @@ class CSSHTMLHeaderPreprocessor(Preprocessor):
                               help="CSS highlight class identifier"
     ).tag(config=True)
 
+    style = Unicode('default',
+            help='Name of the pygments style to use'
+    ).tag(config=True)
+
     def __init__(self, *pargs, **kwargs):
         Preprocessor.__init__(self, *pargs, **kwargs)
         self._default_css_hash = None
@@ -70,7 +74,7 @@ class CSSHTMLHeaderPreprocessor(Preprocessor):
             header.append(f.read())
 
         # Add pygments CSS
-        formatter = HtmlFormatter()
+        formatter = HtmlFormatter(style=self.style)
         pygments_css = formatter.get_style_defs(self.highlight_class)
         header.append(pygments_css)
 

--- a/nbconvert/preprocessors/latex.py
+++ b/nbconvert/preprocessors/latex.py
@@ -49,4 +49,5 @@ class LatexPreprocessor(Preprocessor):
         
         resources.setdefault("latex", {})
         resources["latex"].setdefault("pygments_definitions", LatexFormatter(style=self.style).get_style_defs())
+        resources["latex"].setdefault("pygments_style_name", self.style)
         return nb, resources

--- a/nbconvert/preprocessors/latex.py
+++ b/nbconvert/preprocessors/latex.py
@@ -16,6 +16,7 @@ they are converted.
 from __future__ import print_function, absolute_import
 
 from .base import Preprocessor
+from traitlets import Unicode
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -27,6 +28,10 @@ class LatexPreprocessor(Preprocessor):
     Mainly populates the `latex` key in the resources dict,
     adding definitions for pygments highlight styles.
     """
+
+    style = Unicode('default',
+            help='Name of the pygments style to use'
+    ).tag(config=True)
 
     def preprocess(self, nb, resources):
         """Preprocessing to apply on each notebook.
@@ -43,5 +48,5 @@ class LatexPreprocessor(Preprocessor):
         from pygments.formatters import LatexFormatter
         
         resources.setdefault("latex", {})
-        resources["latex"].setdefault("pygments_definitions", LatexFormatter().get_style_defs())
+        resources["latex"].setdefault("pygments_definitions", LatexFormatter(style=self.style).get_style_defs())
         return nb, resources

--- a/nbconvert/preprocessors/tests/test_latex.py
+++ b/nbconvert/preprocessors/tests/test_latex.py
@@ -34,3 +34,21 @@ class TestLatex(PreprocessorTestsBase):
 
         # Verify that the markdown cell wasn't processed.
         self.assertEqual(nb.cells[1].source, '$ e $')
+    
+    def test_highlight(self):
+        """Check that highlighting style can be changed"""
+        nb = self.build_notebook()
+        res = self.build_resources()
+        preprocessor = self.build_preprocessor()
+
+        # Set the style to a known builtin that's not the default
+        preprocessor.style='colorful'
+        nb, res = preprocessor(nb, res)
+        style_defs = res['latex']['pygments_definitions']
+
+        # Get the default
+        from pygments.formatters import LatexFormatter
+        default_defs = LatexFormatter(style='default').get_style_defs()
+
+        # Verify that the style was in fact changed
+        assert style_defs != default_defs


### PR DESCRIPTION
closes #832 

This will let html, and latex exporting use any pygments style, which means one can set the colors that are used to highlight code!

This is my reattempt at #836, because I messed up the commit history.

- [x] Expose Pygments Styles
- [x] Write docs explaining Pygments Styles
- [x] Write LaTeX test
- [ ] Write HTML test
