### PR TITLE
Fix LaTeX base template name in docs

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -67,7 +67,7 @@ LaTeX
 
     Latex report, providing a table of contents and chapters.
 
-  - ``--template basic``
+  - ``--template base``
 
     Very basic latex output - mainly meant as a starting point for custom
     templates.


### PR DESCRIPTION
The docs currently specify `basic` as the name of the base LaTeX template, which is incorrect, resulting in the following error when used on the command line: `jinja2.exceptions.TemplateNotFound: basic`. In fact `basic` is the name of the base HTML template; the base LaTeX template is named `base`. These names are correct in the module help.