### PR TITLE
adding cell tag data attributes to HTML exporter

### DIFF
--- a/nbconvert/templates/html/basic.tpl
+++ b/nbconvert/templates/html/basic.tpl
@@ -1,8 +1,8 @@
 {%- extends 'display_priority.tpl' -%}
-
+{% from 'celltags.tpl' import celltags %}
 
 {% block codecell %}
-<div class="cell border-box-sizing code_cell rendered">
+<div class="cell border-box-sizing code_cell rendered"{{ celltags(cell) }}>
 {{ super() }}
 </div>
 {%- endblock codecell %}
@@ -75,7 +75,7 @@
 {% endblock output %}
 
 {% block markdowncell scoped %}
-<div class="cell border-box-sizing text_cell rendered">
+<div class="cell border-box-sizing text_cell rendered"{{ celltags(cell) }}>
 {%- if resources.global_content_filter.include_input_prompt-%}
     {{ self.empty_in_prompt() }}
 {%- endif -%}

--- a/nbconvert/templates/html/celltags.tpl
+++ b/nbconvert/templates/html/celltags.tpl
@@ -1,0 +1,4 @@
+{%- macro celltags(cell) -%}
+    {% if cell.metadata.tags | length > 0 %} data-cell-tags="{{ cell.metadata.tags | join(', ') }}"{% endif %}
+{%- endmacro %}
+


### PR DESCRIPTION
In Jupyter Book most of my custom templates exist basically to insert the contents of cell tags into the `<div>`s metadata. I was thinking maybe this is something that would be useful to the HTMLExporter in general.

This PR modifies the base HTML template to do the following:

If a cell has any tags defined, then it adds a `data-cell-tags` attribute to the code or markdown cell. this attribute has a comma-separated string of tags.

This could then be used with selectors etc to do various things to the output HTML based on the tags content.

I thought about doing this with _classes_ instead of `data-` attributes, but it seemed that the former might cause unexpected behavior. If folks think this PR is a good idea, but that using classes would be better, I'm happy to revisit that.