### PR TITLE
add support for alt tags for jpeg and png images

### DIFF
--- a/nbconvert/templates/html/basic.tpl
+++ b/nbconvert/templates/html/basic.tpl
@@ -155,6 +155,10 @@ height={{ height }}
 {%- if output | get_metadata('unconfined', 'image/png') %}
 class="unconfined"
 {%- endif %}
+{%- set alttext=(output | get_metadata('alt', 'image/png')) or (cell | get_metadata('alt')) -%}
+{%- if alttext is not none %}
+alt="{{ alttext }}"
+{%- endif %}
 >
 </div>
 {%- endblock data_png %}
@@ -176,6 +180,10 @@ height={{ height }}
 {%- endif %}
 {%- if output | get_metadata('unconfined', 'image/jpeg') %}
 class="unconfined"
+{%- endif %}
+{%- set alttext=(output | get_metadata('alt', 'image/jpeg')) or (cell | get_metadata('alt')) -%}
+{%- if alttext is not none %}
+alt="{{ alttext }}"
 {%- endif %}
 >
 </div>


### PR DESCRIPTION
Accessible web content needs to have proper 'alt' text for images. Currently, nbconvert will create html pages without any way for the user to add alt text if they wanted to. With this pull request, I added support for alt text for jpeg and png images.

The first way to use it is by adding to the output metadata, like so:

```
    from IPython.display import Image

    Image('images/some_image.jpg', metadata={'alt': 'description of image'})
```

This approach doesn't really work for matplotlib plots, however. Instead, the user must first create the plot:

```
    %matplotlib inline
    import matplotlib.pyplot as plt

    plt.plot([0, 2, 1])
```

And then set the cell's metadata to this:

````
    {
        "alt": "description of plot"
    }
````

Note: use View => Cell Toolbar => Edit Metadata to bring up a button to edit a cell's metadata.

Although writing proper alt text for complicated charts is challenging, there are resources explaining how it can and should be done:

http://diagramcenter.org/specific-guidelines-e.html




