### PR TITLE
Fix LaTeX exporting '?' for non-ascii title

### DIFF
--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -147,7 +147,7 @@ This template does not define a docclass, the inheriting class must define this.
     % Document title
     ((* block title -*))
     ((*- set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] -*))
-    \title{((( nb_title | ascii_only | escape_latex )))}
+    \title{((( nb_title | escape_latex )))}
     ((*- endblock title *))
     ((* block date *))((* endblock date *))
     ((* block author *))


### PR DESCRIPTION
I have the same issue with #786 . When I tried to export a PDF file from a notebook that has a non-ascii title (which is the notebook's file name),  the output is just '????':

<img width="852" alt="螢幕快照 2019-05-30 17 26 26" src="https://user-images.githubusercontent.com/8423594/58623234-1c53bf80-8300-11e9-8435-0a83294e41ca.png">

I discovered that it was not a XeLaTeX problem; I use `ctex` package to support non-ascii rendering (You can see them in the date under the title), but the title is still '???'. I tried to directly export `.tex` source file instead, and it turned out that `nbconvert` itself produces `'\title{????}'` for title while other non-ascii characters in the document body is fine.

In `nbconvert/templates/latex/base.tplx`, I found this line confusing:

`\title{((( nb_title | ascii_only | escape_latex )))}`

I have no idea what `ascii_only` is for, and deleting this is supposed to make sense.

<img width="818" alt="螢幕快照 2019-05-30 17 29 46" src="https://user-images.githubusercontent.com/8423594/58623438-92f0bd00-8300-11e9-9ba3-202274b0c12a.png">
