### PR TITLE
Added tests for each branch in execute's run_cell method

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -463,7 +463,6 @@ class ExecutePreprocessor(Preprocessor):
                                 self.log.error(
                                     "Kernel died while waiting for execute reply.")
                                 raise RuntimeError("Kernel died")
-
                             # kernel still alive, wait for a message
                             continue
                         # message received
@@ -485,9 +484,9 @@ class ExecutePreprocessor(Preprocessor):
                 continue
 
     def run_cell(self, cell, cell_index=0):
-        msg_id = self.kc.execute(cell.source)
+        parent_msg_id = self.kc.execute(cell.source)
         self.log.debug("Executing cell:\n%s", cell.source)
-        exec_reply = self._wait_for_reply(msg_id, cell)
+        exec_reply = self._wait_for_reply(parent_msg_id, cell)
 
         outs = cell.outputs = []
         self.clear_before_next_output = False
@@ -506,7 +505,7 @@ class ExecutePreprocessor(Preprocessor):
                     raise RuntimeError("Timeout waiting for IOPub output")
                 else:
                     break
-            if msg['parent_header'].get('msg_id') != msg_id:
+            if msg['parent_header'].get('msg_id') != parent_msg_id:
                 # not an output from our execution
                 continue
 

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -23,7 +23,6 @@ from .base import PreprocessorTestsBase
 from ..execute import ExecutePreprocessor, CellExecutionError, executenb
 
 import IPython
-from mock import patch, MagicMock
 from traitlets import TraitError
 from nbformat import NotebookNode
 from jupyter_client.kernelspec import KernelSpecManager
@@ -35,6 +34,10 @@ try:
     TimeoutError  # Py 3
 except NameError:
     TimeoutError = RuntimeError  # Py 2
+try:
+    from unittest.mock import MagicMock, patch  # Py 3
+except ImportError:
+    from mock import MagicMock, patch  # Py 2
 
 addr_pat = re.compile(r'0x[0-9a-f]{7,9}')
 ipython_input_pat = re.compile(r'<ipython-input-\d+-[0-9a-f]+>')
@@ -47,14 +50,6 @@ def _normalize_base64(b64_text):
         return b64encode(b64decode(b64_text.encode('ascii'))).decode('ascii')
     except (ValueError, TypeError):
         return b64_text
-
-
-def merge_dicts(first, second):
-    # Because this is annoying to do inline
-    outcome = {}
-    outcome.update(first)
-    outcome.update(second)
-    return outcome
 
 
 class ExecuteTestBase(PreprocessorTestsBase):
@@ -120,7 +115,8 @@ class ExecuteTestBase(PreprocessorTestsBase):
             return MagicMock(
                 side_effect=[
                     # Default the parent_header so mocks don't need to include this
-                    merge_dicts({'parent_header': {'msg_id': parent_id}}, msg)
+                    ExecuteTestBase.merge_dicts(
+                        {'parent_header': {'msg_id': parent_id}}, msg)
                     for msg in messages
                 ]
             )

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -444,7 +444,7 @@ class TestRunCell(ExecuteTestBase):
     def test_idle_message(self, preprocessor, cell_mock, message_mock):
         preprocessor.run_cell(cell_mock)
         # Just the exit message should be fetched
-        message_mock.assert_called_once()
+        assert message_mock.call_count == 1
         # Ensure no outputs were generated
         assert cell_mock.outputs == []
 

--- a/nbconvert/tests/base.py
+++ b/nbconvert/tests/base.py
@@ -98,6 +98,14 @@ class TestsBase(unittest.TestCase):
         #Return directory handler
         return temp_dir
 
+    @classmethod
+    def merge_dicts(cls, *dict_args):
+        # Because this is annoying to do inline
+        outcome = {}
+        for d in dict_args:
+            outcome.update(d)
+        return outcome
+
     def create_empty_notebook(self, path):
         nb = v4.new_notebook()
         with io.open(path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
Refactoring run_cell wasn't really feasible to do safely without these tests. This should now allow https://github.com/jupyter/nbconvert/pull/905 to be tested (and updated) with all code paths that are currently supported.