### PR TITLE
Support pandoc 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,8 @@ addons:
     - cm-super # more fonts
     - texlive-xetex # latex to pdf converter
     - inkscape # for svgs in pdf output
-before_install:
-    - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
+    - wget https://github.com/jgm/pandoc/releases/download/2.7/pandoc-2.7-1-amd64.deb && sudo dpkg -i pandoc-2.7-1-amd64.deb
     - pip install --upgrade setuptools pip pytest
     - pip install -f travis-wheels/wheelhouse . codecov coverage
     - pip install nbconvert[execute,serve,test]

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -231,10 +231,10 @@ i.e. the $i^{th}$"""
     def test_markdown2rst(self):
         """markdown2rst test"""
 
-        #Modify token array for rst, escape asterik
+        #Modify token array for rst, escape asterisk
         tokens = copy(self.tokens)
         tokens[0] = r'\*test'
-        tokens[1] = r'\*\*test'
+        tokens[1] = r'\**test'
 
         for index, test in enumerate(self.tests):
             self._try_markdown(

--- a/nbconvert/utils/pandoc.py
+++ b/nbconvert/utils/pandoc.py
@@ -15,7 +15,7 @@ from ipython_genutils.py3compat import cast_bytes, which
 from .exceptions import ConversionException
 
 _minimal_version = "1.12.1"
-_maximal_version = "2.0.0"
+_maximal_version = "3.0.0"
 
 def pandoc(source, fmt, to, extra_args=None, encoding='utf-8'):
     """Convert an input string using pandoc.

--- a/nbconvert/utils/pandoc.py
+++ b/nbconvert/utils/pandoc.py
@@ -17,6 +17,7 @@ from .exceptions import ConversionException
 _minimal_version = "1.12.1"
 _maximal_version = "3.0.0"
 
+
 def pandoc(source, fmt, to, extra_args=None, encoding='utf-8'):
     """Convert an input string using pandoc.
 
@@ -94,6 +95,9 @@ def check_pandoc_version():
     PandocMissing
       If pandoc is unavailable.
     """
+    if check_pandoc_version._cached is not None:
+        return check_pandoc_version._cached
+
     v = get_pandoc_version()
     if v is None:
         warnings.warn("Sorry, we cannot determine the version of pandoc.\n"
@@ -102,6 +106,7 @@ def check_pandoc_version():
                       RuntimeWarning, stacklevel=2)
         return False
     ok = check_version(v, _minimal_version, max_v=_maximal_version)
+    check_pandoc_version._cached = ok
     if not ok:
         warnings.warn( "You are using an unsupported version of pandoc (%s).\n" % v +
                        "Your version must be at least (%s) " % _minimal_version +
@@ -109,6 +114,9 @@ def check_pandoc_version():
                        "Refer to http://pandoc.org/installing.html.\nContinuing with doubts...",
                        RuntimeWarning, stacklevel=2)
     return ok
+
+
+check_pandoc_version._cached = None
 
 #-----------------------------------------------------------------------------
 # Exception handling


### PR DESCRIPTION
One markdown test had slightly different output, but it appears harmless.

Tests are now run with pandoc 2.7 and the upper bound for the warning is now 3.0.

Additionally, cache `check_pandoc_version` output so that the warning occurs only once.

I'm not entirely sure we should be checking and warning about the pandoc upper bound at all.

closes #933
closes #928
closes #845
closes #815
closes #290