### PR TITLE
Change RegExRemove to remove code cells with output

### DIFF
--- a/nbconvert/preprocessors/regexremove.py
+++ b/nbconvert/preprocessors/regexremove.py
@@ -40,8 +40,7 @@ class RegexRemovePreprocessor(Preprocessor):
 
     def check_conditions(self, cell):
         """
-        Checks that a cell matches the pattern and that (if a code cell)
-        it does not have any outputs.
+        Checks that a cell matches the pattern.
 
         Returns: Boolean.
         True means cell should *not* be removed.
@@ -54,7 +53,7 @@ class RegexRemovePreprocessor(Preprocessor):
                              for pattern in self.patterns))
 
         # Filter out cells that meet the pattern and have no outputs
-        return cell.get('outputs') or not pattern.match(cell.source)
+        return not pattern.match(cell.source)
 
     def preprocess(self, nb, resources):
         """

--- a/nbconvert/preprocessors/tests/test_regexremove.py
+++ b/nbconvert/preprocessors/tests/test_regexremove.py
@@ -69,24 +69,3 @@ class TestRegexRemove(PreprocessorTestsBase):
                 for pattern in patterns:
                     self.assertFalse(pattern.match(cell.source))
 
-    def test_nosource_with_output(self):
-        """
-        Test that the check_conditions returns true when given a code-cell
-        that has non-empty outputs but no source.
-        """
-
-        cell = {
-            'cell_type': 'code',
-            'execution_count': 2,
-            'metadata': {},
-            'outputs': [{
-                'name': 'stdout',
-                'output_type': 'stream',
-                'text': 'I exist.\n'
-            }],
-            'source': ''
-        }
-        preprocessor = self.build_preprocessor()
-        node = from_dict(cell)
-        assert preprocessor.check_conditions(node)
-


### PR DESCRIPTION
Previously, the `RegExRemovePreprocessor` treated code cells without outputs specially: they were never removed, even if they matched the regex pattern. This behavior was intentional but only documented in an internal method, `check_conditions`, not in the docs of an external method. See Issue #1091 for discussion.

This commit removes that behavior and updates the documentation of `check_conditions`. It further removes the test that checked for this behavior.