### PR TITLE
Fix doc build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+sphinx:
+  configuration: docs/source/conf.py
+
+formats: all
+
+conda:
+  environment: docs/environment.yml
+
+build:
+  image: latest
+
+python:
+  version: 3.7

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,7 @@ include nbconvert/tests/README.md
 # Documentation
 graft docs
 exclude docs/\#*
-exclude readthedocs.yml
+exclude .readthedocs.yml
 exclude codecov.yml
 
 # Examples

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: nbconvert_docs
 channels:
   - conda-forge
 dependencies:
-- python==3.5
+- python==3.7
 - pandoc
 - nbformat
 - jupyter_client

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,0 @@
-conda:
-    file: docs/environment.yml
-python:
-    version: 3.5
-    pip_install: true


### PR DESCRIPTION
- add webhook
- bump python to 3.7 to accommodate typing which needs > 3.5
- upgrade readthedoc config file to version 2

[Rendered docs on my test build](https://test-nbconvertreturns.readthedocs.io/en/fix-build/index.html)

@MSeal 