### PR TITLE
remove deprecated `export_by_name`

### DIFF
--- a/nbconvert/exporters/__init__.py
+++ b/nbconvert/exporters/__init__.py
@@ -1,6 +1,5 @@
 from .base import (export, get_exporter, 
                    ExporterNameError, get_export_names)
-from .exporter_locator import export_by_name
 from .html import HTMLExporter
 from .slides import SlidesExporter
 from .templateexporter import TemplateExporter


### PR DESCRIPTION
Through `exporter_locator` was deprecated since nbconvert 5.0,
https://github.com/jupyter/nbconvert/blob/2a7419e3784d71bca0c3566dda7f29b2fd13b7e7/nbconvert/exporters/exporter_locator.py#L27-L28
there still exists an import from it:
https://github.com/jupyter/nbconvert/blob/947055120e2268cca2672653490c294939123844/nbconvert/exporters/__init__.py#L3

This PR trys to fix it. :)