### PR TITLE
Require mock only on Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ setup_args['install_requires'] = [
 jupyter_client_req = 'jupyter_client>=4.2'
 
 extra_requirements = {
-    'test': ['pytest', 'pytest-cov', 'mock', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
+    'test': ['pytest', 'pytest-cov', 'mock; python_version < "3.4"', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
     'serve': ['tornado>=4.0'],
     'execute': [jupyter_client_req],
     'docs': ['sphinx>=1.5.1',


### PR DESCRIPTION
Only usage of mock is inside "except ImportError" meant for running tests
under Python 2. So there is no need to install it for any Python 3.