### PR TITLE
Solves hanging indefinitely when kernel dies

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -413,7 +413,6 @@ class ExecutePreprocessor(Preprocessor):
 
                 if not timeout or timeout < 0:
                     timeout = None
-                msg = self.kc.shell_channel.get_msg(timeout=timeout)
                 
                 if timeout is not None:
                     # timeout specified

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -427,6 +427,7 @@ class ExecutePreprocessor(Preprocessor):
                             #received no message, check if kernel is still alive
                             if not self.kc.is_alive():
                                 raise RuntimeError("Kernel died")
+                            
                             #kernel still alive, wait for a message
                             continue
                         #message received


### PR DESCRIPTION
I use Jupyter notebooks for automatic regression testing. I use nbconvert to execute notebooks containing tests:

 `jupyter nbconvert ..... --allow-errors ....  --ExecutePreprocessor.timeout=-1 .... --execute test.ipynb`

In one of the tests the kernel dies. Unfortunately nbconvert will hang on this. I can't use timeouts as some cells in the test notebooks take a long time to execute. If the kernel dies I want nbconvert to detect this almost immediately.

The patch checks that the kernel is alive while waiting for a message.
 