### PR TITLE
Return an error if latex does.

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -172,8 +172,7 @@ class PDFExporter(LatexExporter):
             self.log.info("Building PDF")
             rc = self.run_latex(tex_file)
             if rc:
-                rc = self.run_bib(tex_file)
-            if rc:
+                self.run_bib(tex_file)
                 rc = self.run_latex(tex_file)
             
             pdf_file = notebook_name + '.pdf'

--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -175,7 +175,7 @@ class PDFExporter(LatexExporter):
                 rc = self.run_latex(tex_file)
             
             pdf_file = notebook_name + '.pdf'
-            if not os.path.isfile(pdf_file):
+            if not rc or not os.path.isfile(pdf_file):
                 raise LatexFailed('\n'.join(self._captured_output))
             self.log.info('PDF successfully created')
             with open(pdf_file, 'rb') as f:


### PR DESCRIPTION
LaTeX can error, but still produce a PDF. This ensures the user is aware
of the error.