### PR TITLE
Fix for ANSI characters in output of code block in style_jupyter.tplx

### DIFF
--- a/nbconvert/templates/latex/style_jupyter.tplx
+++ b/nbconvert/templates/latex/style_jupyter.tplx
@@ -129,7 +129,7 @@
 ((* block execute_result scoped *))
     ((*- for type in output.data | filter_data_type -*))
         ((*- if type in ['text/plain']*))
-            ((( draw_cell(output.data['text/plain'] | wrap_text(charlim) | escape_latex, cell, 'Out', 'outcolor', '\\boxspacing') )))
+            ((( draw_cell(output.data['text/plain'] | wrap_text(charlim) | escape_latex | ansi2latex, cell, 'Out', 'outcolor', '\\boxspacing') )))
         ((* else -*))
             ((( " " )))
             ((( draw_prompt(cell, 'Out', 'outcolor','') )))((( super() )))


### PR DESCRIPTION
Conversion of ANSI characters was missing at a critical place for output of code blocks, which can be problematic with e.g. output of the Almond Scala Kernel. With this fix, colors should be converted and preserved properly when using `style_jupyter.tplx` to generate a pdf.