### PR TITLE
Correct inaccurate description of available LaTeX template

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -69,11 +69,6 @@ LaTeX
 
     Latex report, providing a table of contents and chapters.
 
-  - ``--template base``
-
-    Very basic latex output - mainly meant as a starting point for custom
-    templates. 
-
   .. note::
 
     nbconvert uses pandoc_ to convert between various markup languages,


### PR DESCRIPTION
There is no "basic" LaTeX template. There is a "base" template, but it isn't usable as a standalone, only for inheritance. This commit removes the reference in the documentation to the nonexistent template. 

Closes #954 