### PR TITLE
fix export_from_notebook names

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -23,6 +23,7 @@ class HTMLExporter(TemplateExporter):
     custom preprocessors/filters.  If you don't need custom preprocessors/
     filters, just change the 'template_file' config option.
     """
+    export_from_notebook = "html"
 
     anchor_link_text = Unicode(u'¶',
         help="The text used as the text for anchor links.").tag(config=True)

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -102,8 +102,6 @@ class TemplateExporter(Exporter):
 
     _template_cached = None
 
-    export_from_notebook = "custom"
-
     def _invalidate_template_cache(self, change=None):
         self._template_cached = None
 


### PR DESCRIPTION
When looking at #938, I noticed that the template exporter has ```export_from_notebook``` defined which means it appears in the notebook's download as menu, and the html exporter was inheriting this.