### PR TITLE
Bump pandoc upper bound to 2.5

### DIFF
--- a/nbconvert/utils/pandoc.py
+++ b/nbconvert/utils/pandoc.py
@@ -15,7 +15,7 @@ from ipython_genutils.py3compat import cast_bytes, which
 from .exceptions import ConversionException
 
 _minimal_version = "1.12.1"
-_maximal_version = "2.0.0"
+_maximal_version = "2.5.0"
 
 def pandoc(source, fmt, to, extra_args=None, encoding='utf-8'):
     """Convert an input string using pandoc.


### PR DESCRIPTION
Let's keep it up to date unless there's any breaking issue.

Reference: https://stackoverflow.com/questions/53966433/jupyter-nbconvert-cannot-work-with-latest-version-of-pandoc/53967931#53967931