### PR TITLE
Set flag to not always stop kernel execution on errors

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -540,7 +540,8 @@ class ExecutePreprocessor(Preprocessor):
         return False
 
     def run_cell(self, cell, cell_index=0):
-        parent_msg_id = self.kc.execute(cell.source)
+        parent_msg_id = self.kc.execute(
+            cell.source, stop_on_error=not self.allow_errors)
         self.log.debug("Executing cell:\n%s", cell.source)
         exec_timeout = self._get_timeout(cell)
         deadline = None


### PR DESCRIPTION
There is some non-deterministic error in nbgrader related to the kernel stopping executing after it's received an error, see https://github.com/jupyter/nbgrader/issues/1056 for discussion. In particular, @samuelmanzer gave the following explanation:

> I think that in some subset of the runs, the ZeroMQ messages for multiple cells reside simultaneously on the execution stack, and stop_on_error=True results in the cell containing the assignment statements being thrown away as it is on the stack when the earlier (deliberate) AssertionError exception causes the stack to be discarded. The subsequent assertion which depends on that assignment statement executing successfully then fails.

This PR changes the `stop_on_error` flag to be set adaptively depending on whether `self.allow_errors` is configured.