### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,16 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+<!--- Description --->
+
+<!--- Can you list steps to reproduce this issue? --->
+
+<!--- Can you, if possible, please attach a minimum notebook that reproduces this issue on conversion?
+You may need to attach the .ipynb as a .txt --->
+
+<!--- Can you attach screenshots if relevant? --->
+
+<!--- Are you running the latest version of nbconvert? --->
+**Nbconvert version:**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+---
+
+<!--- Is your feature request related to a problem? What are you trying to achieve? --->
+
+
+<!--- Describe the solution you'd like. --->
+
+
+<!--- If possible, describe alternatives you've considered. Why are they insufficent? --->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,8 @@
+---
+name: Question
+about: If you need some help
+labels: question 
+---
+
+If you have a question, you can file an issue here or
+preferably ask on [Jupyter Discourse](https://discourse.jupyter.org/).


### PR DESCRIPTION
If I've followed [this](https://help.github.com/en/articles/manually-creating-a-single-issue-template-for-your-repository) correctly, then this should add 3 issue templates. I do not have permission to do this through the [repo settings](https://help.github.com/en/articles/creating-issue-templates-for-your-repository).