### PR TITLE
Fix for line break breaking verbatim environment in style_jupyter.tplx

### DIFF
--- a/nbconvert/templates/latex/style_jupyter.tplx
+++ b/nbconvert/templates/latex/style_jupyter.tplx
@@ -139,7 +139,7 @@
 
 ((* block stream *))
     \begin{Verbatim}[commandchars=\\\{\}]
-((( output.text | wrap_text(charlim) | escape_latex | ansi2latex -)))
+((( output.text | wrap_text(charlim) | escape_latex | ansi2latex )))
     \end{Verbatim}
 ((* endblock stream *))
 


### PR DESCRIPTION
This should fix #1071 though I have not yet tested it extensively.