### PR TITLE
Fixing #659 (output cutoff and iopub timeout)

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -537,7 +537,6 @@ class ExecutePreprocessor(Preprocessor):
         polling_exec_reply = True
 
         while more_output or polling_exec_reply:
-
             if polling_exec_reply:
                 if self._passed_deadline(deadline):
                     polling_exec_reply = False
@@ -559,7 +558,7 @@ class ExecutePreprocessor(Preprocessor):
                         continue
 
                     if self.raise_on_iopub_timeout:
-                        raise RuntimeError("Timeout waiting for IOPub output")
+                        raise TimeoutError("Timeout waiting for IOPub output")
                     else:
                         self.log.warning("Timeout waiting for IOPub output")
                         more_output = False
@@ -568,11 +567,11 @@ class ExecutePreprocessor(Preprocessor):
                 # not an output from our execution
                 continue
 
-            # Will raise CellExecutionComplete when completed
             try:
+                # Will raise CellExecutionComplete when completed
                 self.process_message(msg, cell, cell_index)
             except CellExecutionComplete:
-                break
+                more_output = False
 
         # Return cell.outputs still for backwards compatability
         return exec_reply, cell.outputs

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -508,8 +508,8 @@ class ExecutePreprocessor(Preprocessor):
                 continue
 
     def _timeout_with_deadline(self, timeout, deadline):
-        if deadline is not None and deadline - time.time() < timeout:
-            timeout = deadline - time.time()
+        if deadline is not None and deadline - time.monotonic() < timeout:
+            timeout = deadline - time.monotonic()
 
         if timeout < 0:
             timeout = 0
@@ -517,7 +517,7 @@ class ExecutePreprocessor(Preprocessor):
         return timeout
 
     def _passed_deadline(self, deadline):
-        if deadline is not None and deadline - time.time() <= 0:
+        if deadline is not None and deadline - time.monotonic() <= 0:
             self._handle_timeout()
             return True
         return False
@@ -527,7 +527,7 @@ class ExecutePreprocessor(Preprocessor):
         self.log.debug("Executing cell:\n%s", cell.source)
         exec_timeout = self._get_timeout(cell)
         if exec_timeout is not None:
-            deadline = time.time() + exec_timeout # verify this is correct. (monotonic)
+            deadline = time.monotonic() + exec_timeout
 
         cell.outputs = []
         self.clear_before_next_output = False

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -7,9 +7,9 @@ import base64
 from textwrap import dedent
 from contextlib import contextmanager
 try:
-    from time import monotonic
+    from time import monotonic # Py 3
 except ImportError:
-    from time import time as monotonic
+    from time import time as monotonic # Py 2
 
 try:
     from queue import Empty  # Py 3
@@ -526,6 +526,7 @@ class ExecutePreprocessor(Preprocessor):
         parent_msg_id = self.kc.execute(cell.source)
         self.log.debug("Executing cell:\n%s", cell.source)
         exec_timeout = self._get_timeout(cell)
+        deadline = None
         if exec_timeout is not None:
             deadline = monotonic() + exec_timeout
 

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -460,10 +460,7 @@ class ExecutePreprocessor(Preprocessor):
                 return msg
         except Empty:
             # received no message, check if kernel is still alive
-            if not self.kc.is_alive():
-                self.log.error(
-                    "Kernel died while waiting for execute reply.")
-                raise RuntimeError("Kernel died")
+            self._check_alive()
             # kernel still alive, wait for a message
 
     def _get_timeout(self, cell):

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -539,7 +539,6 @@ class ExecutePreprocessor(Preprocessor):
 
             if polling_exec_reply:
                 if self._passed_deadline(deadline):
-                    self._handle_timeout()
                     polling_exec_reply = False
                     continue
 

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -4,9 +4,12 @@ and updates outputs"""
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 import base64
-import time
 from textwrap import dedent
 from contextlib import contextmanager
+try:
+    from time import monotonic
+except ImportError:
+    from time import time as monotonic
 
 try:
     from queue import Empty  # Py 3
@@ -508,8 +511,8 @@ class ExecutePreprocessor(Preprocessor):
                 continue
 
     def _timeout_with_deadline(self, timeout, deadline):
-        if deadline is not None and deadline - time.monotonic() < timeout:
-            timeout = deadline - time.monotonic()
+        if deadline is not None and deadline - monotonic() < timeout:
+            timeout = deadline - monotonic()
 
         if timeout < 0:
             timeout = 0
@@ -517,7 +520,7 @@ class ExecutePreprocessor(Preprocessor):
         return timeout
 
     def _passed_deadline(self, deadline):
-        if deadline is not None and deadline - time.monotonic() <= 0:
+        if deadline is not None and deadline - monotonic() <= 0:
             self._handle_timeout()
             return True
         return False
@@ -527,7 +530,7 @@ class ExecutePreprocessor(Preprocessor):
         self.log.debug("Executing cell:\n%s", cell.source)
         exec_timeout = self._get_timeout(cell)
         if exec_timeout is not None:
-            deadline = time.monotonic() + exec_timeout
+            deadline = monotonic() + exec_timeout
 
         cell.outputs = []
         self.clear_before_next_output = False

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -480,7 +480,6 @@ class ExecutePreprocessor(Preprocessor):
         if self.interrupt_on_timeout:
             self.log.error("Interrupting kernel")
             self.km.interrupt_kernel()
-            return
         else:
             raise TimeoutError("Cell execution timed out")
 

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -581,7 +581,9 @@ class ExecutePreprocessor(Preprocessor):
         """
         Processes a kernel message, updates cell state, and returns the
         resulting output object that was appended to cell.outputs.
+
         The input argument `cell` is modified in-place.
+
         Parameters
         ----------
         msg : dict
@@ -590,6 +592,7 @@ class ExecutePreprocessor(Preprocessor):
             The cell which is currently being processed.
         cell_index : int
             The position of the cell within the notebook object.
+
         Returns
         -------
         output : dict

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -515,7 +515,7 @@ class TestRunCell(PreprocessorTestsBase):
         # Ensure no outputs were generated
         assert cell_mock.outputs == []
 
-    @ExecuteTestBase.prepare_cell_mocks({
+   @prepare_cell_mocks({
         'msg_type': 'stream',
         'header': {'msg_type': 'stream'},
         'content': {'name': 'stdout', 'text': 'foo'},
@@ -539,7 +539,7 @@ class TestRunCell(PreprocessorTestsBase):
             {'output_type': 'stream', 'name': 'stderr', 'text': 'bar'}
         ])
 
-    @ExecuteTestBase.prepare_cell_mocks()
+   @prepare_cell_mocks()
     def test_deadline_iopub(self, preprocessor, cell_mock, message_mock):
         # The shell_channel will complete, so we expect only to hit the iopub timeout.
         message_mock.side_effect = Empty()
@@ -548,7 +548,7 @@ class TestRunCell(PreprocessorTestsBase):
         with pytest.raises(TimeoutError):
             preprocessor.run_cell(cell_mock)
 
-    @ExecuteTestBase.prepare_cell_mocks({
+   @prepare_cell_mocks({
         'msg_type': 'stream',
         'header': {'msg_type': 'stream'},
         'content': {'name': 'stdout', 'text': 'foo'},
@@ -574,7 +574,7 @@ class TestRunCell(PreprocessorTestsBase):
             {'output_type': 'stream', 'name': 'stderr', 'text': 'bar'}
         ])
 
-    @ExecuteTestBase.prepare_cell_mocks({
+   @prepare_cell_mocks({
         'msg_type': 'execute_input',
         'header': {'msg_type': 'execute_input'},
         'content': {}

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -515,7 +515,7 @@ class TestRunCell(PreprocessorTestsBase):
         # Ensure no outputs were generated
         assert cell_mock.outputs == []
 
-   @prepare_cell_mocks({
+    @prepare_cell_mocks({
         'msg_type': 'stream',
         'header': {'msg_type': 'stream'},
         'content': {'name': 'stdout', 'text': 'foo'},
@@ -539,7 +539,7 @@ class TestRunCell(PreprocessorTestsBase):
             {'output_type': 'stream', 'name': 'stderr', 'text': 'bar'}
         ])
 
-   @prepare_cell_mocks()
+    @prepare_cell_mocks()
     def test_deadline_iopub(self, preprocessor, cell_mock, message_mock):
         # The shell_channel will complete, so we expect only to hit the iopub timeout.
         message_mock.side_effect = Empty()
@@ -548,7 +548,7 @@ class TestRunCell(PreprocessorTestsBase):
         with pytest.raises(TimeoutError):
             preprocessor.run_cell(cell_mock)
 
-   @prepare_cell_mocks({
+    @prepare_cell_mocks({
         'msg_type': 'stream',
         'header': {'msg_type': 'stream'},
         'content': {'name': 'stdout', 'text': 'foo'},
@@ -574,7 +574,7 @@ class TestRunCell(PreprocessorTestsBase):
             {'output_type': 'stream', 'name': 'stderr', 'text': 'bar'}
         ])
 
-   @prepare_cell_mocks({
+    @prepare_cell_mocks({
         'msg_type': 'execute_input',
         'header': {'msg_type': 'execute_input'},
         'content': {}


### PR DESCRIPTION
@MSeal @mpacer This is probably a little rough but figured this might be a good place to start.

I still need to add a test showing that this fixes my example. #659 

I'll follow up with changing things towards this https://github.com/jupyter/nbconvert/issues/659#issuecomment-485063446, though the reason that this seems more complex than the suggestion there was I was trying to maintain the current behavior in as many cases as possible.

In particular, the test cases seemed to fail with a "The handle is invalid" error if exec_reply is polled too late, but I'll still give a shot at your suggestion and let you know how it goes.

I'm busy today but might try to play with this Sunday or when I get back to work on Monday.