### PR TITLE
Fix latex dependencies installation command for Ubuntu systems

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -58,7 +58,7 @@ packages are specific to different operating systems:
 
 * Linux: `TeX Live <http://tug.org/texlive/>`_
 
-  * E.g. on Debian or Ubuntu: ``sudo apt-get install texlive-xetex``
+  * E.g. on Debian or Ubuntu: ``sudo apt-get install texlive-xetex texlive-fonts-recommended texlive-generic-recommended``
 
 * macOS (OS X): `MacTeX <http://tug.org/mactex/>`_.
 * Windows: `MikTex <http://www.miktex.org/>`_


### PR DESCRIPTION
As put in issue #1108, there are two additional packages needed
for Ubuntu systems in order to fully supply all the necessary
dependencies for PDF exportation.