### PR TITLE
Refactored execute preprocessor to have a process_message function

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -588,12 +588,12 @@ class ExecutePreprocessor(Preprocessor):
         except ValueError:
             self.log.error("unhandled iopub msg: " + msg_type)
             return
-        else:
-            if self.clear_before_next_output:
-                self.log.debug('Executing delayed clear_output')
-                outs[:] = []
-                self.clear_display_id_mapping(cell_index)
-                self.clear_before_next_output = False
+
+        if self.clear_before_next_output:
+            self.log.debug('Executing delayed clear_output')
+            outs[:] = []
+            self.clear_display_id_mapping(cell_index)
+            self.clear_before_next_output = False
 
         if display_id:
             # record output index in:

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -409,7 +409,9 @@ class ExecutePreprocessor(Preprocessor):
         if cell.cell_type != 'code' or not cell.source.strip():
             return cell, resources
 
-        reply = self.run_cell(cell, cell_index)
+        reply, outputs = self.run_cell(cell, cell_index)
+        # Backwards compatability for processes that wrap run_cell
+        cell.outputs = outputs
 
         cell_allows_errors = (self.allow_errors or "raises-exception"
                               in cell.metadata.get("tags", []))
@@ -523,7 +525,8 @@ class ExecutePreprocessor(Preprocessor):
             except CellExecutionComplete:
                 break
 
-        return exec_reply
+        # Return cell.outputs still for backwards compatability
+        return exec_reply, cell.outputs
 
     def process_message(self, msg, cell, cell_index):
         """

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -25,7 +25,14 @@ from .base import Preprocessor
 from ..utils.exceptions import ConversionException
 
 
-class CellExecutionComplete(Exception): pass  # Used as a control signal
+class CellExecutionComplete(Exception):
+    """
+    Used as a control signal for cell execution across run_cell and
+    process_message function calls. Raised when all execution requests
+    are completed and no further messages are expected from the kernel
+    over zeromq channels.
+    """
+    pass
 
 class CellExecutionError(ConversionException):
     """

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -185,18 +185,18 @@ class TestExecute(ExecuteTestBase):
     def assert_notebooks_equal(self, expected, actual):
         expected_cells = expected['cells']
         actual_cells = actual['cells']
-        self.assertEqual(len(expected_cells), len(actual_cells))
+        assert len(expected_cells) == len(actual_cells)
 
         for expected_cell, actual_cell in zip(expected_cells, actual_cells):
             expected_outputs = expected_cell.get('outputs', [])
             actual_outputs = actual_cell.get('outputs', [])
             normalized_expected_outputs = list(map(self.normalize_output, expected_outputs))
             normalized_actual_outputs = list(map(self.normalize_output, actual_outputs))
-            self.assertEqual(normalized_expected_outputs, normalized_actual_outputs)
+            assert normalized_expected_outputs == normalized_actual_outputs
 
             expected_execution_count = expected_cell.get('execution_count', None)
             actual_execution_count = actual_cell.get('execution_count', None)
-            self.assertEqual(expected_execution_count, actual_execution_count)
+            assert expected_execution_count == actual_execution_count
 
 
     def test_constructor(self):
@@ -414,9 +414,9 @@ class TestExecute(ExecuteTestBase):
         original = copy.deepcopy(input_nb)
         wpp = WrappedPreProc()
         executed = wpp.preprocess(input_nb, {})[0]
-        self.assertEqual(outputs, [
+        assert outputs == [
             {'name': 'stdout', 'output_type': 'stream', 'text': 'Hello World\n'}
-        ])
+        ]
         self.assert_notebooks_equal(original, executed)
 
     def test_execute_function(self):

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -401,7 +401,7 @@ class TestExecute(ExecuteTestBase):
         class WrappedPreProc(ExecutePreprocessor):
             def process_message(self, msg, cell, cell_index):
                 result = super(WrappedPreProc, self).process_message(msg, cell, cell_index)
-                if result and result != msg:
+                if result:
                     outputs.append(result)
                 return result
 

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -23,6 +23,7 @@ from .base import PreprocessorTestsBase
 from ..execute import ExecutePreprocessor, CellExecutionError, executenb
 
 import IPython
+from mock import MagicMock
 from traitlets import TraitError
 from nbformat import NotebookNode
 from jupyter_client.kernelspec import KernelSpecManager
@@ -50,7 +51,6 @@ def _normalize_base64(b64_text):
         return b64encode(b64decode(b64_text.encode('ascii'))).decode('ascii')
     except (ValueError, TypeError):
         return b64_text
-
 
 class ExecuteTestBase(PreprocessorTestsBase):
     def build_preprocessor(self, opts):


### PR DESCRIPTION
Built ontop of https://github.com/jupyter/nbconvert/pull/982 which added additional requested testing. We can merge that PR first if it's desired.

Broke apart the large run_cell function to enable intercepting messages easier. This will enable deleting code from papermill where we have to reimplement the entire `run_cell` method.