### PR TITLE
Fix jquery and element var

### DIFF
--- a/share/jupyter/nbconvert/templates/base/base.html.j2
+++ b/share/jupyter/nbconvert/templates/base/base.html.j2
@@ -248,7 +248,7 @@ var element = $('#{{ div_id }}');
 <div id="{{ div_id }}"></div>
 <div class="output_subarea output_widget_view {{ extra_class }}">
 <script type="text/javascript">
-var element_id = '#{{ div_id }}';
+var element = $('#{{ div_id }}');
 </script>
 <script type="{{ datatype }}">
 {{ output.data[datatype] | json_dumps }}

--- a/share/jupyter/nbconvert/templates/base/base.html.j2
+++ b/share/jupyter/nbconvert/templates/base/base.html.j2
@@ -217,8 +217,7 @@ alt="{{ alttext }}"
 
 {%- block data_javascript scoped %}
 {% set div_id = uuid4() %}
-<div id="{{ div_id }}"></div>
-<div class="output_subarea output_javascript {{ extra_class }}">
+<div id="{{ div_id }}" class="output_subarea output_javascript {{ extra_class }}">
 <script type="text/javascript">
 var element = $('#{{ div_id }}');
 {{ output.data['application/javascript'] }}
@@ -230,8 +229,7 @@ var element = $('#{{ div_id }}');
 {% set div_id = uuid4() %}
 {% set datatype_list = output.data | filter_data_type %} 
 {% set datatype = datatype_list[0]%} 
-<div id="{{ div_id }}"></div>
-<div class="output_subarea output_widget_state {{ extra_class }}">
+<div id="{{ div_id }}" class="output_subarea output_widget_state {{ extra_class }}">
 <script type="text/javascript">
 var element = $('#{{ div_id }}');
 </script>
@@ -245,8 +243,7 @@ var element = $('#{{ div_id }}');
 {% set div_id = uuid4() %}
 {% set datatype_list = output.data | filter_data_type %} 
 {% set datatype = datatype_list[0]%} 
-<div id="{{ div_id }}"></div>
-<div class="output_subarea output_widget_view {{ extra_class }}">
+<div id="{{ div_id }}" class="output_subarea output_widget_view {{ extra_class }}">
 <script type="text/javascript">
 var element = $('#{{ div_id }}');
 </script>

--- a/share/jupyter/nbconvert/templates/classic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/index.html.j2
@@ -13,6 +13,7 @@
 
 {%- block html_head_js -%}
 {%- block html_head_js_jquery -%}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 {%- endblock html_head_js_jquery -%}
 {%- block html_head_js_requirejs -%}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>

--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -223,8 +223,7 @@ class="unconfined"
 
 {% set div_id = uuid4() %}
 {%- block data_javascript scoped %}
-<div id="{{ div_id }}"></div>
-<div class="jp-RenderedJavaScript jp-OutputArea-output {{ extra_class }}" data-mime-type="application/javascript">
+<div id="{{ div_id }}" class="jp-RenderedJavaScript jp-OutputArea-output {{ extra_class }}" data-mime-type="application/javascript">
 <script type="text/javascript">
 var element = document.getElementById('{{ div_id }}');
 {{ output.data['application/javascript'] }}
@@ -236,8 +235,7 @@ var element = document.getElementById('{{ div_id }}');
 {% set div_id = uuid4() %}
 {% set datatype_list = output.data | filter_data_type %}
 {% set datatype = datatype_list[0]%}
-<div id="{{ div_id }}"></div>
-<div class="output_subarea output_widget_state {{ extra_class }}">
+<div id="{{ div_id }}" class="output_subarea output_widget_state {{ extra_class }}">
 <script type="text/javascript">
 var element = document.getElementById('{{ div_id }}');
 </script>
@@ -251,8 +249,7 @@ var element = document.getElementById('{{ div_id }}');
 {% set div_id = uuid4() %}
 {% set datatype_list = output.data | filter_data_type %}
 {% set datatype = datatype_list[0]%}
-<div id="{{ div_id }}"></div>
-<div class="jupyter-widgets jp-OutputArea-output {{ extra_class }}">
+<div id="{{ div_id }}" class="jupyter-widgets jp-OutputArea-output {{ extra_class }}">
 <script type="text/javascript">
 var element = document.getElementById('{{ div_id }}');
 </script>

--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -226,7 +226,7 @@ class="unconfined"
 <div id="{{ div_id }}"></div>
 <div class="jp-RenderedJavaScript jp-OutputArea-output {{ extra_class }}" data-mime-type="application/javascript">
 <script type="text/javascript">
-var element_id = '#{{ div_id }}';
+var element = document.getElementById('{{ div_id }}');
 {{ output.data['application/javascript'] }}
 </script>
 </div>
@@ -239,7 +239,7 @@ var element_id = '#{{ div_id }}';
 <div id="{{ div_id }}"></div>
 <div class="output_subarea output_widget_state {{ extra_class }}">
 <script type="text/javascript">
-var element_id = '#{{ div_id }}';
+var element = document.getElementById('{{ div_id }}');
 </script>
 <script type="{{ datatype }}">
 {{ output.data[datatype] | json_dumps }}
@@ -254,7 +254,7 @@ var element_id = '#{{ div_id }}';
 <div id="{{ div_id }}"></div>
 <div class="jupyter-widgets jp-OutputArea-output {{ extra_class }}">
 <script type="text/javascript">
-var element_id = '#{{ div_id }}';
+var element = document.getElementById('{{ div_id }}');
 </script>
 <script type="{{ datatype }}">
 {{ output.data[datatype] | json_dumps }}

--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -1,6 +1,11 @@
 {%- extends 'classic/index.html.j2' -%}
 
 
+{%- block html_head_js_jquery -%}
+{# no jQuery in Jupyter lab, so also not in this template #}
+{%- endblock html_head_js_jquery -%}
+
+
 {% block notebook_css %}
 {{ resources.include_css("static/index.css") }}
 {% if resources.theme == 'dark' %}


### PR DESCRIPTION
Fixes #1148 and alternative to #1149.

jQuery support was removed in #1056 based on what we've done with voila. However, since we now have the two template (classic and lab) it makes sense that classic stays as compatible as it is with the classical notebook.

Therefore I've restored the jQuery library, and made the template exposes the `element` variable again (used for js library/code).

However, we want to get rid of jQuery, so in the lab template, we simply point the `element` variable to the DOM Node, which has an API similar, meaning the example library mentioned in #1149 works with both the classical and lab template.

The original issue in #1148 was solved by removing the unnecessary div element, and point `element` to the same DOM element as what would happen in the classical notebook.