### PR TITLE
Make latex errors less verbose

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -50,7 +50,7 @@ class PDFExporter(LatexExporter):
         help="How many times latex will be called."
     ).tag(config=True)
 
-    latex_command = List([u"xelatex", u"{filename}"],
+    latex_command = List([u"xelatex", u"{filename}", "-quiet"],
         help="Shell command used to compile latex."
     ).tag(config=True)
 


### PR DESCRIPTION
Passing the quiet flag to latex should make the output when latex throws an error far more user friendly. Warnings will be ignored, but things that actually stop the conversion or return a failure return code will still be displayed.

Example: Due to a simple error in converting math:
New output:
```
notebook2.tex:366: Display math should end with $$
notebook2.tex:368:
notebook2.tex:368: Missing
notebook2.tex:368: Display math should end with $$
```
Old Output:
```
This is XeTeX, Version 3.14159265-2.6-0.99999 (MiKTeX 2.9.6800 64-bit)
entering extended mode
(notebook2.tex
LaTeX2e <2018-04-01> patch level 5
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\base\article.cls"
Document Class: article 2014/09/29 v1.4h Standard LaTeX document class
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\base\size11.clo"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\base\fontenc.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\base\t1enc.def")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\lm\t1lmr.fd"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\psnfss\mathpazo.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\graphics\graphicx.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\graphics\keyval.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\graphics\graphics.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\graphics\trig.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\graphics-cfg\graphics.cf
g")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\graphics-def\xetex.def")
)) ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\caption\caption.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\caption\caption3.sty"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\adjustbox\adjustbox.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\xkeyval\xkeyval.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\xkeyval\xkeyval.tex"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\xkeyval\xkvutils.tex")
)) ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\adjustbox\adjcalc.sty
") ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\adjustbox\trimclip.st
y"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\collectbox\collectbox.st
y")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\adjustbox\tc-xetex.def")
) ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\ifoddpage\ifoddpage.st
y") ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\varwidth\varwidth.st
y")) ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\xcolor\xcolor.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\graphics-cfg\color.cfg")
) ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\tools\enumerate.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\geometry\geometry.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\ifpdf.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\ifvtex.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\ifxetex\ifxetex.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\xelatex\xetexconfig\geometry.c
fg")) ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\amsmath\amsmath.st
y"
For additional information on amsmath, use the `?' option.
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\amsmath\amstext.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\amsmath\amsgen.sty"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\amsmath\amsbsy.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\amsmath\amsopn.sty"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\amsfonts\amssymb.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\amsfonts\amsfonts.sty"))
 ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\base\textcomp.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\base\ts1enc.def"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\upquote\upquote.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\eurosym\eurosym.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\ucs\ucs.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\ucs\uni-global.def"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\base\inputenc.sty"

Package inputenc Warning: inputenc package ignored with utf8 based engines.

) ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\fancyvrb\fancyvrb.sty"

Style option: `fancyvrb' v2.7a, with DG/SPQR fixes, and firstline=lastline fix
<2008/02/07> (tvz))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\oberdiek\grffile.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\oberdiek\kvoptions.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\ltxcmds.sty")
 ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\kvsetkeys.st
y"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\infwarerr.sty
")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\etexcmds.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\ifluatex.sty"
))))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\pdftexcmds.st
y"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\hyperref\hyperref.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\hobsub-hyperr
ef.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\hobsub-generi
c.sty"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\oberdiek\auxhook.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\hyperref\pd1enc.def")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\00miktex\hyperref.cfg")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\url\url.sty"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\hyperref\hxetex.def"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\hyperref\puenc.def")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\stringenc.sty
")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\oberdiek\rerunfilecheck.
sty"))
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\tools\longtable.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\booktabs\booktabs.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\enumitem\enumitem.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\ulem\ulem.sty")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\jknappen\mathrsfs.sty")
(notebook2.aux)
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\base\ts1cmr.fd")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\psnfss\t1ppl.fd")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\caption\ltcaption.sty")
*geometry* detected driver: pdftex
*geometry* verbose mode - [ preamble ] result:
* driver: pdftex
* paper: <default>
* layout: <same size as paper>
* layoutoffset:(h,v)=(0.0pt,0.0pt)
* modes:
* h-part:(L,W,R)=(72.26999pt, 469.75502pt, 72.26999pt)
* v-part:(T,H,B)=(72.26999pt, 650.43001pt, 72.26999pt)
* \paperwidth=614.295pt
* \paperheight=794.96999pt
* \textwidth=469.75502pt
* \textheight=650.43001pt
* \oddsidemargin=0.0pt
* \evensidemargin=0.0pt
* \topmargin=-37.0pt
* \headheight=12.0pt
* \headsep=25.0pt
* \topskip=11.0pt
* \footskip=30.0pt
* \marginparwidth=59.0pt
* \marginparsep=10.0pt
* \columnsep=10.0pt
* \skip\footins=10.0pt plus 4.0pt minus 2.0pt
* \hoffset=0.0pt
* \voffset=0.0pt
* \mag=1000
* \@twocolumnfalse
* \@twosidefalse
* \@mparswitchfalse
* \@reversemarginfalse
* (1in=72.27pt=25.4mm, 1cm=28.453pt)

("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\ucs\ucsencs.def")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\hyperref\nameref.sty"
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\gettitlestrin
g.sty")) (notebook2.out) (notebook2.out)
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\psnfss\ot1ppl.fd")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\psnfss\omlzplm.fd")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\psnfss\omszplm.fd")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\psnfss\omxzplm.fd")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\psnfss\ot1zplm.fd")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\jknappen\ursfs.fd")

LaTeX Warning: No \author given.


("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\generic\oberdiek\se-ascii-prin
t.def") ("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\lm\t1lmtt.fd")
("E:\TMOko\AppData\Local\Programs\MiKTeX 2.9\tex\latex\lm\ts1lmtt.fd") [1]
Underfull \hbox (badness 10000) in paragraph at lines 357--358

! Display math should end with $$.
<to be read again>

l.366 \$\[$

?

! LaTeX Error: Bad math environment delimiter.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...

l.368 \]

?
! Missing $ inserted.
<inserted text>
                $
l.368 \]

?
! Display math should end with $$.
<to be read again>
                   \endgroup
l.368 \]

?
[2] (notebook2.aux) )
Output written on notebook2.pdf (2 pages).
Transcript written on notebook2.log.
```