### PR TITLE
add a timeout error so that it shows the contents of the cell which timed out

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -539,7 +539,6 @@ class ExecutePreprocessor(Preprocessor):
                 raise CellExecutionTimeoutError.from_cell_and_msg(cell)
             else:
                 raise TimeoutError("Cell execution timed out")
-            raise TimeoutError("Cell execution timed out")
 
     def _check_alive(self):
         if not self.kc.is_alive():

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -84,9 +84,9 @@ An error occurred while executing the following cell:
 class CellExecutionTimeoutError(TimeoutError):
     """
     Custom exception to propagate exceptions that are raised during
-    notebook execution to the caller. This is mostly useful when
-    using nbconvert as a library, since it allows to deal with
-    failures gracefully.
+    notebook execution to the caller for timeout. This is mostly
+    useful when using nbconvert as a library, since it allows to
+    deal with failures gracefully.
     """
     def __init__(self, traceback):
         super(CellExecutionTimeoutError, self).__init__(traceback)


### PR DESCRIPTION
added `CellExecutionTimeoutError` which inherits from `TimeoutError`, this follows a similar format to `CellExecutionError`. In addition, added cell as an optional argument to get the cell source code out to the exception.

Should close #1123 