### PR TITLE
Fix RTD

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,14 +14,15 @@
 # serve to show the default.
 
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../../.')) # path to nbconvert for autodoc
 
 # Automatically generate config_options.rst
-import os
 with open(os.path.join(os.path.dirname(__file__), '..', 'autogen_config.py')) as f:
     exec(compile(f.read(), 'autogen_config.py', 'exec'), {})
 


### PR DESCRIPTION
Readthedocs was failing because it wasn't finding the right version of nbconvert (related to #1048). This will ensure that the module near the docs is always found.