### PR TITLE
Update CDN URLs, add option for local libs and SRI attributes

### DIFF
--- a/docs/source/customizing.ipynb
+++ b/docs/source/customizing.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Under the hood, nbconvert uses [Jinja templates](https://jinja2.readthedocs.io/en/latest/intro.html) to specify how the notebooks should be formatted. These templates can be fully customized, allowing you to use nbconvert to create notebooks in different formats with different styles as well."
+    "Under the hood, nbconvert uses [Jinja templates](http://jinja.pocoo.org/docs/) to specify how the notebooks should be formatted. These templates can be fully customized, allowing you to use nbconvert to create notebooks in different formats with different styles as well."
    ]
   },
   {

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -30,6 +30,10 @@ class HTMLExporter(TemplateExporter):
         help="If True, use local folder libs/ instead of fetching resources from CDN"
     ).tag(config=True)
 
+    use_sri_attr = Bool(False,
+        help="If True, use SRI hashes for sub-resources, i.e. external javascript and CSS"
+    ).tag(config=True)
+
     @default('file_extension')
     def _file_extension_default(self):
         return '.html'
@@ -96,6 +100,7 @@ class HTMLExporter(TemplateExporter):
         if 'reveal' not in resources:
             resources['reveal'] = {}
         resources['reveal']['use_local_libs'] = self.use_local_libs
+        resources['reveal']['use_sri_attr'] = self.use_sri_attr
 
         langinfo = nb.metadata.get('language_info', {})
         lexer = langinfo.get('pygments_lexer', langinfo.get('name', None))

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -100,7 +100,7 @@ class SlidesExporter(HTMLExporter):
             warn("Please update RevealHelpPreprocessor.url_prefix to "
                  "SlidesExporter.reveal_url_prefix in config files.")
             return self.config.RevealHelpPreprocessor.url_prefix
-        return 'https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.5.0'
+        return 'https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.7.0/js/reveal.min.js'
 
     reveal_theme = Unicode('simple',
         help="""
@@ -130,7 +130,7 @@ class SlidesExporter(HTMLExporter):
     ).tag(config=True)
 
     require_js_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js",
         help="""
         URL to load require.js from.
 
@@ -139,7 +139,7 @@ class SlidesExporter(HTMLExporter):
     ).tag(config=True)
 
     jquery_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js",
         help="""
         URL to load jQuery from.
 

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -100,7 +100,7 @@ class SlidesExporter(HTMLExporter):
             warn("Please update RevealHelpPreprocessor.url_prefix to "
                  "SlidesExporter.reveal_url_prefix in config files.")
             return self.config.RevealHelpPreprocessor.url_prefix
-        return 'https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.7.0/js/reveal.min.js'
+        return 'https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.7.0'
 
     reveal_theme = Unicode('simple',
         help="""

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -123,11 +123,6 @@ nbconvert_flags.update({
         """Exclude input cells and output prompts from converted document. 
         This mode is ideal for generating code-free reports."""
         ),
-    # this does not seem to work yet
-    # 'local-libs' : (
-    #     {'HTMLExporter' : { 'use_local_libs' : True}},
-    #     "Use local folder libs/ instead of fetching resources from CDN"
-    #     ),
 })
 
 

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -123,6 +123,11 @@ nbconvert_flags.update({
         """Exclude input cells and output prompts from converted document. 
         This mode is ideal for generating code-free reports."""
         ),
+    # this does not seem to work yet
+    # 'local-libs' : (
+    #     {'HTMLExporter' : { 'use_local_libs' : True}},
+    #     "Use local folder libs/ instead of fetching resources from CDN"
+    #     ),
 })
 
 

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -23,7 +23,7 @@
 {% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>{{nb_title}}</title>
 
-<script src="{{urls.require_js_url}}" {{attr.reveal_js_attr}}></script>
+<script src="{{urls.require_js_url}}" {{attr.require_js_attr}}></script>
 <script src="{{urls.jquery_url}}" {{attr.jquery_attr}}></script>
 
 {% block ipywidgets %}

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -1,4 +1,5 @@
 {%- extends 'basic.tpl' -%}
+{% from 'urls.tpl' import urls %}
 {% from 'mathjax.tpl' import mathjax %}
 
 
@@ -11,8 +12,8 @@
 {% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>{{nb_title}}</title>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+<script src="{{urls.requirejs_url}}"></script>
+<script src="{{urls.jquery_url}}"></script>
 
 {% block ipywidgets %}
 {%- if "widgets" in nb.metadata -%}

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -1,12 +1,18 @@
 {%- extends 'basic.tpl' -%}
-{% from 'urls.tpl' import all_urls %}
+{% from 'mathjax.tpl' import mathjax %}
+{% from 'urls.tpl' import all_urls, all_attr %}
+
 {% if resources['reveal']['use_local_libs'] == true %}
   {% set urls = all_urls.local_paths %}
 {% else %}
   {% set urls = all_urls.default_cdn %}
 {% endif %}
 
-{% from 'mathjax.tpl' import mathjax %}
+{% if resources['reveal']['use_sri_attr'] == true %}
+  {% set attr = all_attr.sri_attr %}
+{% else %}
+  {% set attr = all_attr.empty_attr %}
+{% endif %}
 
 {%- block header -%}
 <!DOCTYPE html>
@@ -17,8 +23,8 @@
 {% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>{{nb_title}}</title>
 
-<script src="{{urls.require_js_url}}" {{urls.reveal_js_attr}}></script>
-<script src="{{urls.jquery_url}}" {{urls.jquery_attr}}></script>
+<script src="{{urls.require_js_url}}" {{attr.reveal_js_attr}}></script>
+<script src="{{urls.jquery_url}}" {{attr.jquery_attr}}></script>
 
 {% block ipywidgets %}
 {%- if "widgets" in nb.metadata -%}

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -12,7 +12,7 @@
 {% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>{{nb_title}}</title>
 
-<script src="{{urls.requirejs_url}}"></script>
+<script src="{{urls.require_js_url}}"></script>
 <script src="{{urls.jquery_url}}"></script>
 
 {% block ipywidgets %}

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -1,7 +1,12 @@
 {%- extends 'basic.tpl' -%}
-{% from 'urls.tpl' import urls %}
-{% from 'mathjax.tpl' import mathjax %}
+{% from 'urls.tpl' import all_urls %}
+{% if resources['reveal']['use_local_libs'] == true %}
+  {% set urls = all_urls.local_paths %}
+{% else %}
+  {% set urls = all_urls.default_cdn %}
+{% endif %}
 
+{% from 'mathjax.tpl' import mathjax %}
 
 {%- block header -%}
 <!DOCTYPE html>
@@ -88,7 +93,7 @@ div#notebook-container{
 <link rel="stylesheet" href="custom.css">
 
 <!-- Loading mathjax macro -->
-{{ mathjax() }}
+{{ mathjax(urls) }}
 {%- endblock html_head -%}
 </head>
 {%- endblock header -%}

--- a/nbconvert/templates/html/full.tpl
+++ b/nbconvert/templates/html/full.tpl
@@ -12,8 +12,8 @@
 {% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>{{nb_title}}</title>
 
-<script src="{{urls.require_js_url}}"></script>
-<script src="{{urls.jquery_url}}"></script>
+<script src="{{urls.require_js_url}}" {{urls.reveal_js_attr}}></script>
+<script src="{{urls.jquery_url}}" {{urls.jquery_attr}}></script>
 
 {% block ipywidgets %}
 {%- if "widgets" in nb.metadata -%}

--- a/nbconvert/templates/html/mathjax.tpl
+++ b/nbconvert/templates/html/mathjax.tpl
@@ -1,7 +1,7 @@
 {%- macro mathjax() -%}
 {% from 'urls.tpl' import urls %}
     <!-- Load mathjax -->
-    <script src="{{urls.mathjax_url}}"></script>
+    <script src="{{urls.mathjax_url}}" {{urls.mathjax_attr}}></script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({

--- a/nbconvert/templates/html/mathjax.tpl
+++ b/nbconvert/templates/html/mathjax.tpl
@@ -1,5 +1,4 @@
-{%- macro mathjax() -%}
-{% from 'urls.tpl' import urls %}
+{%- macro mathjax(urls) -%}
     <!-- Load mathjax -->
     <script src="{{urls.mathjax_url}}" {{urls.mathjax_attr}}></script>
     <!-- MathJax configuration -->

--- a/nbconvert/templates/html/mathjax.tpl
+++ b/nbconvert/templates/html/mathjax.tpl
@@ -1,6 +1,7 @@
-{%- macro mathjax(url='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML') -%}
+{%- macro mathjax() -%}
+{% from 'urls.tpl' import urls %}
     <!-- Load mathjax -->
-    <script src="{{url}}"></script>
+    <script src="{{urls.mathjax_url}}"></script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({

--- a/nbconvert/templates/html/urls.tpl
+++ b/nbconvert/templates/html/urls.tpl
@@ -1,4 +1,5 @@
 {% set default_cdn = true %}
+{% set cdn_alternative = false %}
 
 {%-if default_cdn %}
   {% set cdn1_url = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
@@ -8,6 +9,15 @@
   {% set jquery_url       = cdn1_url ~ 'jquery/3.3.1/jquery.min.js' %}
   {% set reveal_js        = cdn1_url ~ 'reveal.js/3.7.0/js/reveal.min.js' %}
   {% set font_awesome_url = cdn1_url ~ 'font-awesome/4.7.0/css/font-awesome.css' %}
+
+{% elif cdn_alternative %}
+  {% set cdn2_url = 'https://cdn.jsdelivr.net/npm/' %}
+
+  {% set mathjax_url      = cdn2_url ~ 'mathjax@2.7.5/unpacked/MathJax.min.js' %}
+  {% set require_js_url   = 'https://requirejs.org/docs/release/2.3.6/minified/require.js' %}
+  {% set jquery_url       = cdn2_url ~ 'jquery@3.3.1/dist/jquery.min.js' %}
+  {% set reveal_js        = cdn2_url ~ 'reveal.js@3.7.0/js/reveal.min.js' %}
+  {% set font_awesome_url = 'https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' %}
 
 {% else %}
   {% set libs_dir  = 'libs/' %}

--- a/nbconvert/templates/html/urls.tpl
+++ b/nbconvert/templates/html/urls.tpl
@@ -1,88 +1,56 @@
-{# not yet implemented as switch #}
-{% set mathjax_attr = '' %}
-{% set require_js_attr = '' %}
-{% set jquery_attr = '' %}
-{% set reveal_js_attr = '' %}
-{% set font_awesome_attr = '' %}
-
-{% set set_link_attr = false %}
-{% if set_link_attr %}
-    {% set mathjax_attr = 'integrity="sha256-WUED7NFzpsmHtLO7bswSz4JSfkhE+cD4ncKeOznwFSY= sha384-paYjEtNXu9X/q6SBQB9EivI88vKEc/TiZWUaaH5j2Hi4vAOnVYmcahbzUELr3LHw sha512-BlZeGCIONWMdv9uCBB3I3hpY94r8I2e4DdNxyl4OOHYg0Y/LwwWDC4ioJr9vRaLNHwQG0oHiFdmqt7UaTCAZ0A==" crossorigin="anonymous"' %}
-    {% set require_js_attr = 'integrity="sha256-1fEPhSsRKlFKGfK3eO710tEweHh1fwokU5wFGDHO+vg= sha384-38qS6ZDmuc4fn68ICZ1CTMDv4+Yrqtpijvp5fwMNdbumNGNJ7JVJHgWr2X+nJfqM sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"' %}
-    {% set jquery_attr = 'integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8= sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT sha512-+NqPlbbtM1QqiK8ZAo4Yrj2c4lNQoGv8P79DPtKzj++l5jnN39rHA/xsqn8zE9l0uSoxaCdrOgFs6yjyfbBxSg==" crossorigin="anonymous"' %}
-    {% set reveal_js_attr = 'integrity="sha256-Xr6ZH+/kc7hDVReZLO5khBknteLqu5oen/xnSraXrVk= sha384-YSZJq04Xw1k1QeTgkujYtdAjgN/sspQx01Qx4JPksOst7V7juBOa/XBwsIK+mJ7c sha512-47qp+bUV262nwngjB+lBR1txpTKevoQKlz3d1+0uvu6Zly3Q+Y+tR19xDDk4NnutJ9vu6uojPXQS4S3sOB06qw==" crossorigin="anonymous"' %}
-    {% set font_awesome_attr = 'integrity="sha256-NuCn4IvuZXdBaFKJOAcsU2Q3ZpwbdFisd5dux4jkQ5w= sha384-FckWOBo7yuyMS7In0aXZ0aoVvnInlnFMwCv77x9sZpFgOonQgnBj1uLwenWVtsEj sha512-5A8nwdMOWrSz20fDsjczgUidUBR8liPYU+WymTZP1lmY9G6Oc7HlZv156XqnsgNUzTyMefFTcsFH/tnJE/+xBg==" crossorigin="anonymous"' %}
-{% endif %}
-
 {# default configuration #}
 {% set cdn1_base = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
-
-{% set mathjax_url_1      = cdn1_base ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
-{% set require_js_url_1   = cdn1_base ~ 'require.js/2.3.6/require.min.js' %}
-{% set jquery_url_1       = cdn1_base ~ 'jquery/3.3.1/jquery.min.js' %}
-{% set reveal_js_url_1    = cdn1_base ~ 'reveal.js/3.7.0/js/reveal.min.js' %}
-{% set font_awesome_url_1 = cdn1_base ~ 'font-awesome/4.7.0/css/font-awesome.css' %}
-
 {% set default_cdn      = {
-  'mathjax_url' : mathjax_url_1,
-  'require_js_url' : require_js_url_1,
-  'jquery_url' : jquery_url_1,
-  'reveal_js_url' : reveal_js_url_1,
-  'font_awesome_url' : font_awesome_url_1,
-  'mathjax_attr' : mathjax_attr,
-  'require_js_attr' : require_js_attr,
-  'jquery_attr' : jquery_attr,
-  'reveal_js_attr' : reveal_js_attr,
-  'font_awesome_attr' : font_awesome_attr,
+  'mathjax_url'      : cdn1_base ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML',
+  'require_js_url'   : cdn1_base ~ 'require.js/2.3.6/require.min.js',
+  'jquery_url'       : cdn1_base ~ 'jquery/3.3.1/jquery.min.js',
+  'reveal_js_url'    : cdn1_base ~ 'reveal.js/3.7.0/js/reveal.min.js',
+  'font_awesome_url' : cdn1_base ~ 'font-awesome/4.7.0/css/font-awesome.css',
   } %}
 
 {# alternative external resources - not yet implemented as switch #}
 {% set cdn2_base = 'https://cdn.jsdelivr.net/npm/' %}
-
-{% set mathjax_url_2      = cdn2_base ~ 'mathjax@2.7.5/unpacked/MathJax.min.js' %}
-{% set require_js_url_2   = 'https://requirejs.org/docs/release/2.3.6/minified/require.js' %}
-{% set jquery_url_2       = cdn2_base ~ 'jquery@3.3.1/dist/jquery.min.js' %}
-{% set reveal_js_url_2    = cdn2_base ~ 'reveal.js@3.7.0/js/reveal.min.js' %}
-{% set font_awesome_url_2 = 'https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' %}
-
 {% set alternative_cdn      = {
-  'mathjax_url' : mathjax_url_2,
-  'require_js_url' : require_js_url_2,
-  'jquery_url' : jquery_url_2,
-  'reveal_js_url' : reveal_js_url_2,
-  'font_awesome_url' : font_awesome_url_2,
-  'mathjax_attr' : mathjax_attr,
-  'require_js_attr' : require_js_attr,
-  'jquery_attr' : jquery_attr,
-  'reveal_js_attr' : reveal_js_attr,
-  'font_awesome_attr' : font_awesome_attr,
+  'mathjax_url'      : cdn2_base ~ 'mathjax@2.7.5/unpacked/MathJax.min.js',
+  'require_js_url'   : 'https://requirejs.org/docs/release/2.3.6/minified/require.js',
+  'jquery_url'       : cdn2_base ~ 'jquery@3.3.1/dist/jquery.min.js',
+  'reveal_js_url'    : cdn2_base ~ 'reveal.js@3.7.0/js/reveal.min.js',
+  'font_awesome_url' : 'https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css',
   } %}
 
 {# set local paths for resources #}
 {% set libs_dir  = 'libs/' %}
-
-{% set mathjax_path      = libs_dir ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
-{% set require_js_path   = libs_dir ~ 'require.min.js' %}
-{% set jquery_path       = libs_dir ~ 'jquery.min.js' %}
-{% set reveal_js_path    = libs_dir ~ 'reveal.min.js' %}
-{% set font_awesome_path = libs_dir ~ 'font-awesome.css' %}
-
 {% set local_paths      = {
-  'mathjax_url' : mathjax_path,
-  'require_js_url' : require_js_path,
-  'jquery_url' : jquery_path,
-  'reveal_js_url' : reveal_js_path,
-  'font_awesome_url' : font_awesome_path,
-  'mathjax_attr' : mathjax_attr,
-  'require_js_attr' : require_js_attr,
-  'jquery_attr' : jquery_attr,
-  'reveal_js_attr' : reveal_js_attr,
-  'font_awesome_attr' : font_awesome_attr,
+  'mathjax_url'      : libs_dir ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML',
+  'require_js_url'   : libs_dir ~ 'require.min.js',
+  'jquery_url'       : libs_dir ~ 'jquery.min.js',
+  'reveal_js_url'    : libs_dir ~ 'reveal.min.js',
+  'font_awesome_url' : libs_dir ~ 'font-awesome.css',
   } %}
 
 {% set all_urls = {
   'default_cdn'     : default_cdn ,
   'alternative_cdn' : alternative_cdn ,
   'local_paths'     : local_paths ,
-} %}
+  } %}
 
+{% set empty_attr     = {
+  'mathjax_attr'      : '',
+  'require_js_attr'   : '',
+  'jquery_attr'       : '',
+  'reveal_js_attr'    : '',
+  'font_awesome_attr' : '',
+  } %}
+
+{% set sri_attr     = {
+'mathjax_attr'      : 'integrity="sha256-WUED7NFzpsmHtLO7bswSz4JSfkhE+cD4ncKeOznwFSY= sha384-paYjEtNXu9X/q6SBQB9EivI88vKEc/TiZWUaaH5j2Hi4vAOnVYmcahbzUELr3LHw sha512-BlZeGCIONWMdv9uCBB3I3hpY94r8I2e4DdNxyl4OOHYg0Y/LwwWDC4ioJr9vRaLNHwQG0oHiFdmqt7UaTCAZ0A==" crossorigin="anonymous"',
+'require_js_attr'   : 'integrity="sha256-1fEPhSsRKlFKGfK3eO710tEweHh1fwokU5wFGDHO+vg= sha384-38qS6ZDmuc4fn68ICZ1CTMDv4+Yrqtpijvp5fwMNdbumNGNJ7JVJHgWr2X+nJfqM sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"',
+'jquery_attr'       : 'integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8= sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT sha512-+NqPlbbtM1QqiK8ZAo4Yrj2c4lNQoGv8P79DPtKzj++l5jnN39rHA/xsqn8zE9l0uSoxaCdrOgFs6yjyfbBxSg==" crossorigin="anonymous"',
+'reveal_js_attr'    : 'integrity="sha256-Xr6ZH+/kc7hDVReZLO5khBknteLqu5oen/xnSraXrVk= sha384-YSZJq04Xw1k1QeTgkujYtdAjgN/sspQx01Qx4JPksOst7V7juBOa/XBwsIK+mJ7c sha512-47qp+bUV262nwngjB+lBR1txpTKevoQKlz3d1+0uvu6Zly3Q+Y+tR19xDDk4NnutJ9vu6uojPXQS4S3sOB06qw==" crossorigin="anonymous"',
+'font_awesome_attr' : 'integrity="sha256-NuCn4IvuZXdBaFKJOAcsU2Q3ZpwbdFisd5dux4jkQ5w= sha384-FckWOBo7yuyMS7In0aXZ0aoVvnInlnFMwCv77x9sZpFgOonQgnBj1uLwenWVtsEj sha512-5A8nwdMOWrSz20fDsjczgUidUBR8liPYU+WymTZP1lmY9G6Oc7HlZv156XqnsgNUzTyMefFTcsFH/tnJE/+xBg==" crossorigin="anonymous"',
+  } %}
+
+{% set all_attr = {
+  'empty_attr'  : empty_attr,
+  'sri_attr'    : sri_attr,
+  } %}

--- a/nbconvert/templates/html/urls.tpl
+++ b/nbconvert/templates/html/urls.tpl
@@ -1,16 +1,24 @@
-{% set cdn1_url = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
-{# set cdn2_url = 'https://cdn.jsdelivr.net/npm/' #}
+{% set default_cdn = true %}
 
-{% set mathjax_url      = cdn1_url ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
-{# set mathjax_url      = cdn2_url ~ 'mathjax@2.7.5/unpacked/MathJax.min.js' #}
-{% set require_js_url   = cdn1_url ~ 'require.js/2.3.6/require.min.js' %}
-{# set require_js_url   = 'https://requirejs.org/docs/release/2.3.6/minified/require.js' #}
-{% set jquery_url       = cdn1_url ~ 'jquery/3.3.1/jquery.min.js' %}
-{# set jquery_url       = cdn2_url ~ 'jquery@3.3.1/dist/jquery.min.js' #}
-{% set reveal_js        = cdn1_url ~ 'reveal.js/3.7.0/js/reveal.min.js' %}
-{# set reveal_js        = cdn2_url ~ 'reveal.js@3.7.0/js/reveal.min.js' #}
-{% set font_awesome_url = cdn1_url ~ 'font-awesome/4.7.0/css/font-awesome.css' %}
-{# set font_awesome_url = 'https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' #}
+{%-if default_cdn %}
+  {% set cdn1_url = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
+
+  {% set mathjax_url      = cdn1_url ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
+  {% set require_js_url   = cdn1_url ~ 'require.js/2.3.6/require.min.js' %}
+  {% set jquery_url       = cdn1_url ~ 'jquery/3.3.1/jquery.min.js' %}
+  {% set reveal_js        = cdn1_url ~ 'reveal.js/3.7.0/js/reveal.min.js' %}
+  {% set font_awesome_url = cdn1_url ~ 'font-awesome/4.7.0/css/font-awesome.css' %}
+
+{% else %}
+  {% set libs_dir  = 'libs/' %}
+
+  {% set mathjax_url      = libs_dir ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
+  {% set require_js_url   = libs_dir ~ 'require.min.js' %}
+  {% set jquery_url       = libs_dir ~ 'jquery.min.js' %}
+  {% set reveal_js        = libs_dir ~ 'reveal.min.js' %}
+  {% set font_awesome_url = libs_dir ~ 'font-awesome.css' %}
+  
+{% endif %}
 
 {% set urls           = { 
   'mathjax_url' : mathjax_url, 

--- a/nbconvert/templates/html/urls.tpl
+++ b/nbconvert/templates/html/urls.tpl
@@ -1,65 +1,88 @@
-{% set default_cdn = true %}
-{% set cdn_alternative = false %}
+{# not yet implemented as switch #}
+{% set mathjax_attr = '' %}
+{% set require_js_attr = '' %}
+{% set jquery_attr = '' %}
+{% set reveal_js_attr = '' %}
+{% set font_awesome_attr = '' %}
+
 {% set set_link_attr = false %}
-
-{%-if default_cdn %}
-  {% set cdn1_url = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
-
-  {% set mathjax_url      = cdn1_url ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
-  {% set require_js_url   = cdn1_url ~ 'require.js/2.3.6/require.min.js' %}
-  {% set jquery_url       = cdn1_url ~ 'jquery/3.3.1/jquery.min.js' %}
-  {% set reveal_js_url        = cdn1_url ~ 'reveal.js/3.7.0/js/reveal.min.js' %}
-  {% set font_awesome_url = cdn1_url ~ 'font-awesome/4.7.0/css/font-awesome.css' %}
-
-{% elif cdn_alternative %}
-  {% set cdn2_url = 'https://cdn.jsdelivr.net/npm/' %}
-
-  {% set mathjax_url      = cdn2_url ~ 'mathjax@2.7.5/unpacked/MathJax.min.js' %}
-  {% set require_js_url   = 'https://requirejs.org/docs/release/2.3.6/minified/require.js' %}
-  {% set jquery_url       = cdn2_url ~ 'jquery@3.3.1/dist/jquery.min.js' %}
-  {% set reveal_js_url        = cdn2_url ~ 'reveal.js@3.7.0/js/reveal.min.js' %}
-  {% set font_awesome_url = 'https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' %}
-
-{% else %}
-  {% set libs_dir  = 'libs/' %}
-
-  {% set mathjax_url      = libs_dir ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
-  {% set require_js_url   = libs_dir ~ 'require.min.js' %}
-  {% set jquery_url       = libs_dir ~ 'jquery.min.js' %}
-  {% set reveal_js_url    = libs_dir ~ 'reveal.min.js' %}
-  {% set font_awesome_url = libs_dir ~ 'font-awesome.css' %}
-  
+{% if set_link_attr %}
+    {% set mathjax_attr = 'integrity="sha256-WUED7NFzpsmHtLO7bswSz4JSfkhE+cD4ncKeOznwFSY= sha384-paYjEtNXu9X/q6SBQB9EivI88vKEc/TiZWUaaH5j2Hi4vAOnVYmcahbzUELr3LHw sha512-BlZeGCIONWMdv9uCBB3I3hpY94r8I2e4DdNxyl4OOHYg0Y/LwwWDC4ioJr9vRaLNHwQG0oHiFdmqt7UaTCAZ0A==" crossorigin="anonymous"' %}
+    {% set require_js_attr = 'integrity="sha256-1fEPhSsRKlFKGfK3eO710tEweHh1fwokU5wFGDHO+vg= sha384-38qS6ZDmuc4fn68ICZ1CTMDv4+Yrqtpijvp5fwMNdbumNGNJ7JVJHgWr2X+nJfqM sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"' %}
+    {% set jquery_attr = 'integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8= sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT sha512-+NqPlbbtM1QqiK8ZAo4Yrj2c4lNQoGv8P79DPtKzj++l5jnN39rHA/xsqn8zE9l0uSoxaCdrOgFs6yjyfbBxSg==" crossorigin="anonymous"' %}
+    {% set reveal_js_attr = 'integrity="sha256-Xr6ZH+/kc7hDVReZLO5khBknteLqu5oen/xnSraXrVk= sha384-YSZJq04Xw1k1QeTgkujYtdAjgN/sspQx01Qx4JPksOst7V7juBOa/XBwsIK+mJ7c sha512-47qp+bUV262nwngjB+lBR1txpTKevoQKlz3d1+0uvu6Zly3Q+Y+tR19xDDk4NnutJ9vu6uojPXQS4S3sOB06qw==" crossorigin="anonymous"' %}
+    {% set font_awesome_attr = 'integrity="sha256-NuCn4IvuZXdBaFKJOAcsU2Q3ZpwbdFisd5dux4jkQ5w= sha384-FckWOBo7yuyMS7In0aXZ0aoVvnInlnFMwCv77x9sZpFgOonQgnBj1uLwenWVtsEj sha512-5A8nwdMOWrSz20fDsjczgUidUBR8liPYU+WymTZP1lmY9G6Oc7HlZv156XqnsgNUzTyMefFTcsFH/tnJE/+xBg==" crossorigin="anonymous"' %}
 {% endif %}
 
-{% set urls           = { 
-  'mathjax_url' : mathjax_url, 
-  'require_js_url' : require_js_url, 
-  'jquery_url' : jquery_url,
-  'reveal_js_url' : reveal_js_url,
-  'font_awesome_url' : font_awesome_url,
-  'mathjax_attr' : '', 
-  'require_js_attr' : '', 
-  'jquery_attr' : '',
-  'reveal_js_attr' : '',
-  'font_awesome_attr' : '',
+{# default configuration #}
+{% set cdn1_base = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
+
+{% set mathjax_url_1      = cdn1_base ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
+{% set require_js_url_1   = cdn1_base ~ 'require.js/2.3.6/require.min.js' %}
+{% set jquery_url_1       = cdn1_base ~ 'jquery/3.3.1/jquery.min.js' %}
+{% set reveal_js_url_1    = cdn1_base ~ 'reveal.js/3.7.0/js/reveal.min.js' %}
+{% set font_awesome_url_1 = cdn1_base ~ 'font-awesome/4.7.0/css/font-awesome.css' %}
+
+{% set default_cdn      = {
+  'mathjax_url' : mathjax_url_1,
+  'require_js_url' : require_js_url_1,
+  'jquery_url' : jquery_url_1,
+  'reveal_js_url' : reveal_js_url_1,
+  'font_awesome_url' : font_awesome_url_1,
+  'mathjax_attr' : mathjax_attr,
+  'require_js_attr' : require_js_attr,
+  'jquery_attr' : jquery_attr,
+  'reveal_js_attr' : reveal_js_attr,
+  'font_awesome_attr' : font_awesome_attr,
   } %}
 
-{%-if set_link_attr %}
-  {% set urls           = { 
-    'mathjax_url' : mathjax_url, 
-    'require_js_url' : require_js_url, 
-    'jquery_url' : jquery_url,
-    'reveal_js_url' : reveal_js_url,
-    'font_awesome_url' : font_awesome_url,
+{# alternative external resources - not yet implemented as switch #}
+{% set cdn2_base = 'https://cdn.jsdelivr.net/npm/' %}
 
-    'mathjax_attr' : 'integrity="sha256-WUED7NFzpsmHtLO7bswSz4JSfkhE+cD4ncKeOznwFSY= sha384-paYjEtNXu9X/q6SBQB9EivI88vKEc/TiZWUaaH5j2Hi4vAOnVYmcahbzUELr3LHw sha512-BlZeGCIONWMdv9uCBB3I3hpY94r8I2e4DdNxyl4OOHYg0Y/LwwWDC4ioJr9vRaLNHwQG0oHiFdmqt7UaTCAZ0A==" crossorigin="anonymous"', 
+{% set mathjax_url_2      = cdn2_base ~ 'mathjax@2.7.5/unpacked/MathJax.min.js' %}
+{% set require_js_url_2   = 'https://requirejs.org/docs/release/2.3.6/minified/require.js' %}
+{% set jquery_url_2       = cdn2_base ~ 'jquery@3.3.1/dist/jquery.min.js' %}
+{% set reveal_js_url_2    = cdn2_base ~ 'reveal.js@3.7.0/js/reveal.min.js' %}
+{% set font_awesome_url_2 = 'https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' %}
 
-    'require_js_attr' : 'integrity="sha256-1fEPhSsRKlFKGfK3eO710tEweHh1fwokU5wFGDHO+vg= sha384-38qS6ZDmuc4fn68ICZ1CTMDv4+Yrqtpijvp5fwMNdbumNGNJ7JVJHgWr2X+nJfqM sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"', 
+{% set alternative_cdn      = {
+  'mathjax_url' : mathjax_url_2,
+  'require_js_url' : require_js_url_2,
+  'jquery_url' : jquery_url_2,
+  'reveal_js_url' : reveal_js_url_2,
+  'font_awesome_url' : font_awesome_url_2,
+  'mathjax_attr' : mathjax_attr,
+  'require_js_attr' : require_js_attr,
+  'jquery_attr' : jquery_attr,
+  'reveal_js_attr' : reveal_js_attr,
+  'font_awesome_attr' : font_awesome_attr,
+  } %}
 
-    'jquery_attr' : 'integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8= sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT sha512-+NqPlbbtM1QqiK8ZAo4Yrj2c4lNQoGv8P79DPtKzj++l5jnN39rHA/xsqn8zE9l0uSoxaCdrOgFs6yjyfbBxSg==" crossorigin="anonymous"',
+{# set local paths for resources #}
+{% set libs_dir  = 'libs/' %}
 
-    'reveal_js_attr' : 'integrity="sha256-Xr6ZH+/kc7hDVReZLO5khBknteLqu5oen/xnSraXrVk= sha384-YSZJq04Xw1k1QeTgkujYtdAjgN/sspQx01Qx4JPksOst7V7juBOa/XBwsIK+mJ7c sha512-47qp+bUV262nwngjB+lBR1txpTKevoQKlz3d1+0uvu6Zly3Q+Y+tR19xDDk4NnutJ9vu6uojPXQS4S3sOB06qw==" crossorigin="anonymous"',
+{% set mathjax_path      = libs_dir ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
+{% set require_js_path   = libs_dir ~ 'require.min.js' %}
+{% set jquery_path       = libs_dir ~ 'jquery.min.js' %}
+{% set reveal_js_path    = libs_dir ~ 'reveal.min.js' %}
+{% set font_awesome_path = libs_dir ~ 'font-awesome.css' %}
 
-    'font_awesome_attr' : 'integrity="sha256-NuCn4IvuZXdBaFKJOAcsU2Q3ZpwbdFisd5dux4jkQ5w= sha384-FckWOBo7yuyMS7In0aXZ0aoVvnInlnFMwCv77x9sZpFgOonQgnBj1uLwenWVtsEj sha512-5A8nwdMOWrSz20fDsjczgUidUBR8liPYU+WymTZP1lmY9G6Oc7HlZv156XqnsgNUzTyMefFTcsFH/tnJE/+xBg==" crossorigin="anonymous"',
-    } %}
-{% endif %}
+{% set local_paths      = {
+  'mathjax_url' : mathjax_path,
+  'require_js_url' : require_js_path,
+  'jquery_url' : jquery_path,
+  'reveal_js_url' : reveal_js_path,
+  'font_awesome_url' : font_awesome_path,
+  'mathjax_attr' : mathjax_attr,
+  'require_js_attr' : require_js_attr,
+  'jquery_attr' : jquery_attr,
+  'reveal_js_attr' : reveal_js_attr,
+  'font_awesome_attr' : font_awesome_attr,
+  } %}
+
+{% set all_urls = {
+  'default_cdn'     : default_cdn ,
+  'alternative_cdn' : alternative_cdn ,
+  'local_paths'     : local_paths ,
+} %}
+

--- a/nbconvert/templates/html/urls.tpl
+++ b/nbconvert/templates/html/urls.tpl
@@ -1,0 +1,7 @@
+{% set base_url      = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
+
+{% set mathjax_url   = base_url ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
+{% set requirejs_url = base_url ~ 'require.js/2.1.10/require.min.js' %}
+{% set jquery_url    = base_url ~ 'jquery/2.0.3/jquery.min.js' %}
+
+{% set urls          = { 'mathjax_url' : mathjax_url, 'requirejs_url' : requirejs_url, 'jquery_url' : jquery_url } %}

--- a/nbconvert/templates/html/urls.tpl
+++ b/nbconvert/templates/html/urls.tpl
@@ -1,5 +1,6 @@
 {% set default_cdn = true %}
 {% set cdn_alternative = false %}
+{% set set_link_attr = false %}
 
 {%-if default_cdn %}
   {% set cdn1_url = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
@@ -7,7 +8,7 @@
   {% set mathjax_url      = cdn1_url ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
   {% set require_js_url   = cdn1_url ~ 'require.js/2.3.6/require.min.js' %}
   {% set jquery_url       = cdn1_url ~ 'jquery/3.3.1/jquery.min.js' %}
-  {% set reveal_js        = cdn1_url ~ 'reveal.js/3.7.0/js/reveal.min.js' %}
+  {% set reveal_js_url        = cdn1_url ~ 'reveal.js/3.7.0/js/reveal.min.js' %}
   {% set font_awesome_url = cdn1_url ~ 'font-awesome/4.7.0/css/font-awesome.css' %}
 
 {% elif cdn_alternative %}
@@ -16,7 +17,7 @@
   {% set mathjax_url      = cdn2_url ~ 'mathjax@2.7.5/unpacked/MathJax.min.js' %}
   {% set require_js_url   = 'https://requirejs.org/docs/release/2.3.6/minified/require.js' %}
   {% set jquery_url       = cdn2_url ~ 'jquery@3.3.1/dist/jquery.min.js' %}
-  {% set reveal_js        = cdn2_url ~ 'reveal.js@3.7.0/js/reveal.min.js' %}
+  {% set reveal_js_url        = cdn2_url ~ 'reveal.js@3.7.0/js/reveal.min.js' %}
   {% set font_awesome_url = 'https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' %}
 
 {% else %}
@@ -25,7 +26,7 @@
   {% set mathjax_url      = libs_dir ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
   {% set require_js_url   = libs_dir ~ 'require.min.js' %}
   {% set jquery_url       = libs_dir ~ 'jquery.min.js' %}
-  {% set reveal_js        = libs_dir ~ 'reveal.min.js' %}
+  {% set reveal_js_url    = libs_dir ~ 'reveal.min.js' %}
   {% set font_awesome_url = libs_dir ~ 'font-awesome.css' %}
   
 {% endif %}
@@ -34,6 +35,31 @@
   'mathjax_url' : mathjax_url, 
   'require_js_url' : require_js_url, 
   'jquery_url' : jquery_url,
-  'reveal_js' : reveal_js,
-  'font_awesome_url' : font_awesome_url
+  'reveal_js_url' : reveal_js_url,
+  'font_awesome_url' : font_awesome_url,
+  'mathjax_attr' : '', 
+  'require_js_attr' : '', 
+  'jquery_attr' : '',
+  'reveal_js_attr' : '',
+  'font_awesome_attr' : '',
   } %}
+
+{%-if set_link_attr %}
+  {% set urls           = { 
+    'mathjax_url' : mathjax_url, 
+    'require_js_url' : require_js_url, 
+    'jquery_url' : jquery_url,
+    'reveal_js_url' : reveal_js_url,
+    'font_awesome_url' : font_awesome_url,
+
+    'mathjax_attr' : 'integrity="sha256-WUED7NFzpsmHtLO7bswSz4JSfkhE+cD4ncKeOznwFSY= sha384-paYjEtNXu9X/q6SBQB9EivI88vKEc/TiZWUaaH5j2Hi4vAOnVYmcahbzUELr3LHw sha512-BlZeGCIONWMdv9uCBB3I3hpY94r8I2e4DdNxyl4OOHYg0Y/LwwWDC4ioJr9vRaLNHwQG0oHiFdmqt7UaTCAZ0A==" crossorigin="anonymous"', 
+
+    'require_js_attr' : 'integrity="sha256-1fEPhSsRKlFKGfK3eO710tEweHh1fwokU5wFGDHO+vg= sha384-38qS6ZDmuc4fn68ICZ1CTMDv4+Yrqtpijvp5fwMNdbumNGNJ7JVJHgWr2X+nJfqM sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous"', 
+
+    'jquery_attr' : 'integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8= sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT sha512-+NqPlbbtM1QqiK8ZAo4Yrj2c4lNQoGv8P79DPtKzj++l5jnN39rHA/xsqn8zE9l0uSoxaCdrOgFs6yjyfbBxSg==" crossorigin="anonymous"',
+
+    'reveal_js_attr' : 'integrity="sha256-Xr6ZH+/kc7hDVReZLO5khBknteLqu5oen/xnSraXrVk= sha384-YSZJq04Xw1k1QeTgkujYtdAjgN/sspQx01Qx4JPksOst7V7juBOa/XBwsIK+mJ7c sha512-47qp+bUV262nwngjB+lBR1txpTKevoQKlz3d1+0uvu6Zly3Q+Y+tR19xDDk4NnutJ9vu6uojPXQS4S3sOB06qw==" crossorigin="anonymous"',
+
+    'font_awesome_attr' : 'integrity="sha256-NuCn4IvuZXdBaFKJOAcsU2Q3ZpwbdFisd5dux4jkQ5w= sha384-FckWOBo7yuyMS7In0aXZ0aoVvnInlnFMwCv77x9sZpFgOonQgnBj1uLwenWVtsEj sha512-5A8nwdMOWrSz20fDsjczgUidUBR8liPYU+WymTZP1lmY9G6Oc7HlZv156XqnsgNUzTyMefFTcsFH/tnJE/+xBg==" crossorigin="anonymous"',
+    } %}
+{% endif %}

--- a/nbconvert/templates/html/urls.tpl
+++ b/nbconvert/templates/html/urls.tpl
@@ -1,7 +1,21 @@
-{% set base_url      = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
+{% set cdn1_url = 'https://cdnjs.cloudflare.com/ajax/libs/' %}
+{# set cdn2_url = 'https://cdn.jsdelivr.net/npm/' #}
 
-{% set mathjax_url   = base_url ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
-{% set requirejs_url = base_url ~ 'require.js/2.1.10/require.min.js' %}
-{% set jquery_url    = base_url ~ 'jquery/2.0.3/jquery.min.js' %}
+{% set mathjax_url      = cdn1_url ~ 'mathjax/2.7.5/latest.js?config=TeX-AMS_HTML' %}
+{# set mathjax_url      = cdn2_url ~ 'mathjax@2.7.5/unpacked/MathJax.min.js' #}
+{% set require_js_url   = cdn1_url ~ 'require.js/2.3.6/require.min.js' %}
+{# set require_js_url   = 'https://requirejs.org/docs/release/2.3.6/minified/require.js' #}
+{% set jquery_url       = cdn1_url ~ 'jquery/3.3.1/jquery.min.js' %}
+{# set jquery_url       = cdn2_url ~ 'jquery@3.3.1/dist/jquery.min.js' #}
+{% set reveal_js        = cdn1_url ~ 'reveal.js/3.7.0/js/reveal.min.js' %}
+{# set reveal_js        = cdn2_url ~ 'reveal.js@3.7.0/js/reveal.min.js' #}
+{% set font_awesome_url = cdn1_url ~ 'font-awesome/4.7.0/css/font-awesome.css' %}
+{# set font_awesome_url = 'https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' #}
 
-{% set urls          = { 'mathjax_url' : mathjax_url, 'requirejs_url' : requirejs_url, 'jquery_url' : jquery_url } %}
+{% set urls           = { 
+  'mathjax_url' : mathjax_url, 
+  'require_js_url' : require_js_url, 
+  'jquery_url' : jquery_url,
+  'reveal_js' : reveal_js,
+  'font_awesome_url' : font_awesome_url
+  } %}


### PR DESCRIPTION
Hello,

This pull request is a bunch of stuff that is related and introduces two new options: 
* `--HTMLExporter.use_local_libs=<Bool>` _(Default: False)_
* `--HTMLExporter.use_sri_attr=<Bool>` _(Default: False)_

This allows you to create html output where resources are loaded from a local folder and/or hashes for the external resources are added within the tag loading the resource.

This (partially) addresses the following issues: https://github.com/jupyter/nbconvert/issues/238 https://github.com/jupyter/nbconvert/issues/754  https://github.com/jupyter/nbconvert/issues/761 https://github.com/jupyter/nbconvert/issues/763

The default behaviour is not changed (except for updated versions of the external resources)

## Changes/additions

* Update versions of external resources used (in `slides.py` still hardcoded)
  * jQuery 2.0.3 → jQuery 3.3.1
  * require.js 2.1.10 → require.js 2.3.6
  * reveal.js 3.5.0 → reveal.js 3.7.0 
* Created a template file for (eventually) all external resources `urls.tpl` in the `templates/html` folder
  * `urls.tpl` generates URLs for CDN (as they used to be hardcoded in `full.tpl`)
  * `urls.tpl` is imported in `full.tpl` and depending on the switches the variables are set
  * also generates alternative external URLs (not used yet…)
  * generates URLs for using local resources in the `libs/` folder relative to your HTML output file
* Small changes
  * update jinja url in docs

## Open issues

* __Make options available as switches in the main command, probably in `nbconvertapp.py`__ 
  * I couldn't get this to work (any help here would be appreciated)