### PR TITLE
Mathjax.tpl url update

### DIFF
--- a/nbconvert/templates/html/mathjax.tpl
+++ b/nbconvert/templates/html/mathjax.tpl
@@ -1,4 +1,4 @@
-{%- macro mathjax(url='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML') -%}
+{%- macro mathjax(url='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML') -%}
     <!-- Load mathjax -->
     <script src="{{url}}"></script>
     <!-- MathJax configuration -->


### PR DESCRIPTION
Hi dear nbconvert maintainers, thank you again taking care of such a valuable tool!

As reported in #925 the current MathJax url doesn't allow proper rendering of latex math formulas when exporting to html. The commit in this PR fixes this problem.
