### PR TITLE
Update svg2pdf.py to search the PATH for inkscape

### DIFF
--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -17,6 +17,12 @@ from traitlets import Unicode, default
 
 from .convertfigures import ConvertFiguresPreprocessor
 
+if sys.version_info >= (3,3):
+    from shutil import which
+    get_inkscape_path = which('inkscape')
+else:
+    get_inkscape_path = None
+
 
 INKSCAPE_APP = '/Applications/Inkscape.app/Contents/Resources/bin/inkscape'
 
@@ -58,6 +64,8 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
     inkscape = Unicode(help="The path to Inkscape, if necessary").tag(config=True)
     @default('inkscape')
     def _inkscape_default(self):
+        if get_inkscape_path is not None:
+            return get_inkscape_path 
         if sys.platform == "darwin":
             if os.path.isfile(INKSCAPE_APP):
                 return INKSCAPE_APP


### PR DESCRIPTION
Instead of relying on the registry to locate inkscape, for Python 3.3+,
use the shutil.which function to locate the file. If this fails because
inkscape is not in the path or if the version of Python is less than
3.3, then fall back to the existing methods. This has the advantage of
being a platform independent process as shutil.which is designed to be
platform agnostic. This PR fixes the problems seen in issue #139 and
#456 (as well as probably other issues), for resolving the path on
Windows. This doesn't invalidate the work in PR #1008, which may help
with the registry method, but I believe this change eliminates the need
for PR #1008 for most by utilizing a more standard approach. Where the
registry method is better is when inkscape is only in the registry and
not in the PATH, but finding the file in the PATH is bound to be more
resilient to change such as might happen if files on the disk are moved
and yet the registry key was not updated with the change, or the
registry key was left over and not removed from an old install. This is
intended to compliment the existing method rather than replace.