### PR TITLE
Fix selection of mimetype when converting to HTML

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -166,7 +166,7 @@ class IPythonRenderer(mistune.Renderer):
                 if preferred_mime_type in attachment:
                     break
             else:  # otherwise we choose the first mimetype we can find
-                preferred_mime_types = attachment.keys()[0]
+                preferred_mime_type = list(attachment.keys())[0]
             mime_type = preferred_mime_type
             data = attachment[mime_type]
             src = 'data:' + mime_type + ';base64,' + data


### PR DESCRIPTION
When converting to HTML, there is currently a bug in selecting the mimetype for attachments that do not have one of the preferred mimetypes:

```
[NbConvertApp] Converting notebook Round 2 - Regression.ipynb to html
Traceback (most recent call last):
  File "/Users/jhamrick/miniconda3/envs/nbgrader/bin/jupyter-nbconvert", line 10, in <module>
    sys.exit(main())
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/jupyter_core/application.py", line 266, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/traitlets/config/application.py", line 658, in launch_instance
    app.start()
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/nbconvertapp.py", line 338, in start
    self.convert_notebooks()
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/nbconvertapp.py", line 508, in convert_notebooks
    self.convert_single_notebook(notebook_filename)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/nbconvertapp.py", line 479, in convert_single_notebook
    output, resources = self.export_single_notebook(notebook_filename, resources, input_buffer=input_buffer)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/nbconvertapp.py", line 408, in export_single_notebook
    output, resources = self.exporter.from_filename(notebook_filename, resources=resources)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/exporter.py", line 179, in from_filename
    return self.from_file(f, resources=resources, **kw)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/exporter.py", line 197, in from_file
    return self.from_notebook_node(nbformat.read(file_stream, as_version=4), resources=resources, **kw)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/html.py", line 90, in from_notebook_node
    return super(HTMLExporter, self).from_notebook_node(nb, resources, **kw)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/templateexporter.py", line 314, in from_notebook_node
    output = self.template.render(nb=nb_copy, resources=resources)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/../templates/html/full.tpl", line 2, in top-level template code
    {% from 'mathjax.tpl' import mathjax %}
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/../templates/html/basic.tpl", line 1, in top-level template code
    {%- extends 'display_priority.tpl' -%}
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/../templates/skeleton/display_priority.tpl", line 1, in top-level template code
    {%- extends 'null.tpl' -%}
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/../templates/skeleton/null.tpl", line 26, in top-level template code
    {%- block body -%}
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/../templates/html/full.tpl", line 99, in block "body"
    {{ super() }}
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/../templates/skeleton/null.tpl", line 28, in block "body"
    {%- block any_cell scoped -%}
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/../templates/skeleton/null.tpl", line 81, in block "any_cell"
    {%- block markdowncell scoped-%} {%- endblock markdowncell -%}
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/../templates/html/basic.tpl", line 84, in block "markdowncell"
    {{ cell.source  | markdown2html | strip_files_prefix }}
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/exporters/html.py", line 78, in markdown2html
    return MarkdownWithMath(renderer=renderer).render(source)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 1001, in render
    return self.parse(text)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 1004, in parse
    out = self.output(preprocessing(text))
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 1053, in output
    out += self.tok()
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 1063, in tok
    return getattr(self, 'output_%s' % t)()
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 1168, in output_paragraph
    return self.renderer.paragraph(self.inline(self.token['text']))
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 555, in __call__
    return self.output(text, rules)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 585, in output
    ret = manipulate(text)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 579, in manipulate
    out = getattr(self, 'output_%s' % key)(m)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 641, in output_link
    return self._process_link(m, m.group(3), m.group(4))
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/mistune.py", line 661, in _process_link
    return self.renderer.image(link, title, text)
  File "/Users/jhamrick/miniconda3/envs/nbgrader/lib/python3.7/site-packages/nbconvert/filters/markdown_mistune.py", line 169, in image
    preferred_mime_types = attachment.keys()[0]
TypeError: 'dict_keys' object is not subscriptable
```

This just seems to be because the list of keys is not actually a list, and the variable it assigns to has the incorrect name. This PR fixes these issues.