### PR TITLE
[WIP] Strict placement of images

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -65,6 +65,8 @@ This template does not define a docclass, the inheriting class must define this.
     \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
                                 % normalem makes italics be italics, not underlines
     \usepackage{mathrsfs}
+    \usepackage{float}
+    \floatplacement{figure}{H}
     ((* endblock packages *))
 
     ((* block definitions *))


### PR DESCRIPTION
When pandoc converts markdown images to latex it places them inside a ```\begin{figure}…\end{figure}```. Since the ```figure``` environment is a float, latex will place the image where is seems fit which is likely not the same location as in the notebook. This fixes that. (Issue mentioned [here](https://github.com/jupyter/nbconvert/issues/552#issuecomment-478138406).)