### PR TITLE
Strict Placement of Images from Markdown

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -50,7 +50,7 @@ class PDFExporter(LatexExporter):
         help="How many times latex will be called."
     ).tag(config=True)
 
-    latex_command = List([u"xelatex", u"{filename}"],
+    latex_command = List([u"xelatex", u"{filename}", "-quiet"],
         help="Shell command used to compile latex."
     ).tag(config=True)
 

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -65,6 +65,8 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
                                 % normalem makes italics be italics, not underlines
     \usepackage{mathrsfs}
+    \usepackage{float}
+    \floatplacement{figure}{H} % force markdown images to be in the proper location.
     ((* endblock packages *))
 
     ((* block definitions *))


### PR DESCRIPTION
When pandoc converts markdown images it places them inside a ```\begin{figure}…\end{figure}```. Since the ```figure``` environment is a float, latex will place the image where is seems fit and likely not the same location as in the notebook. This fixes that. (Issue mentioned [here](https://github.com/jupyter/nbconvert/issues/552#issuecomment-478138406).)