### PR TITLE
Pip-install nbconvert on readthedocs.org

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,3 +18,6 @@ build:
 
 python:
   version: 3.7
+  install:
+    - method: pip
+      path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,13 +14,11 @@
 # serve to show the default.
 
 import os
-import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('../../.')) # path to nbconvert for autodoc
 
 # Automatically generate config_options.rst
 with open(os.path.join(os.path.dirname(__file__), '..', 'autogen_config.py')) as f:


### PR DESCRIPTION
This reverts #1050 and tries to install `nbconvert` via `pip` on https://readthedocs.org/.

WARNING: I don't know if this actually works!

I'm using this method on several of my RTD projects, but I don't use `conda`, so I don't know if that also works with `conda`.

But if it *does* work, it seems cleaner than hacking `sys.path`.