### PR TITLE
Fix backwards incompatibility with markdown2html

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -71,7 +71,7 @@ class HTMLExporter(TemplateExporter):
     @contextfilter
     def markdown2html(self, context, source):
         """Markdown to HTML filter respecting the anchor_link_text setting"""
-        cell = context['cell']
+        cell = context.get('cell', {})
         attachments = cell.get('attachments', {})
         renderer = IPythonRenderer(escape=False, attachments=attachments,
                                    anchor_link_text=self.anchor_link_text)


### PR DESCRIPTION
Recent changes to `html.py`'s handling of `markdown2html` also breaks nbgrader, which uses the `markdown2html` filter. The original filter only assumes the input is source code, not necessarily a cell, but the new version of the filter in this file assumes the context includes a `'cell'` field. This isn't the case for the way the filter is being used by nbgrader, but this change alleviates the problem by returning an empty dictionary by default for the cell contents.

Related to #1007 