### PR TITLE
Return string rather than bytes from SVG2PDFPreprocessor conversion.

### DIFF
--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -97,6 +97,6 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
             if os.path.isfile(output_filename):
                 with open(output_filename, 'rb') as f:
                     # PDF is a nb supported binary, data type, so base64 encode.
-                    return base64.encodestring(f.read())
+                    return base64.encodestring(f.read()).decode('ascii')
             else:
                 raise TypeError("Inkscape svg to pdf conversion failed")


### PR DESCRIPTION
The conversion should always return valid json but it seems it was slipping by unnoticed for a little while. As suggested in #904, #847 is causing the output extraction preprocessor to try and convert the bytestring to json which is raising an error.

This should fix #904. 