### PR TITLE
CircleCI: Use conda root environment, no need to "activate"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
     working_directory: ~/checkout
 
     environment:
+      BASH_ENV: /root/.bashrc
       MINICONDA_INSTALLER: https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-      ACTIVATE: source /root/miniconda/bin/activate nbconvert_docs
       PIP_INSTALL: python3 -m pip install --user --progress-bar off --upgrade
 
     steps:
@@ -35,11 +35,12 @@ jobs:
             else
               echo Miniconda is already installed
             fi
+            /root/miniconda/bin/conda init bash
 
       - run:
           name: Creating/Updating conda environment
           command: |
-            /root/miniconda/bin/conda env update -f docs/environment.yml --prune
+            conda env update -f docs/environment.yml -n root --prune
 
       - save_cache:
           key: v1-miniconda-{{ .Branch }}-{{ checksum "docs/environment.yml" }}
@@ -49,13 +50,11 @@ jobs:
       - run:
           name: Installing nbconvert
           command: |
-            $ACTIVATE
             $PIP_INSTALL .
 
       - run:
           name: Building HTML
           command: |
-            $ACTIVATE
             python3 setup.py build_sphinx -b html
 
       - store_artifacts:
@@ -66,7 +65,6 @@ jobs:
       - run:
           name: Building LaTeX
           command: |
-            $ACTIVATE
             python3 setup.py build_sphinx -b latex
 
       - run:
@@ -83,7 +81,6 @@ jobs:
       - run:
           name: Checking for broken links
           command: |
-            $ACTIVATE
             python3 setup.py build_sphinx -b linkcheck
 
 workflows:


### PR DESCRIPTION
I didn't like having to call "activate" before each step in my original setup (see #1114).

By installing everything in the "root" environment, we can avoid this.
We also have to save the `conda` paths etc. in `BASH_ENV`, for them to be made available in each new task.