### PR TITLE
Disable IPython History in executing preprocessor

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -220,6 +220,20 @@ class ExecutePreprocessor(Preprocessor):
             )
     ).tag(config=True)
 
+    ipython_hist_file = Unicode(
+        default_value=':memory:',
+        help="""Path to file to use for SQLite history database for an IPython kernel.
+        
+        The specific value `:memory:` (including the colon
+        at both end but not the back ticks), avoids creating a history file. Otherwise, IPython
+        will create a history file for each kernel. 
+        
+        When running kernels simultaneously (e.g. via multiprocessing) saving history a single
+        SQLite file can result in database errors, so using `:memory:` is recommended in non-interactive
+        contexts.
+        
+        """).tag(config=True)
+
     kernel_manager_class = Type(
         config=True,
         help='The kernel manager class to use.'
@@ -268,6 +282,8 @@ class ExecutePreprocessor(Preprocessor):
                 'kernelspec', {}).get('name', 'python')
         km = self.kernel_manager_class(kernel_name=self.kernel_name,
                                        config=self.config)
+        if km.ipykernel and self.ipython_hist_file:
+            self.extra_arguments += ['--HistoryManager.hist_file={}'.format(self.ipython_hist_file)]
         km.start_kernel(extra_arguments=self.extra_arguments, **kwargs)
 
         kc = km.client()

--- a/nbconvert/preprocessors/tests/files/Check History in Memory.ipynb
+++ b/nbconvert/preprocessors/tests/files/Check History in Memory.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython import get_ipython"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "ip = get_ipython()\n",
+    "assert ip.history_manager.hist_file == ':memory:'"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbconvert/preprocessors/tests/files/Check History in Memory.ipynb
+++ b/nbconvert/preprocessors/tests/files/Check History in Memory.ipynb
@@ -22,25 +22,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.0"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/nbconvert/preprocessors/tests/files/Parallel Execute.ipynb
+++ b/nbconvert/preprocessors/tests/files/Parallel Execute.ipynb
@@ -1,6 +1,18 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ensure notebooks can execute in parallel\n",
+    "\n",
+    "This notebook uses a file system based \"lock\" to assert that two instances of the notebook kernel will run in parallel. Each instance writes to a file in a temporary directory, and then tries to read the other file from\n",
+    "the temporary directory, so that running them in sequence will fail, but running them in parallel will succed.\n",
+    "\n",
+    "Two notebooks are launched, each with an injected cell which sets the `this_notebook` variable. One notebook is set to `this_notebook = 'A'` and the other `this_notebook = 'B'`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -18,6 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# the variable this_notebook is injectected in a cell above by the test framework.\n",
     "other_notebook = {'A':'B', 'B':'A'}[this_notebook]\n",
     "directory = os.environ['NBEXECUTE_TEST_PARALLEL_TMPDIR']\n",
     "with open(os.path.join(directory, 'test_file_{}.txt'.format(this_notebook)), 'w') as f:\n",
@@ -44,20 +57,6 @@
     "else:\n",
     "    assert False, \"Timed out – didn't get a message from {}\".format(other_notebook)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/nbconvert/preprocessors/tests/files/Parallel Execute.ipynb
+++ b/nbconvert/preprocessors/tests/files/Parallel Execute.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import os.path\n",
+    "import tempfile\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "other_notebook = {'A':'B', 'B':'A'}[this_notebook]\n",
+    "directory = os.environ['NBEXECUTE_TEST_PARALLEL_TMPDIR']\n",
+    "with open(os.path.join(directory, 'test_file_{}.txt'.format(this_notebook)), 'w') as f:\n",
+    "    f.write('Hello from {}'.format(this_notebook))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = time.time()\n",
+    "timeout = 5\n",
+    "end = start + timeout\n",
+    "target_file = os.path.join(directory, 'test_file_{}.txt'.format(other_notebook))\n",
+    "while time.time() < end:\n",
+    "    time.sleep(0.1)\n",
+    "    if os.path.exists(target_file):\n",
+    "        with open(target_file, 'r') as f:\n",
+    "            text = f.read()\n",
+    "        if text == 'Hello from {}'.format(other_notebook):\n",
+    "            break\n",
+    "else:\n",
+    "    assert False, \"Timed out – didn't get a message from {}\".format(other_notebook)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbconvert/preprocessors/tests/files/Parallel Execute.ipynb
+++ b/nbconvert/preprocessors/tests/files/Parallel Execute.ipynb
@@ -59,25 +59,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.0"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -12,7 +12,6 @@ import copy
 import glob
 import io
 import os
-import logging
 import re
 import threading
 import multiprocessing as mp
@@ -225,6 +224,7 @@ def assert_notebooks_equal(expected, actual):
         assert expected_execution_count == actual_execution_count
 
 def notebook_resources():
+    """Prepare a notebook resources dictionary for executing test notebooks in the `files` folder."""
     res = ResourcesDict()
     res['metadata'] = ResourcesDict()
     res['metadata']['path'] = os.path.join(current_dir, 'files')

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -265,16 +265,7 @@ def label_parallel_notebook(nb, label):
     
     Used for parallel testing to label two notebooks which are run simultaneously.
     """
-    label_cell = nbformat.NotebookNode(
-        {
-            "cell_type": "code",
-            "execution_count": None,
-            "metadata": {},
-            "outputs": [],
-            "source": "this_notebook = '{}'".format(label),
-        }
-    )
-
+    label_cell = nbformat.v4.new_code_cell(source="this_notebook = '{}'".format(label))
     nb.cells.insert(1, label_cell)
     return nb
 

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -238,6 +238,7 @@ def assert_notebooks_equal(expected, actual):
         ("Unicode.ipynb", dict(kernel_name="python")),
         ("UnicodePy3.ipynb", dict(kernel_name="python")),
         ("update-display-id.ipynb", dict(kernel_name="python")),
+        ("Check History in Memory.ipynb", dict(kernel_name="python")),
     ]
 )
 def test_run_all_notebooks(input_name, opts):


### PR DESCRIPTION
IPython has a feature where command history is written to a SQLite database. When running multiple kernels in parallel, this feature runs into problems, as the SQLite database will be open from several processes, and sometimes hits a locking error.

To fix this, we have disabled SQLite history in IPython Kernels launched from the preprocessing executor, as recommended by ipython/ipython#11460.

This issue was originally brought up in the context of multiprocessing (see nteract/papermill#239) and this PR partially solves that problem, and adds a test to prove that two notebook kernels, *started from the same process* can be run simultaneously.

I am working on a separate PR to test and maintain multiprocessing support, as there is at least one more issue to be solved.

Thanks @MSeal for all of the help and guidance during PyCon sprints to figure this out.