### PR TITLE
Latex improvements

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -27,7 +27,7 @@ This template does not define a docclass, the inheriting class must define this.
     % in the conversion process - todo).
     \usepackage{caption}
     \DeclareCaptionLabelFormat{nolabel}{}
-    \captionsetup{labelformat=nolabel}
+    \captionsetup{format=nolabel}
 
     \usepackage[Export]{adjustbox} % Used to constrain images to a maximum size
     \adjustboxset{max size={0.9\linewidth}{0.9\paperheight}}

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -26,8 +26,8 @@ This template does not define a docclass, the inheriting class must define this.
     % proper Figure object with a Caption API and a way to capture that
     % in the conversion process - todo).
     \usepackage{caption}
-    \DeclareCaptionFormat{nolabel}{}
-    \captionsetup{format=nolabel}
+    \DeclareCaptionFormat{nocaption}{}
+    \captionsetup{format=nocaption,aboveskip=0pt,belowskip=0pt}
 
     \usepackage[Export]{adjustbox} % Used to constrain images to a maximum size
     \adjustboxset{max size={0.9\linewidth}{0.9\paperheight}}

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -31,6 +31,8 @@ This template does not define a docclass, the inheriting class must define this.
 
     \usepackage[Export]{adjustbox} % Used to constrain images to a maximum size
     \adjustboxset{max size={0.9\linewidth}{0.9\paperheight}}
+    \usepackage{float}
+    \floatplacement{figure}{H} % forces figures to be placed at the correct location
     \usepackage{xcolor} % Allow colors to be defined
     \usepackage{enumerate} % Needed for markdown enumerations to work
     \usepackage{geometry} % Used to adjust the document margins

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -20,16 +20,6 @@ This template does not define a docclass, the inheriting class must define this.
     % Basic figure setup, for now with no caption control since it's done
     % automatically by Pandoc (which extracts ![](path) syntax from Markdown).
     \usepackage{graphicx}
-    % We will generate all images so they have a width \maxwidth. This means
-    % that they will get their normal width if they fit onto the page, but
-    % are scaled down if they would overflow the margins.
-    \makeatletter
-    \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth
-    \else\Gin@nat@width\fi}
-    \makeatother
-    \let\Oldincludegraphics\includegraphics
-    % Set max figure width to be 80% of text width, for now hardcoded.
-    \renewcommand{\includegraphics}[1]{\Oldincludegraphics[width=.8\maxwidth]{#1}}
     % Ensure that by default, figures have no caption (until we provide a
     % proper Figure object with a Caption API and a way to capture that
     % in the conversion process - todo).
@@ -37,7 +27,8 @@ This template does not define a docclass, the inheriting class must define this.
     \DeclareCaptionLabelFormat{nolabel}{}
     \captionsetup{labelformat=nolabel}
 
-    \usepackage{adjustbox} % Used to constrain images to a maximum size 
+    \usepackage[Export]{adjustbox} % Used to constrain images to a maximum size
+    \adjustboxset{max size={0.9\linewidth}{0.9\paperheight}}
     \usepackage{xcolor} % Allow colors to be defined
     \usepackage{enumerate} % Needed for markdown enumerations to work
     \usepackage{geometry} % Used to adjust the document margins

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -59,6 +59,9 @@ This template does not define a docclass, the inheriting class must define this.
     % internal navigation ('pdf bookmarks' for the table of contents,
     % internal cross-reference links, web links for URLs, etc.)
     \usepackage{hyperref}
+    % The default LaTeX title has an obnoxious amount of whitespace. By default,
+    % titling removes some of it. It also provides customization options.
+    \usepackage{titling}
     \usepackage{longtable} % longtable support required by pandoc >1.10
     \usepackage{booktabs}  % table support for pandoc > 1.12.2
     \usepackage[inline]{enumitem} % IRkernel/repr support (it uses the enumerate* environment)

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -20,6 +20,8 @@ This template does not define a docclass, the inheriting class must define this.
     % Basic figure setup, for now with no caption control since it's done
     % automatically by Pandoc (which extracts ![](path) syntax from Markdown).
     \usepackage{graphicx}
+    % Maintain compatibility with old templates. Remove in nbconvert 6.0
+    \let\Oldincludegraphics\includegraphics
     % Ensure that by default, figures have no caption (until we provide a
     % proper Figure object with a Caption API and a way to capture that
     % in the conversion process - todo).

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -26,7 +26,7 @@ This template does not define a docclass, the inheriting class must define this.
     % proper Figure object with a Caption API and a way to capture that
     % in the conversion process - todo).
     \usepackage{caption}
-    \DeclareCaptionLabelFormat{nolabel}{}
+    \DeclareCaptionFormat{nolabel}{}
     \captionsetup{format=nolabel}
 
     \usepackage[Export]{adjustbox} % Used to constrain images to a maximum size

--- a/nbconvert/templates/latex/style_jupyter.tplx
+++ b/nbconvert/templates/latex/style_jupyter.tplx
@@ -100,9 +100,12 @@
     ((*- endblock style_colors *))
     
     % prompt
+    \makeatletter
+    \newcommand{\boxspacing}{\kern\kvtcb@left@rule\kern\kvtcb@boxsep}
+	\makeatother
     ((*- block style_prompt *))
     \newcommand{\prompt}[4]{
-        \llap{{\color{#2}[#3]: #4}}\vspace{-1.25em}
+        \ttfamily\llap{{\color{#2}[#3]:\hspace{3pt}#4}}\vspace{-\baselineskip}
     }
     ((* endblock style_prompt *))
     
@@ -113,7 +116,7 @@
 %===============================================================================
 
 ((* block input scoped *))
-    ((( draw_cell(cell.source | highlight_code(strip_verbatim=True), cell, 'In', 'incolor', '\\hspace{4pt}') )))
+    ((( draw_cell(cell.source | highlight_code(strip_verbatim=True), cell, 'In', 'incolor', '\\boxspacing') )))
 ((* endblock input *))
 
 
@@ -128,7 +131,7 @@
 ((* block execute_result scoped *))
     ((*- for type in output.data | filter_data_type -*))
         ((*- if type in ['text/plain']*))
-            ((( draw_cell(output.data['text/plain'] | wrap_text(charlim) | escape_latex, cell, 'Out', 'outcolor', '\\hspace{3.5pt}') )))
+            ((( draw_cell(output.data['text/plain'] | wrap_text(charlim) | escape_latex, cell, 'Out', 'outcolor', '\\boxspacing') )))
         ((* else -*))
             ((( " " )))
             ((( draw_prompt(cell, 'Out', 'outcolor','') )))((( super() )))
@@ -152,7 +155,7 @@
 ((* macro draw_cell(text, cell, prompt, prompt_color, extra_space) -*))
 ((*- if prompt == 'In' -*))
 ((*- set style = "breakable, size=fbox, boxrule=1pt, pad at break*=1mm,colback=cellbackground, colframe=cellborder"-*))
-((*- else -*))((*- set style = "breakable, boxrule=.5pt, size=fbox, pad at break*=1mm, opacityfill=0"-*))((*-  endif -*))
+((*- else -*))((*- set style = "breakable, size=fbox, boxrule=.5pt, pad at break*=1mm, opacityfill=0"-*))((*-  endif -*))
 
 \begin{tcolorbox}[((( style )))]
 (((- draw_prompt(cell, prompt, prompt_color, extra_space) )))

--- a/nbconvert/templates/latex/style_jupyter.tplx
+++ b/nbconvert/templates/latex/style_jupyter.tplx
@@ -3,6 +3,7 @@
 
 ((*- block packages -*))
     \usepackage[breakable]{tcolorbox}
+    \usepackage{parskip} % Stop auto-indenting (to mimic markdown behaviour)
     \usepackage{float}
     \floatplacement{figure}{H} % forces figures to be placed at the correct location
     ((( super() )))

--- a/nbconvert/templates/latex/style_jupyter.tplx
+++ b/nbconvert/templates/latex/style_jupyter.tplx
@@ -4,8 +4,6 @@
 ((*- block packages -*))
     \usepackage[breakable]{tcolorbox}
     \usepackage{parskip} % Stop auto-indenting (to mimic markdown behaviour)
-    \usepackage{float}
-    \floatplacement{figure}{H} % forces figures to be placed at the correct location
     ((( super() )))
 ((*- endblock packages -*))
 

--- a/nbconvert/templates/latex/style_jupyter.tplx
+++ b/nbconvert/templates/latex/style_jupyter.tplx
@@ -3,7 +3,6 @@
 
 ((*- block packages -*))
     \usepackage[breakable]{tcolorbox}
-    \tcbset{nobeforeafter} % prevents tcolorboxes being placing in paragraphs
     \usepackage{float}
     \floatplacement{figure}{H} % forces figures to be placed at the correct location
     ((( super() )))

--- a/nbconvert/templates/latex/style_jupyter.tplx
+++ b/nbconvert/templates/latex/style_jupyter.tplx
@@ -102,7 +102,7 @@
     % prompt
     \makeatletter
     \newcommand{\boxspacing}{\kern\kvtcb@left@rule\kern\kvtcb@boxsep}
-	\makeatother
+    \makeatother
     ((*- block style_prompt *))
     \newcommand{\prompt}[4]{
         \ttfamily\llap{{\color{#2}[#3]:\hspace{3pt}#4}}\vspace{-\baselineskip}


### PR DESCRIPTION
The follow up PR to #992.
- Slightly better title spacing. (The gap between title/author/date is smaller. Added ```usepackage{titling})```)
- Better spacing between cells. (Removed ```\tcbset{nobeforeafter}```)
- Paragraphs are no longer auto-indented like in markdown. (Added ``` \usepackage{parskip}```)
- Better prompt font, and spacing (using tcolorboxes lengths)
- Fixes #340. I was unable to use the ```\setkeys``` option to fix this, since it had a side effect of shrinking ```adjustimage``` boxes. However, by adding the ```Export``` flag to the adjustbox package it exports a new version of ```includegraphics``` that still allows use of all the keys whilst still setting a maximum size for images.
- Stop alt-text from being used as an image caption. Apparently, before, it was just removing the caption label but not the caption as the comments described. This PR now supersedes #990.

Before:
![image](https://user-images.githubusercontent.com/18018386/57660153-fe652b80-7599-11e9-8560-c44df6d48419.png)

After:
![image](https://user-images.githubusercontent.com/18018386/57660128-e392b700-7599-11e9-8f97-ce3538571186.png)
