### PR TITLE
fix delimiter in config docs

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -555,7 +555,7 @@ class NbConvertApp(JupyterApp):
                 sections += ".. image:: _static/{image}_inheritance.png\n\n".format(image=category)
             sections += '\n'.join(c.class_config_rst_doc() for c in categories[category])
 
-        return sections.replace(':',r'\:')
+        return sections.replace(' : ',r' \: ')
             
 #-----------------------------------------------------------------------------
 # Main entry point

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -555,7 +555,7 @@ class NbConvertApp(JupyterApp):
                 sections += ".. image:: _static/{image}_inheritance.png\n\n".format(image=category)
             sections += '\n'.join(c.class_config_rst_doc() for c in categories[category])
 
-        return sections
+        return sections.replace(':',r'\:')
             
 #-----------------------------------------------------------------------------
 # Main entry point


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/18018386/59559097-4a4e2a80-8fb5-11e9-9045-cb86362a825e.png)

After:
![image](https://user-images.githubusercontent.com/18018386/59568126-49f07680-902b-11e9-90eb-bf94c85dee70.png)


This has been a problem since Sphinx 2.0 was released.