### PR TITLE
Improve template whitespacing

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -319,6 +319,8 @@ class TemplateExporter(Exporter):
 
         # Top level variables are passed to the template_exporter here.
         output = self.template.render(nb=nb_copy, resources=resources)
+        if resources.get('strip_preceding_newlines', True):
+            output = output.lstrip('\r\n')
         return output, resources
 
     def _register_filter(self, environ, name, jinja_filter):

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -319,8 +319,7 @@ class TemplateExporter(Exporter):
 
         # Top level variables are passed to the template_exporter here.
         output = self.template.render(nb=nb_copy, resources=resources)
-        if resources.get('strip_preceding_newlines', True):
-            output = output.lstrip('\r\n')
+        output = output.lstrip('\r\n')
         return output, resources
 
     def _register_filter(self, environ, name, jinja_filter):

--- a/nbconvert/templates/latex/article.tplx
+++ b/nbconvert/templates/latex/article.tplx
@@ -1,8 +1,8 @@
 
 ((=- Default to the notebook output style -=))
-((* if not cell_style is defined *))
+((*- if not cell_style is defined -*))
     ((* set cell_style = 'style_jupyter.tplx' *))
-((* endif *))
+((*- endif -*))
 
 ((=- Inherit from the specified cell style. -=))
 ((* extends cell_style *))
@@ -12,6 +12,6 @@
 % Latex Article
 %===============================================================================
 
-((* block docclass *))
+((*- block docclass -*))
 \documentclass[11pt]{article}
 ((* endblock docclass *))

--- a/nbconvert/templates/latex/article.tplx
+++ b/nbconvert/templates/latex/article.tplx
@@ -14,4 +14,4 @@
 
 ((*- block docclass -*))
 \documentclass[11pt]{article}
-((* endblock docclass *))
+((*- endblock docclass -*))

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -13,7 +13,7 @@ override this.-=))
 ((*- block header -*))
     ((* block docclass *))\documentclass[11pt]{article}((* endblock docclass *))
 
-    ((* block packages -*))
+    ((* block packages *))
     \usepackage[T1]{fontenc}
     % Nicer default font (+ math font) than Computer Modern for most use cases
     \usepackage{mathpazo}

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -12,8 +12,8 @@ override this.-=))
 
 ((*- block header -*))
     ((* block docclass *))\documentclass[11pt]{article}((* endblock docclass *))
-    
-    ((* block packages *))
+
+    ((* block packages -*))
     \usepackage[T1]{fontenc}
     % Nicer default font (+ math font) than Computer Modern for most use cases
     \usepackage{mathpazo}
@@ -177,8 +177,7 @@ override this.-=))
 ((* endblock header *))
 
 ((* block body *))
-    \begin{document}
-    
+\begin{document}
     ((* block predoc *))
     ((* block maketitle *))\maketitle((* endblock maketitle *))
     ((* block abstract *))((* endblock abstract *))
@@ -190,5 +189,5 @@ override this.-=))
     ((* block postdoc *))
     ((* block bibliography *))((* endblock bibliography *))
     ((* endblock postdoc *))
-    \end{document}
+\end{document}
 ((* endblock body *))

--- a/nbconvert/templates/latex/base.tplx
+++ b/nbconvert/templates/latex/base.tplx
@@ -1,7 +1,8 @@
-((= Latex base template (must inherit)
+((=- Latex base template (must inherit)
 This template builds upon the abstract template, adding common latex output
-functions.  Figures, data_text,
-This template does not define a docclass, the inheriting class must define this.=))
+functions. Figures, data_text,
+This template defines defines a default docclass, the inheriting class should
+override this.-=))
 
 ((*- extends 'document_contents.tplx' -*))
 
@@ -9,8 +10,8 @@ This template does not define a docclass, the inheriting class must define this.
 % Abstract overrides
 %===============================================================================
 
-((* block header *))
-    ((* block docclass *))((* endblock docclass *))
+((*- block header -*))
+    ((* block docclass *))\documentclass[11pt]{article}((* endblock docclass *))
     
     ((* block packages *))
     \usepackage[T1]{fontenc}

--- a/nbconvert/templates/latex/skeleton/null.tplx
+++ b/nbconvert/templates/latex/skeleton/null.tplx
@@ -1,5 +1,5 @@
-((= Auto-generated template file, DO NOT edit directly!
-    To edit this file, please refer to ../../skeleton/README.md =))
+((=- Auto-generated template file, DO NOT edit directly!
+    To edit this file, please refer to ../../skeleton/README.md -=))
 
 
 ((=

--- a/nbconvert/templates/skeleton/Makefile
+++ b/nbconvert/templates/skeleton/Makefile
@@ -6,9 +6,9 @@ all: clean $(TPLS)
 # see http://flask.pocoo.org/snippets/55/ for more info
 ../latex/skeleton/%.tplx: %.tpl
 	@echo 'generating tex equivalent of $^: $@'
-	@echo '((= Auto-generated template file, DO NOT edit directly!\n' \
+	@echo '((=- Auto-generated template file, DO NOT edit directly!\n' \
 		  '   To edit this file, please refer to ../../skeleton/README.md' \
-		  '=))\n\n' > $@
+		  '-=))\n\n' > $@
 	@sed \
 		-e 's/{%/((*/g' \
 		-e 's/%}/*))/g' \


### PR DESCRIPTION
Fixes #1059, and fixes #376. I chose this method because I noticed that the markdown exporter has the same issue which is problematic for people that need a title as the first thing in a markdown export.

I also made some improves to enhance readability of the latex exporter, but nothing will render differently due to this.

I also added a default documentclass to the ```base.tplx``` so that all of the ```style_*.tplx``` files can now be used on there own. This technically makes ```article.tplx``` redundant.