### PR TITLE
Correct a few typos

### DIFF
--- a/docs/source/external_exporters.rst
+++ b/docs/source/external_exporters.rst
@@ -218,4 +218,4 @@ And the template file, that inherits from the html `full` template and prepend/a
 
 Assuming you install this package locally, or from PyPI, you can now use::
 
-    jupyter nbconvert --to mypackage.MyEporter notebook.ipynb
+    jupyter nbconvert --to mypackage.MyExporter notebook.ipynb

--- a/docs/source/highlighting.rst
+++ b/docs/source/highlighting.rst
@@ -59,4 +59,4 @@ You can preview all the styles from an environment that can display html like ju
 Making your own styles
 ----------------------
 To make your own style you must subclass ``pygments.styles.Style``, and then you must register your new style with Pygments using
-their pluggin system. This is explained in detail in the `Pygments documentation <http://pygments.org/docs/styles/>`_.
+their plugin system. This is explained in detail in the `Pygments documentation <http://pygments.org/docs/styles/>`_.

--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -255,7 +255,7 @@ class Exporter(LoggingConfigurable):
         """
         self._preprocessors = []
 
-        # Load default preprocessors (not necessarly enabled by default).
+        # Load default preprocessors (not necessarily enabled by default).
         for preprocessor in self.default_preprocessors:
             self.register_preprocessor(preprocessor)
 

--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -15,9 +15,8 @@ from .templateexporter import TemplateExporter
 class LatexExporter(TemplateExporter):
     """
     Exports to a Latex template.  Inherit from this class if your template is
-    LaTeX based and you need custom tranformers/filters.  Inherit from it if 
-    you are writing your own HTML template and need custom tranformers/filters.  
-    If you don't need custom tranformers/filters, just change the 
+    LaTeX based and you need custom transformers/filters.
+    If you don't need custom transformers/filters, just change the 
     'template_file' config option.  Place your template in the special "/latex" 
     subfolder of the "../templates" folder.
     """

--- a/nbconvert/filters/citation.py
+++ b/nbconvert/filters/citation.py
@@ -28,7 +28,7 @@ def citation2latex(s):
     """Parse citations in Markdown cells.
     
     This looks for HTML tags having a data attribute names `data-cite`
-    and replaces it by the call to LaTeX cite command. The tranformation
+    and replaces it by the call to LaTeX cite command. The transformation
     looks like this:
     
     `<cite data-cite="granger">(Granger, 2013)</cite>`

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -307,7 +307,7 @@ class ExecutePreprocessor(Preprocessor):
             passing ``{'metadata': {'path': run_path}}`` sets the
             execution path to ``run_path``.
         km : KernerlManager (optional)
-            Optional kernel manaher. If none is provided, a kernel manager will
+            Optional kernel manager. If none is provided, a kernel manager will
             be created.
 
         Returns
@@ -417,7 +417,7 @@ class ExecutePreprocessor(Preprocessor):
             return cell, resources
 
         reply, outputs = self.run_cell(cell, cell_index)
-        # Backwards compatability for processes that wrap run_cell
+        # Backwards compatibility for processes that wrap run_cell
         cell.outputs = outputs
 
         cell_allows_errors = (self.allow_errors or "raises-exception"
@@ -589,7 +589,7 @@ class ExecutePreprocessor(Preprocessor):
             except CellExecutionComplete:
                 more_output = False
 
-        # Return cell.outputs still for backwards compatability
+        # Return cell.outputs still for backwards compatibility
         return exec_reply, cell.outputs
 
     def process_message(self, msg, cell, cell_index):

--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -46,7 +46,7 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
         This string is a template, which will be formatted with the keys
         to_filename and from_filename.
         
-        The conversion call must read the SVG from {from_flename},
+        The conversion call must read the SVG from {from_filename},
         and write a PDF to {to_filename}.
         """).tag(config=True)
 


### PR DESCRIPTION
I used a spell check extension for VS code to help find these. Some of the typos are in documentation, and some are in code comments.