### PR TITLE
Require mock for tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ setup_args['install_requires'] = [
 jupyter_client_req = 'jupyter_client>=4.2'
 
 extra_requirements = {
-    'test': ['pytest', 'pytest-cov', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
+    'test': ['pytest', 'pytest-cov', 'mock', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
     'serve': ['tornado>=4.0'],
     'execute': [jupyter_client_req],
     'docs': ['sphinx>=1.5.1',


### PR DESCRIPTION
```
______ ERROR collecting nbconvert/preprocessors/tests/test_execute.py ______
ImportError while importing test module '.../jupyter/nbconvert/nbconvert/preprocessors/tests/test_execute.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
nbconvert/preprocessors/tests/test_execute.py:26: in <module>
    from mock import MagicMock
E   ModuleNotFoundError: No module named 'mock'
```