### PR TITLE
Fix Testing on Windows

### DIFF
--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -24,7 +24,6 @@ from ..execute import ExecutePreprocessor, CellExecutionError, executenb, DeadKe
 from ...exporters.exporter import ResourcesDict
 
 import IPython
-from mock import MagicMock
 from traitlets import TraitError
 from nbformat import NotebookNode
 from jupyter_client.kernelspec import KernelSpecManager

--- a/nbconvert/tests/base.py
+++ b/nbconvert/tests/base.py
@@ -146,9 +146,17 @@ class TestsBase(unittest.TestCase):
         ignore_return_code : optional bool (default False)
             Throw an OSError if the return code
         """
-        if isinstance(parameters, string_types):
-            parameters = shlex.split(parameters)
-        cmd = [sys.executable, '-m', 'nbconvert'] + parameters
+        cmd = [sys.executable, '-m', 'nbconvert']
+        if sys.platform == 'win32':
+            if isinstance(parameters, string_types):
+                cmd = ' '.join(cmd) + ' ' + parameters
+            else:
+                cmd = ' '.join(cmd + parameters)
+        elif isinstance(parameters, string_types):
+                parameters = shlex.split(parameters)
+                cmd += parameters
+        else:
+            cmd += parameters
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
         stdout, stderr = p.communicate(input=stdin)
         if not (p.returncode == 0 or ignore_return_code):

--- a/nbconvert/tests/base.py
+++ b/nbconvert/tests/base.py
@@ -152,10 +152,9 @@ class TestsBase(unittest.TestCase):
                 cmd = ' '.join(cmd) + ' ' + parameters
             else:
                 cmd = ' '.join(cmd + parameters)
-        elif isinstance(parameters, string_types):
-                parameters = shlex.split(parameters)
-                cmd += parameters
         else:
+            if isinstance(parameters, string_types):
+                parameters = shlex.split(parameters)
             cmd += parameters
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
         stdout, stderr = p.communicate(input=stdin)


### PR DESCRIPTION
I develop primarily on windows, and I have been having problems running tests. Manually testing of features in failing tests shows that the issues seem to be the tests. Most of the problems seem to be due to ```shlex.split``` not understanding windows (even with ```posix=False```). This mostly fixes testing on windows.

Though I still seem to have some reliability problems. ```preprocessors\tests\test_execute.py```, ```exporters\tests\test_pdf.py```, and ```tests\test_nbconvertapp.py``` seem to have some odd failures but only sometimes. This appears to me like pytests caching issues because the issues tend to temporarily disappear when I restart my console. This also may be caused by sometimes using ```pytest``` instead of ```py.test```. Using ```pytests``` seems to cause errors, and then using ```py.test``` after using ```pytests``` does not resolve them without restarting the console. For reference, this required me to set vs code to use ```"python.testing.pyTestPath": "py.test"``` in my workspace settings.

For now, I believe my solution is sufficient, though ```py.test``` is considered legacy. Perhaps, we should consider investigating moving to ```pytest```. Also, It might be worth having CI, like appveyor, set up to test on windows.