### PR TITLE
multiline search in RegexRemovePreprocessor

### DIFF
--- a/nbconvert/preprocessors/regexremove.py
+++ b/nbconvert/preprocessors/regexremove.py
@@ -50,10 +50,11 @@ class RegexRemovePreprocessor(Preprocessor):
         # by a non-capturing group to ensure the correct order of precedence
         # and the patterns are joined with a logical or
         pattern = re.compile('|'.join('(?:%s)' % pattern
-                             for pattern in self.patterns))
+                             for pattern in self.patterns),
+                             re.MULTILINE)
 
         # Filter out cells that meet the pattern and have no outputs
-        return not pattern.match(cell.source)
+        return not pattern.search(cell.source)
 
     def preprocess(self, nb, resources):
         """


### PR DESCRIPTION
Currently, `RegexRemovePreprocessor` does not match multiline code.

* Added `re.MULTILINE` to `re.compile`
* Changed `match` to `search` due to https://docs.python.org/3/library/re.html#search-vs-match

```python
import re
somepat = '(?:^hellothere)'
somestr = '\nhellothere'
print("match (master)      :", re.compile(somepat).match(somestr))
print("search w/o MULTILINE:", re.compile(somepat).search(somestr))
print("search w/  MULTILINE:", re.compile(somepat, re.MULTILINE).search(somestr))
```