### PR TITLE
Use nbsphinx development version for docs build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,5 +12,5 @@ dependencies:
 - tornado
 - entrypoints
 - pip:
-    - nbsphinx>=0.2.12
+    - git+https://github.com/spatialaudio/nbsphinx.git#egg=nbsphinx
     - sphinxcontrib_github_alt


### PR DESCRIPTION
Should work with recent changes to nbconvert templates.