### PR TITLE
simplify the function signature for preprocess()

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -371,7 +371,7 @@ class ExecutePreprocessor(Preprocessor):
                 for attr in ['nb', 'km', 'kc']:
                     delattr(self, attr)
 
-    def preprocess(self, nb, resources, km=None):
+    def preprocess(self, nb, resources=None, km=None):
         """
         Preprocess notebook executing each code cell.
 
@@ -381,7 +381,7 @@ class ExecutePreprocessor(Preprocessor):
         ----------
         nb : NotebookNode
             Notebook being executed.
-        resources : dictionary
+        resources : dictionary (optional)
             Additional resources used in the conversion process. For example,
             passing ``{'metadata': {'path': run_path}}`` sets the
             execution path to ``run_path``.
@@ -396,6 +396,9 @@ class ExecutePreprocessor(Preprocessor):
         resources : dictionary
             Additional resources used in the conversion process.
         """
+
+        if not resources:
+            resources = {}
 
         with self.setup_preprocessor(nb, resources, km=km):
             self.log.info("Executing notebook with kernel: %s" % self.kernel_name)


### PR DESCRIPTION
Small change: When [executing notebooks using the Python API interface](https://nbconvert.readthedocs.io/en/latest/execute_api.html#executing-notebooks-using-the-python-api-interface), I noticed that providing the `resources` to `preprocess()` is required, even if the user doesn't intend for anything to be overridden. This change makes that argument optional.

Thanks!