### PR TITLE
exclude header

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -189,6 +189,10 @@ class TemplateExporter(Exporter):
     #Extension that the template files use.
     template_extension = Unicode(".tpl").tag(config=True, affects_environment=True)
 
+    exclude_header = Bool(False,
+        help = "This allows you to exclude the header from all templates if set to True."
+        ).tag(config=True)
+
     exclude_input = Bool(False,
         help = "This allows you to exclude code cell inputs from all templates if set to True."
         ).tag(config=True)
@@ -300,6 +304,7 @@ class TemplateExporter(Exporter):
         nb_copy, resources = super(TemplateExporter, self).from_notebook_node(nb, resources, **kw)
         resources.setdefault('raw_mimetypes', self.raw_mimetypes)
         resources['global_content_filter'] = {
+                'include_header': not self.exclude_header,
                 'include_code': not self.exclude_code_cell,
                 'include_markdown': not self.exclude_markdown,
                 'include_raw': not self.exclude_raw,

--- a/nbconvert/templates/latex/skeleton/null.tplx
+++ b/nbconvert/templates/latex/skeleton/null.tplx
@@ -25,8 +25,10 @@ calling super.
 consider calling super even if it is a leave block, we might insert more blocks later.
 
 =))
+((*- if resources.global_content_filter.include_header -*))
 ((*- block header -*))
 ((*- endblock header -*))
+((*- endif -*))
 ((*- block body -*))
 ((*- for cell in nb.cells -*))
     ((*- block any_cell scoped -*))

--- a/nbconvert/templates/skeleton/null.tpl
+++ b/nbconvert/templates/skeleton/null.tpl
@@ -21,8 +21,10 @@ calling super.
 consider calling super even if it is a leave block, we might insert more blocks later.
 
 #}
+{%- if resources.global_content_filter.include_header -%}
 {%- block header -%}
 {%- endblock header -%}
+{%- endif -%}
 {%- block body -%}
 {%- for cell in nb.cells -%}
     {%- block any_cell scoped -%}


### PR DESCRIPTION
I'm not sure if I'm altering the right templates here but the goal is to add an option to exclude the header.

The idea is that not all Python scripts need the shebang, added in the header recently, and sometimes one may want to get parts of the latex document to concatenate with another header.

I understand that one can do the same with a custom template but sometimes it is easier to just set a flag.