### PR TITLE
ExecutePreprocessor: Get kernel name when executing, and not during initialization

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -158,16 +158,6 @@ class ExecutePreprocessor(Preprocessor):
         )
     ).tag(config=True)
 
-    @default('kernel_name')
-    def _kernel_name_default(self):
-        try:
-            return self.nb.metadata.get('kernelspec', {}).get('name', 'python')
-        except AttributeError:
-            raise AttributeError('You did not specify a kernel_name for '
-                                 'the ExecutePreprocessor and you have not set '
-                                 'self.nb to be able to use that to infer the '
-                                 'kernel_name.')
-
     raise_on_iopub_timeout = Bool(False,
         help=dedent(
             """
@@ -248,6 +238,9 @@ class ExecutePreprocessor(Preprocessor):
         kc : KernelClient
             Kernel client as created by the kernel manager `km`.
         """
+        if not self.kernel_name:
+            self.kernel_name = self.nb.metadata.get(
+                'kernelspec', {}).get('name', 'python')
         km = self.kernel_manager_class(kernel_name=self.kernel_name,
                                        config=self.config)
         km.start_kernel(extra_arguments=self.extra_arguments, **kwargs)


### PR DESCRIPTION
Since there doesn't seem to be any progress in PR #886, I'm proposing this more minimalist approach to fixing #878 (that I've already suggested in https://github.com/jupyter/nbconvert/pull/886#issuecomment-420734298).

The underlying design problems (as mentioned in https://github.com/jupyter/nbconvert/pull/886#issuecomment-421959025) are of course still there, but this PR at least fixes the regression introduced in #816. Hopefully this can be incorporated in the next `nbconvert` release!

If desired, I can make another PR at a later point to fix those other problems, but I think that is not as urgent as the fix in this PR.