### PR TITLE
WIP - Add JupyterLab template

### DIFF
--- a/nbconvert/templates/html/lab_basic.tpl
+++ b/nbconvert/templates/html/lab_basic.tpl
@@ -1,0 +1,282 @@
+{%- extends 'display_priority.tpl' -%}
+
+{% block codecell %}
+{%- if not cell.outputs -%}
+{%- set extra_class="jp-mod-noOutput" -%}
+{%- endif -%}
+<div class="jp-Cell jp-CodeCell jp-Notebook-cell {{ extra_class }}">
+{{ super() }}
+</div>
+{%- endblock codecell %}
+
+{% block input_group -%}
+<div class="jp-Cell-inputWrapper">
+{{ super() }}
+</div>
+{% endblock input_group %}
+
+{% block input %}
+<div class="jp-InputArea jp-Cell-inputArea">
+    <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+        <div class="CodeMirror cm-s-jupyter">
+{{ cell.source | highlight_code(metadata=cell.metadata) }}
+        </div>
+    </div>
+</div>
+{%- endblock input %}
+
+{% block output_group %}
+<div class="jp-Cell-outputWrapper">
+{{ super() }}
+</div>
+{% endblock output_group %}
+
+{% block outputs %}
+<div class="jp-OutputArea jp-Cell-outputArea">
+{{ super() }}
+</div>
+{% endblock outputs %}
+
+{% block output %}
+<div class="jp-OutputArea-child">
+{% if resources.global_content_filter.include_output_prompt %}
+    {{ self.output_area_prompt() }}
+{% endif %}
+{{ super() }}
+</div>
+{% endblock output %}
+
+{% block in_prompt -%}
+<div class="jp-InputPrompt jp-InputArea-prompt">
+    {%- if cell.execution_count is defined -%}
+        In&nbsp;[{{ cell.execution_count|replace(None, "&nbsp;") }}]:
+    {%- else -%}
+        In&nbsp;[&nbsp;]:
+    {%- endif -%}
+</div>
+{%- endblock in_prompt %}
+
+{% block empty_in_prompt -%}
+<div class="jp-InputPrompt jp-InputArea-prompt">
+</div>
+{%- endblock empty_in_prompt %}
+
+{# 
+ ###############################################################################
+ # Note: the output_prompt block is is empty because there is already a prompt #
+ # div in each output area.                                                    #
+ ###############################################################################
+ #}
+
+{% block output_prompt %}
+{% endblock output_prompt %}
+
+{% block output_area_prompt %}
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">
+{%- if output.output_type == 'execute_result' -%}
+    {%- if cell.execution_count is defined -%}
+        Out[{{ cell.execution_count|replace(None, "&nbsp;") }}]:
+    {%- else -%}
+        Out[&nbsp;]:
+    {%- endif -%}
+{%- endif -%}
+    </div>
+{% endblock output_area_prompt %}
+
+{% block markdowncell scoped %}
+<div class="jp-Cell-inputWrapper">
+{%- if resources.global_content_filter.include_input_prompt-%}
+    {{ self.empty_in_prompt() }}
+{%- endif -%}
+<div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
+{{ cell.source  | markdown2html | strip_files_prefix }}
+</div>
+</div>
+{%- endblock markdowncell %}
+
+{% block unknowncell scoped %}
+unknown type  {{ cell.type }}
+{% endblock unknowncell %}
+
+{% block execute_result -%}
+{%- set extra_class="jp-OutputArea-executeResult" -%}
+{% block data_priority scoped %}
+{{ super() }}
+{% endblock data_priority %}
+{%- set extra_class="" -%}
+{%- endblock execute_result %}
+
+{% block stream_stdout -%}
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>
+{{- output.text | ansi2html -}}
+</pre>
+</div>
+{%- endblock stream_stdout %}
+
+{% block stream_stderr -%}
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>
+{{- output.text | ansi2html -}}
+</pre>
+</div>
+{%- endblock stream_stderr %}
+
+{% block data_svg scoped -%}
+<div class="jp-RenderedSVG jp-OutputArea-output {{ extra_class }}" data-mime-type="image/svg+xml">
+{%- if output.svg_filename %}
+<img src="{{ output.svg_filename | posix_path }}"
+{%- else %}
+{{ output.data['image/svg+xml'] }}
+{%- endif %}
+</div>
+{%- endblock data_svg %}
+
+{% block data_html scoped -%}
+<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output {{ extra_class }}" data-mime-type="text/html">
+{{ output.data['text/html'] }}
+</div>
+{%- endblock data_html %}
+
+{% block data_markdown scoped -%}
+<div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-OutputArea-output {{ extra_class }}" data-mime-type="text/markdown">
+{{ output.data['text/markdown'] | markdown2html }}
+</div>
+{%- endblock data_markdown %}
+
+{% block data_png scoped %}
+<div class="jp-RenderedImage jp-OutputArea-output {{ extra_class }}">
+{%- if 'image/png' in output.metadata.get('filenames', {}) %}
+<img src="{{ output.metadata.filenames['image/png'] | posix_path }}"
+{%- else %}
+<img src="data:image/png;base64,{{ output.data['image/png'] }}"
+{%- endif %}
+{%- set width=output | get_metadata('width', 'image/png') -%}
+{%- if width is not none %}
+width={{ width }}
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/png') -%}
+{%- if height is not none %}
+height={{ height }}
+{%- endif %}
+{%- if output | get_metadata('unconfined', 'image/png') %}
+class="unconfined"
+{%- endif %}
+>
+</div>
+{%- endblock data_png %}
+
+{% block data_jpg scoped %}
+<div class="jp-RenderedImage jp-OutputArea-output {{ extra_class }}">
+{%- if 'image/jpeg' in output.metadata.get('filenames', {}) %}
+<img src="{{ output.metadata.filenames['image/jpeg'] | posix_path }}"
+{%- else %}
+<img src="data:image/jpeg;base64,{{ output.data['image/jpeg'] }}"
+{%- endif %}
+{%- set width=output | get_metadata('width', 'image/jpeg') -%}
+{%- if width is not none %}
+width={{ width }}
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/jpeg') -%}
+{%- if height is not none %}
+height={{ height }}
+{%- endif %}
+{%- if output | get_metadata('unconfined', 'image/jpeg') %}
+class="unconfined"
+{%- endif %}
+>
+</div>
+{%- endblock data_jpg %}
+
+{% block data_latex scoped %}
+<div class="jp-RenderedLatex jp-OutputArea-output {{ extra_class }}" data-mime-type="text/latex">
+{{ output.data['text/latex'] }}
+</div>
+{%- endblock data_latex %}
+
+{% block error -%}
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>
+{{- super() -}}
+</pre>
+</div>
+{%- endblock error %}
+
+{%- block traceback_line %}
+{{ line | ansi2html }}
+{%- endblock traceback_line %}
+
+{%- block data_text scoped %}
+<div class="jp-RenderedText jp-OutputArea-output {{ extra_class }}" data-mime-type="text/plain">
+<pre>
+{{- output.data['text/plain'] | ansi2html -}}
+</pre>
+</div>
+{%- endblock -%}
+
+{# 
+ ###############################################################################
+ # TODO: how to better handle JavaScript repr?                                 #
+ ###############################################################################
+ #}
+
+{% set div_id = uuid4() %}
+{%- block data_javascript scoped %}
+<div id="{{ div_id }}"></div>
+<div class="jp-RenderedJavaScript jp-OutputArea-output {{ extra_class }}" data-mime-type="application/javascript">
+<script type="text/javascript">
+var element = $('#{{ div_id }}');
+{{ output.data['application/javascript'] }}
+</script>
+</div>
+{%- endblock -%}
+
+{%- block data_widget_state scoped %}
+data_widget_state
+{#
+{% set div_id = uuid4() %}
+{% set datatype_list = output.data | filter_data_type %} 
+{% set datatype = datatype_list[0]%} 
+<div id="{{ div_id }}"></div>
+<div class="output_subarea output_widget_state {{ extra_class }}">
+<script type="text/javascript">
+var element = $('#{{ div_id }}');
+</script>
+<script type="{{ datatype }}">
+{{ output.data[datatype] | json_dumps }}
+</script>
+</div>
+#}
+{%- endblock data_widget_state -%}
+
+{# 
+ ###############################################################################
+ # TODO: the widget output area does not exist anymore. How should this be     #
+ # handled?                                                                    #
+ ###############################################################################
+ #}
+
+{%- block data_widget_view scoped %}
+{% set div_id = uuid4() %}
+{% set datatype_list = output.data | filter_data_type %} 
+{% set datatype = datatype_list[0]%} 
+<div id="{{ div_id }}"></div>
+<div class="jupyter-widgets jp-OutputArea-output {{ extra_class }}">
+<script type="text/javascript">
+var element = $('#{{ div_id }}');
+</script>
+<script type="{{ datatype }}">
+{{ output.data[datatype] | json_dumps }}
+</script>
+</div>
+{%- endblock data_widget_view -%}
+
+{%- block footer %}
+{% set mimetype = 'application/vnd.jupyter.widget-state+json'%} 
+{% if mimetype in nb.metadata.get("widgets",{})%}
+<script type="{{ mimetype }}">
+{{ nb.metadata.widgets[mimetype] | json_dumps }}
+</script>
+{% endif %}
+{{ super() }}
+{%- endblock footer-%}

--- a/nbconvert/templates/html/lab_full.tpl
+++ b/nbconvert/templates/html/lab_full.tpl
@@ -1,0 +1,175 @@
+{%- extends 'lab_basic.tpl' -%}
+{% from 'mathjax.tpl' import mathjax %}
+
+{%- block header -%}
+<!DOCTYPE html>
+<html>
+<head>
+{%- block html_head -%}
+<meta charset="utf-8" />
+{% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
+<title>{{nb_title}}</title>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+
+{% block ipywidgets %}
+{%- if "widgets" in nb.metadata -%}
+<script>
+(function() {
+  function addWidgetsRenderer() {
+    var mimeElement = document.querySelector('script[type="application/vnd.jupyter.widget-view+json"]');
+    var scriptElement = document.createElement('script');
+    var widgetRendererSrc = '{{ resources.ipywidgets_base_url }}@jupyter-widgets/html-manager@*/dist/embed-amd.js';
+    var widgetState;
+
+    // Fallback for older version:
+    try {
+      widgetState = mimeElement && JSON.parse(mimeElement.innerHTML);
+
+      if (widgetState && (widgetState.version_major < 2 || !widgetState.version_major)) {
+        widgetRendererSrc = '{{ resources.ipywidgets_base_url }}jupyter-js-widgets@*/dist/embed.js';
+      }
+    } catch(e) {}
+
+    scriptElement.src = widgetRendererSrc;
+    document.body.appendChild(scriptElement);
+  }
+
+  document.addEventListener('DOMContentLoaded', addWidgetsRenderer);
+}());
+</script>
+{%- endif -%}
+{% endblock ipywidgets %}
+
+{# 
+ ############################################
+ # TODO: use "resources" to provide lab CSS #
+ ############################################
+ #}
+
+{#
+{% for css in resources.inlining.css -%}
+    <style type="text/css">
+    {{ css }}
+    </style>
+{% endfor %}
+#}
+
+<link rel="stylesheet" href="https://unpkg.com/font-awesome@4.5.0/css/font-awesome.min.css" type="text/css" />
+<link rel="stylesheet" href="https://unpkg.com/@jupyterlab/cells@0.19.1/style/index.css" type="text/css" />
+<link rel="stylesheet" href="https://unpkg.com/@jupyterlab/outputarea@0.19.1/style/index.css" type="text/css" />
+<link rel="stylesheet" href="https://unpkg.com/@jupyterlab/notebook@1.0.0-alpha.7/style/index.css" type="text/css" />
+<link rel="stylesheet" href="https://unpkg.com/@jupyterlab/codemirror@1.0.0-alpha.6/style/index.css" type="text/css" />
+<link rel="stylesheet" href="https://unpkg.com/@jupyterlab/rendermime@1.0.0-alpha.6/style/index.css" type="text/css" />
+<link rel="stylesheet" href="https://unpkg.com/@jupyterlab/theme-light-extension@1.0.0-alpha.7/style/index.css" type="text/css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pygments-css@1.0.0/default.css" type="text/css">
+
+<style>
+a.anchor-link {
+  display: none;
+}
+
+.highlight  {
+  margin: 0.4em;
+}
+</style>
+
+{# 
+ ############################################################
+ # TODO: use generate pygment style using lab CSS variables #
+ ############################################################
+ #}
+
+<style>
+.highlight  { background: var(--jp-cell-editor-background); }
+.highlight .hll { background-color: #ffffcc; }
+
+.highlight .k { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword */
+.highlight .err { border: 1px solid var(--jp-mirror-editor-error-color) } /* Error */
+
+.highlight .c { color: var(--jp-mirror-editor-comment-color); font-style: italic } /* Comment */
+.highlight .o { color: #666666 } /* Operator .highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: var(--jp-mirror-editor-comment-color); font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
+.highlight .cpf { color: var(--jp-mirror-editor-comment-color); font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: var(--jp-mirror-editor-comment-color); font-style: italic } /* Comment.Single */
+.highlight .cs { color: var(-jp-mirror-editor-comment-color); font-style: italic } /* Comment.Special */
+
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #B00040 } /* Keyword.Type */
+.highlight .m { color: var(--jp-mirror-editor-number-color); } /* Literal.Number */
+.highlight .s { color: var(--jp-mirror-editor-string-color); } /* Literal.String */
+.highlight .na { color: #7D9029 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.highlight .no { color: #880000 } /* Name.Constant */
+.highlight .nd { color: #AA22FF } /* Name.Decorator */
+.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #0000FF } /* Name.Function */
+.highlight .nl { color: #A0A000 } /* Name.Label */
+.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #19177C } /* Name.Variable */
+.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #666666 } /* Literal.Number.Bin */
+.highlight .mf { color: #666666 } /* Literal.Number.Float */
+.highlight .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
+.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
+.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #008000 } /* Literal.String.Other */
+.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #0000FF } /* Name.Function.Magic */
+.highlight .vc { color: #19177C } /* Name.Variable.Class */
+.highlight .vg { color: #19177C } /* Name.Variable.Global */
+.highlight .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight .vm { color: #19177C } /* Name.Variable.Magic */
+.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
+</style>
+
+<!-- Loading mathjax macro -->
+{{ mathjax() }}
+{%- endblock html_head -%}
+</head>
+{%- endblock header -%}
+
+{% block body %}
+<body>
+  <div class="jp-Notebook" tabindex="-1">
+{{ super() }}
+  </div>
+</body>
+{%- endblock body %}
+
+{% block footer %}
+{{ super() }}
+</html>
+{% endblock footer %}

--- a/nbconvert/templates/html/lab_full.tpl
+++ b/nbconvert/templates/html/lab_full.tpl
@@ -76,83 +76,52 @@ a.anchor-link {
 </style>
 
 {# 
- ############################################################
- # TODO: use generate pygment style using lab CSS variables #
- ############################################################
+ ####################################################
+ # Generated pygments style using lab CSS variables #
+ ####################################################
  #}
 
 <style>
+.highlight .hll { background-color: #ffffcc }
 .highlight  { background: var(--jp-cell-editor-background); }
-.highlight .hll { background-color: #ffffcc; }
-
+.highlight .c { color: var(--jp-mirror-editor-comment-color) } /* Comment */
+.highlight .err { color: var(--jp-mirror-editor-error-color) } /* Error */
 .highlight .k { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword */
-.highlight .err { border: 1px solid var(--jp-mirror-editor-error-color) } /* Error */
-
-.highlight .c { color: var(--jp-mirror-editor-comment-color); font-style: italic } /* Comment */
-.highlight .o { color: #666666 } /* Operator .highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
-.highlight .cm { color: var(--jp-mirror-editor-comment-color); font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
-.highlight .cpf { color: var(--jp-mirror-editor-comment-color); font-style: italic } /* Comment.PreprocFile */
-.highlight .c1 { color: var(--jp-mirror-editor-comment-color); font-style: italic } /* Comment.Single */
-.highlight .cs { color: var(-jp-mirror-editor-comment-color); font-style: italic } /* Comment.Special */
-
-.highlight .gd { color: #A00000 } /* Generic.Deleted */
-.highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gr { color: #FF0000 } /* Generic.Error */
-.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight .gi { color: #00A000 } /* Generic.Inserted */
-.highlight .go { color: #888888 } /* Generic.Output */
-.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
-.highlight .gs { font-weight: bold } /* Generic.Strong */
-.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight .gt { color: #0044DD } /* Generic.Traceback */
-.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
-.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
-.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
-.highlight .kp { color: #008000 } /* Keyword.Pseudo */
-.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: #B00040 } /* Keyword.Type */
-.highlight .m { color: var(--jp-mirror-editor-number-color); } /* Literal.Number */
-.highlight .s { color: var(--jp-mirror-editor-string-color); } /* Literal.String */
-.highlight .na { color: #7D9029 } /* Name.Attribute */
-.highlight .nb { color: #008000 } /* Name.Builtin */
-.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
-.highlight .no { color: #880000 } /* Name.Constant */
-.highlight .nd { color: #AA22FF } /* Name.Decorator */
-.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
-.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
-.highlight .nf { color: #0000FF } /* Name.Function */
-.highlight .nl { color: #A0A000 } /* Name.Label */
-.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
-.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
-.highlight .nv { color: #19177C } /* Name.Variable */
-.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
-.highlight .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight .mb { color: #666666 } /* Literal.Number.Bin */
-.highlight .mf { color: #666666 } /* Literal.Number.Float */
-.highlight .mh { color: #666666 } /* Literal.Number.Hex */
-.highlight .mi { color: #666666 } /* Literal.Number.Integer */
-.highlight .mo { color: #666666 } /* Literal.Number.Oct */
-.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
-.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
-.highlight .sc { color: #BA2121 } /* Literal.String.Char */
-.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
-.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
-.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
-.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
-.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
-.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
-.highlight .sx { color: #008000 } /* Literal.String.Other */
-.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
-.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
-.highlight .ss { color: #19177C } /* Literal.String.Symbol */
-.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
-.highlight .fm { color: #0000FF } /* Name.Function.Magic */
-.highlight .vc { color: #19177C } /* Name.Variable.Class */
-.highlight .vg { color: #19177C } /* Name.Variable.Global */
-.highlight .vi { color: #19177C } /* Name.Variable.Instance */
-.highlight .vm { color: #19177C } /* Name.Variable.Magic */
-.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
+.highlight .o { color: var(--jp-mirror-editor-operator-color) } /* Operator */
+.highlight .ch { color: var(--jp-mirror-editor-comment-color) } /* Comment.Hashbang */
+.highlight .cm { color: var(--jp-mirror-editor-comment-color) } /* Comment.Multiline */
+.highlight .cp { color: var(--jp-mirror-editor-comment-color) } /* Comment.Preproc */
+.highlight .cpf { color: var(--jp-mirror-editor-comment-color) } /* Comment.PreprocFile */
+.highlight .c1 { color: var(--jp-mirror-editor-comment-color) } /* Comment.Single */
+.highlight .cs { color: var(--jp-mirror-editor-comment-color) } /* Comment.Special */
+.highlight .kc { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Type */
+.highlight .m { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number */
+.highlight .s { color: var(--jp-mirror-editor-string-color) } /* Literal.String */
+.highlight .ow { color: var(--jp-mirror-editor-operator-color) } /* Operator.Word */
+.highlight .mb { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Bin */
+.highlight .mf { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Float */
+.highlight .mh { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Hex */
+.highlight .mi { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Integer */
+.highlight .mo { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Oct */
+.highlight .sa { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Affix */
+.highlight .sb { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Backtick */
+.highlight .sc { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Char */
+.highlight .dl { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Delimiter */
+.highlight .sd { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Doc */
+.highlight .s2 { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Double */
+.highlight .se { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Escape */
+.highlight .sh { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Heredoc */
+.highlight .si { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Interpol */
+.highlight .sx { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Other */
+.highlight .sr { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Regex */
+.highlight .s1 { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Single */
+.highlight .ss { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Symbol */
+.highlight .il { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Integer.Long */
 </style>
 
 <!-- Loading mathjax macro -->


### PR DESCRIPTION
This PR adds an nbconvert template producing the same DOM structure as JupyterLab. The goal is to enable the styling of HTML produced with nbconvert with JupyterLab's themes.

- `lab_basic.tpl` contains the main jinja2 block producing the JLab DOM structure
- `lab_full.tpl` includes the CSS. Please ignore that file as it is still hacky. Eventually, we will provide the jlab CSS from inlining resources like the classic notebook template.
- Also, I am working on a `pygments` theme using the JupyterLab CSS variables used by the Jupyter CodeMirror theme.