### PR TITLE
update export_from_notebook names

### DIFF
--- a/nbconvert/exporters/asciidoc.py
+++ b/nbconvert/exporters/asciidoc.py
@@ -23,7 +23,7 @@ class ASCIIDocExporter(TemplateExporter):
         return 'asciidoc'
 
     output_mimetype = 'text/asciidoc'
-    export_from_notebook = "asciidoc"
+    export_from_notebook = "AsciiDoc"
 
     @default('raw_mimetypes')
     def _raw_mimetypes_default(self):

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -23,7 +23,7 @@ class HTMLExporter(TemplateExporter):
     custom preprocessors/filters.  If you don't need custom preprocessors/
     filters, just change the 'template_file' config option.
     """
-    export_from_notebook = "html"
+    export_from_notebook = "HTML"
 
     anchor_link_text = Unicode(u'¶',
         help="The text used as the text for anchor links.").tag(config=True)

--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -21,7 +21,7 @@ class LatexExporter(TemplateExporter):
     'template_file' config option.  Place your template in the special "/latex" 
     subfolder of the "../templates" folder.
     """
-    export_from_notebook = "latex"
+    export_from_notebook = "LaTeX"
 
     @default('file_extension')
     def _file_extension_default(self):

--- a/nbconvert/exporters/markdown.py
+++ b/nbconvert/exporters/markdown.py
@@ -13,7 +13,7 @@ class MarkdownExporter(TemplateExporter):
     """
     Exports to a markdown document (.md)
     """
-    export_from_notebook = "markdown"
+    export_from_notebook = "Markdown"
 
     @default('file_extension')
     def _file_extension_default(self):

--- a/nbconvert/exporters/notebook.py
+++ b/nbconvert/exporters/notebook.py
@@ -26,7 +26,7 @@ class NotebookExporter(Exporter):
         return '.ipynb'
 
     output_mimetype = 'application/json'
-    export_from_notebook = "notebook"
+    export_from_notebook = "Notebook"
 
     def from_notebook_node(self, nb, resources=None, **kw):
         nb_copy, resources = super(NotebookExporter, self).from_notebook_node(nb, resources, **kw)

--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -44,7 +44,7 @@ class PDFExporter(LatexExporter):
     a temporary directory using the template machinery, and then runs LaTeX
     to create a pdf.
     """
-    export_from_notebook="pdf"
+    export_from_notebook="PDF via LaTeX"
 
     latex_count = Integer(3,
         help="How many times latex will be called."

--- a/nbconvert/exporters/python.py
+++ b/nbconvert/exporters/python.py
@@ -21,4 +21,3 @@ class PythonExporter(TemplateExporter):
         return 'python.tpl'
 
     output_mimetype = 'text/x-python'
-    export_from_notebook = "python"

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -23,7 +23,7 @@ class RSTExporter(TemplateExporter):
         return 'rst.tpl'
 
     output_mimetype = 'text/restructuredtext'
-    export_from_notebook = "rst"
+    export_from_notebook = "reST"
 
     @property
     def default_config(self):

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -14,7 +14,7 @@ class ScriptExporter(TemplateExporter):
     # Caches of already looked-up and instantiated exporters for delegation:
     _exporters = Dict()
     _lang_exporters = Dict()
-    export_from_notebook = "script"
+    export_from_notebook = "Script"
 
     @default('template_file')
     def _template_file_default(self):

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -75,7 +75,7 @@ def prepare(nb):
 class SlidesExporter(HTMLExporter):
     """Exports HTML slides with reveal.js"""
 
-    export_from_notebook = "slides"
+    export_from_notebook = "Reveal.js slides"
 
     reveal_url_prefix = Unicode(
         help="""The URL prefix for reveal.js (version 3.x).


### PR DESCRIPTION
```export_from_notebook``` is supposed to define a human readable name. This updates the names to be more like the original hard-coded values in the notebook that they are suppose to replace:
![image](https://user-images.githubusercontent.com/18018386/57947834-d8d76b00-7894-11e9-9b6b-1d5ac0aacef6.png)

I also removed the ```export_from_name``` for the python exporter since the script exporter gets renamed to python when a python notebook is used, and the python exporter should not appear for non-python notebooks.

Along with [notebook #4588](https://github.com/jupyter/notebook/pull/4588). This closes #938 