### PR TITLE
FIX: respect wait for clear_output

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -479,7 +479,7 @@ class ExecutePreprocessor(Preprocessor):
                 self.clear_output(outs, msg, cell_index)
                 continue
             elif msg_type.startswith('comm'):
-                self.handle_comm_msg(msg)
+                self.handle_comm_msg(outs, msg, cell_index)
                 continue
 
             display_id = None
@@ -531,7 +531,7 @@ class ExecutePreprocessor(Preprocessor):
             if cell_index in cell_map:
                 cell_map[cell_index] = []
 
-    def handle_comm_msg(self, msg):
+    def handle_comm_msg(self, outs, msg, cell_index):
         pass
 
 def executenb(nb, cwd=None, km=None, **kwargs):

--- a/nbconvert/preprocessors/tests/files/Clear Output.ipynb
+++ b/nbconvert/preprocessors/tests/files/Clear Output.ipynb
@@ -31,6 +31,158 @@
     "    clear_output()\n",
     "    print(i)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Hello world\")\n",
+    "clear_output()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello world\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Hello world\")\n",
+    "clear_output(wait=True)  # no output after this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "world\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Hello\")\n",
+    "clear_output(wait=True)  # here we have new output after wait=True\n",
+    "print(\"world\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hello world'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "handle0 = display(\"Hello world\", display_id=\"id0\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'world'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "handle1 = display(\"Hello\", display_id=\"id1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "handle1.update('world')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "handle2 = display(\"Hello world\", display_id=\"id2\")\n",
+    "clear_output()  # clears all output, also with display_ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hello world'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "handle3 = display(\"Hello world\", display_id=\"id3\")\n",
+    "clear_output(wait=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "world\n"
+     ]
+    }
+   ],
+   "source": [
+    "handle4 = display(\"Hello\", display_id=\"id4\")\n",
+    "clear_output(wait=True)\n",
+    "print('world')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "handle4.update('Hello world')  # it is cleared, so it should not show up in the above cell"
+   ]
   }
  ],
  "metadata": {},


### PR DESCRIPTION
clear_output was not respecting wait. This caused, for instance, ipywidgets' interact not to work https://github.com/QuantStack/voila/issues/85

The follow code:
```python
print("Hello world")
clear_output(wait=True)  # no output after this
```

did not output 'Hello world'. This is fixed with this PR. More complicated scenarios are tested in the notebook.