### PR TITLE
fix ansi2latex filtering

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -58,6 +58,7 @@ default_filters = {
         'get_metadata': filters.get_metadata,
         'convert_pandoc': filters.convert_pandoc,
         'json_dumps': json.dumps,
+        'strip_trailing_newline': filters.strip_trailing_newline,
 }
 
 class ExtensionTolerantLoader(BaseLoader):

--- a/nbconvert/filters/ansi.py
+++ b/nbconvert/filters/ansi.py
@@ -71,7 +71,13 @@ def ansi2latex(text):
         Text containing ANSI colors to convert to LaTeX
 
     """
-    return _ansi2anything(text, _latexconverter)
+    fix_ending_space = text.endswith('\n')
+    if fix_ending_space:
+        text = text[:-1]
+    text = _ansi2anything(text, _latexconverter)
+    if fix_ending_space:
+        text += '\n'
+    return text
 
 
 def _htmlconverter(fg, bg, bold, underline, inverse):
@@ -189,10 +195,6 @@ def _ansi2anything(text, converter):
     numbers = []
     out = []
 
-    fix_ending_space = (converter == _latexconverter) and text.endswith('\n')
-    if fix_ending_space:
-        text = text[:-1]
-
     while text:
         m = _ANSI_RE.search(text)
         if m:
@@ -263,10 +265,7 @@ def _ansi2anything(text, converter):
             else:
                 pass  # Unknown codes are ignored
 
-    output = ''.join(out)
-    if fix_ending_space:
-        output += '\n'
-    return output
+    return ''.join(out)
 
 
 def _get_extended_color(numbers):

--- a/nbconvert/filters/ansi.py
+++ b/nbconvert/filters/ansi.py
@@ -189,6 +189,10 @@ def _ansi2anything(text, converter):
     numbers = []
     out = []
 
+    fix_ending_space = (converter == _latexconverter) and text.endswith('\n')
+    if fix_ending_space:
+        text = text[:-1]
+
     while text:
         m = _ANSI_RE.search(text)
         if m:
@@ -258,7 +262,11 @@ def _ansi2anything(text, converter):
                 bg = n - 100 + 8
             else:
                 pass  # Unknown codes are ignored
-    return ''.join(out)
+
+    output = ''.join(out)
+    if fix_ending_space:
+        output += '\n'
+    return output
 
 
 def _get_extended_color(numbers):

--- a/nbconvert/filters/ansi.py
+++ b/nbconvert/filters/ansi.py
@@ -71,8 +71,6 @@ def ansi2latex(text):
         Text containing ANSI colors to convert to LaTeX
 
     """
-    if text.endswith('\n'):
-        text = text[:-1]
     return _ansi2anything(text, _latexconverter)
 
 

--- a/nbconvert/filters/ansi.py
+++ b/nbconvert/filters/ansi.py
@@ -74,7 +74,9 @@ def ansi2latex(text):
     fix_ending_space = text.endswith('\n')
     if fix_ending_space:
         text = text[:-1]
+
     text = _ansi2anything(text, _latexconverter)
+
     if fix_ending_space:
         text += '\n'
     return text
@@ -264,7 +266,6 @@ def _ansi2anything(text, converter):
                 bg = n - 100 + 8
             else:
                 pass  # Unknown codes are ignored
-
     return ''.join(out)
 
 

--- a/nbconvert/filters/ansi.py
+++ b/nbconvert/filters/ansi.py
@@ -71,15 +71,9 @@ def ansi2latex(text):
         Text containing ANSI colors to convert to LaTeX
 
     """
-    fix_ending_space = text.endswith('\n')
-    if fix_ending_space:
+    if text.endswith('\n'):
         text = text[:-1]
-
-    text = _ansi2anything(text, _latexconverter)
-
-    if fix_ending_space:
-        text += '\n'
-    return text
+    return _ansi2anything(text, _latexconverter)
 
 
 def _htmlconverter(fg, bg, bold, underline, inverse):

--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -39,6 +39,7 @@ __all__ = [
     'add_prompts',
     'ascii_only',
     'prevent_list_blocks',
+    'strip_trailing_newline',
 ]
 
 
@@ -241,3 +242,11 @@ def prevent_list_blocks(s):
     out = re.sub('(^\s*)\+', '\\1\+', out)
     out = re.sub('(^\s*)\*', '\\1\*', out)
     return out
+
+def strip_trailing_newline(text):
+    """
+    Strips a newline from the end of text.
+    """
+    if text.endswith('\n'):
+        text = text[:-1]
+    return text

--- a/nbconvert/templates/latex/style_jupyter.tplx
+++ b/nbconvert/templates/latex/style_jupyter.tplx
@@ -139,7 +139,7 @@
 
 ((* block stream *))
     \begin{Verbatim}[commandchars=\\\{\}]
-((( output.text | wrap_text(charlim) | escape_latex | ansi2latex -)))
+((( output.text | wrap_text(charlim) | escape_latex | ansi2latex )))
     \end{Verbatim}
 ((* endblock stream *))
 

--- a/nbconvert/templates/latex/style_jupyter.tplx
+++ b/nbconvert/templates/latex/style_jupyter.tplx
@@ -139,7 +139,7 @@
 
 ((* block stream *))
     \begin{Verbatim}[commandchars=\\\{\}]
-((( output.text | wrap_text(charlim) | escape_latex | ansi2latex )))
+((( output.text | wrap_text(charlim) | escape_latex | strip_trailing_newline | ansi2latex )))
     \end{Verbatim}
 ((* endblock stream *))
 


### PR DESCRIPTION
Alternative to #1073. Fixes #1071

This produces:
![image](https://user-images.githubusercontent.com/18018386/62178058-4293dc80-b2fc-11e9-860a-3a03a56951db.png)

As opposed to what #1073 produces:
![image](https://user-images.githubusercontent.com/18018386/62177516-0495b900-b2fa-11e9-9ab4-da5b708e7a01.png)

@MSeal I'll leave it to you to decide which option to choose. 