### PR TITLE
LaTeX: Better placement of non-text code cell output

### DIFF
--- a/nbconvert/templates/latex/document_contents.tplx
+++ b/nbconvert/templates/latex/document_contents.tplx
@@ -58,7 +58,7 @@
 % Redirect execute_result to display data priority.
 ((* block execute_result scoped *))
     ((* block data_priority scoped *))
-    ((( super() )))
+    \noindent ((( super() )))
     ((* endblock *))
 ((* endblock execute_result *))
 

--- a/nbconvert/templates/latex/style_ipython.tplx
+++ b/nbconvert/templates/latex/style_ipython.tplx
@@ -38,7 +38,7 @@
             ((*- if type in ['text/plain'] *))
 ((( add_prompt(output.data['text/plain'] | escape_latex, cell, 'Out', 'outcolor') )))
             ((* else -*))
-\texttt{\color{outcolor}Out[{\color{outcolor}((( cell.execution_count )))}]:}((( super() )))
+\texttt{\color{outcolor}Out[((( cell.execution_count )))]:}((( super() )))
             ((*- endif -*))
         ((*- else -*))
             ((*- if type in ['text/plain'] *))
@@ -65,6 +65,6 @@
     ((*- endif -*))
     ((*- set indention =  " " * (execution_count | length + 7) -*))
 \begin{Verbatim}[commandchars=\\\{\}]
-((( text | add_prompts(first='{\color{' ~ prompt_color ~ '}' ~ prompt ~ '[{\\color{' ~ prompt_color ~ '}' ~ execution_count ~ '}]:} ', cont=indention) )))
+((( text | add_prompts(first='{\color{' ~ prompt_color ~ '}' ~ prompt ~ '[' ~ execution_count ~ ']:} ', cont=indention) )))
 \end{Verbatim}
 ((*- endmacro *))

--- a/nbconvert/templates/latex/style_ipython.tplx
+++ b/nbconvert/templates/latex/style_ipython.tplx
@@ -38,8 +38,18 @@
             ((*- if type in ['text/plain'] *))
 ((( add_prompt(output.data['text/plain'] | escape_latex, cell, 'Out', 'outcolor') )))
             ((* else -*))
-\texttt{\color{outcolor}Out[((( cell.execution_count )))]:}((( super() )))
-            ((*- endif -*))
+\newbox\promptbox
+\savebox{\promptbox}{\texttt{\color{outcolor}Out[((( cell.execution_count )))]:} }
+\newskip\outputareawidth
+\outputareawidth=\textwidth
+\advance\outputareawidth by -\wd\promptbox
+\vspace{-1.5ex}\begin{minipage}[t]{\wd\promptbox}\vspace{0pt}
+\usebox{\promptbox}
+\end{minipage}%%
+\begin{minipage}[t]{\outputareawidth}\vspace{0pt}
+((( super() )))
+\end{minipage}
+            ((* endif -*))
         ((*- else -*))
             ((*- if type in ['text/plain'] *))
 ((( output.data['text/plain'] | escape_latex )))

--- a/nbconvert/templates/latex/style_ipython.tplx
+++ b/nbconvert/templates/latex/style_ipython.tplx
@@ -49,6 +49,7 @@
 \begin{minipage}[t]{\outputareawidth}\vspace{0pt}
 ((( super() )))
 \end{minipage}
+\vspace{0pt}
             ((* endif -*))
         ((*- else -*))
             ((*- if type in ['text/plain'] *))


### PR DESCRIPTION
I did the same thing for `nbsphinx` in https://github.com/spatialaudio/nbsphinx/pull/212/commits/fc4fe32aa2931d5f40e2fa1efa99d090ab215129, so I thought I'll just apply the same trick here.

Before:

![grafik](https://user-images.githubusercontent.com/705404/46366275-e7ad3c80-c67a-11e8-84cf-27ed37c06a03.png)

After:

![grafik](https://user-images.githubusercontent.com/705404/46366829-5fc83200-c67c-11e8-93ce-b4d23b94df80.png)

Obviously, the vertical distance to the next paragraph is still too short, but I didn't know what's the best way to fix this. It's not obvious to me, any ideas?
