### PR TITLE
Removed python 3.4 support, added 3.7 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,15 @@ sudo: required
 dist: trusty
 
 language: python
-python:
-    - "nightly"
-    - 3.6
-    - 3.5
-    - 3.4
-    - 2.7
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+    - python: nightly
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: required
 dist: trusty
 language: python
 
-language: python
 matrix:
     include:
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,19 @@
 # needs these two lines:
 sudo: required
 dist: trusty
+language: python
 
 language: python
 matrix:
-  include:
-    - python: 2.7
-    - python: 3.5
-    - python: 3.6
-    - python: 3.7
-      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
-    - python: nightly
+    include:
+        - python: 2.7
+        - python: 3.5
+        - python: 3.6
+        - python: 3.7
+          dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+        - python: nightly
+    allow_failures:
+        - python: nightly
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/bin:$PATH
@@ -41,6 +43,3 @@ script:
     - py.test --cov nbconvert -v --pyargs nbconvert
 after_success:
     - codecov
-matrix:
-    allow_failures:
-        - python: "nightly"

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ name = 'nbconvert'
 import sys
 
 v = sys.version_info
-if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,4)):
-    error = "ERROR: %s requires Python version 2.7 or 3.4 or above." % name
+if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,5)):
+    error = "ERROR: %s requires Python version 2.7 or 3.5 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -169,7 +169,7 @@ setup_args = dict(
     long_description= long_description,
     package_data    = package_data,
     cmdclass        = cmdclass,
-    python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     author          = 'Jupyter Development Team',
     author_email    = 'jupyter@googlegroups.com',
     url             = 'https://jupyter.org',
@@ -190,7 +190,6 @@ setup_args = dict(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Discussed in person with @mpacer -- given our several underlying libraries no longer support 3.4 and we see some consistent test failures on PRs with 3.4 we thought removing python 3.4 from nbconvert 5.5 would make sense.