### PR TITLE
Typo in template syntax

### DIFF
--- a/docs/source/customizing.ipynb
+++ b/docs/source/customizing.ipynb
@@ -154,7 +154,7 @@
     "{% extends 'python.tpl'%}\n",
     "\n",
     "## remove markdown cells\n",
-    "{% block markdowncell -%}\n",
+    "{% block markdowncell %}\n",
     "{% endblock markdowncell %}\n",
     "\n",
     "## change the appearance of execution count\n",


### PR DESCRIPTION
Removed extraneous minus that I don't think should be there.