### PR TITLE
PDFExporter currently has its "output_mimetype" traitlet to be 'text/latex'

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -64,6 +64,8 @@ class PDFExporter(LatexExporter):
 
     texinputs = Unicode(help="texinputs dir. A notebook's directory is added")
     writer = Instance("nbconvert.writers.FilesWriter", args=(), kw={'build_directory': '.'})
+
+    output_mimetype = "application/pdf"
     
     _captured_output = List()
 


### PR DESCRIPTION
Closes https://github.com/jupyter/nbconvert/issues/970 

This causes issues when using "Export to pdf" option in the notebook,
as the notebook web application uses this traitlet's value as the
mimetype of the attached file.