### PR TITLE
Correct the location of the javascript output element

### DIFF
--- a/share/jupyter/nbconvert/templates/base/base.html.j2
+++ b/share/jupyter/nbconvert/templates/base/base.html.j2
@@ -217,8 +217,8 @@ alt="{{ alttext }}"
 
 {%- block data_javascript scoped %}
 {% set div_id = uuid4() %}
-<div id="{{ div_id }}"></div>
 <div class="output_subarea output_javascript {{ extra_class }}">
+<div id="{{ div_id }}"></div>
 <script type="text/javascript">
 var element = $('#{{ div_id }}');
 {{ output.data['application/javascript'] }}
@@ -230,8 +230,8 @@ var element = $('#{{ div_id }}');
 {% set div_id = uuid4() %}
 {% set datatype_list = output.data | filter_data_type %} 
 {% set datatype = datatype_list[0]%} 
-<div id="{{ div_id }}"></div>
 <div class="output_subarea output_widget_state {{ extra_class }}">
+<div id="{{ div_id }}"></div>
 <script type="text/javascript">
 var element = $('#{{ div_id }}');
 </script>
@@ -245,8 +245,8 @@ var element = $('#{{ div_id }}');
 {% set div_id = uuid4() %}
 {% set datatype_list = output.data | filter_data_type %} 
 {% set datatype = datatype_list[0]%} 
-<div id="{{ div_id }}"></div>
 <div class="output_subarea output_widget_view {{ extra_class }}">
+<div id="{{ div_id }}"></div>
 <script type="text/javascript">
 var element_id = '#{{ div_id }}';
 </script>


### PR DESCRIPTION
Fixes #1148 

I assume this issue also applies to the jupyter widgets, so moved those too.

Without this change, my javascript element is rendered without padding, and compressed by an empty `output_javascript` flexbox:

![image](https://user-images.githubusercontent.com/425260/70340540-dea09800-1848-11ea-8f32-545928da1c3b.png)

cc @hugohadfield whose https://github.com/pygae/pyganja is outputing the `Javascript`
