### PR TITLE
Group \prompt command in jupyter latex template

### DIFF
--- a/share/jupyter/nbconvert/templates/latex/style_jupyter.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/style_jupyter.tex.j2
@@ -103,7 +103,7 @@
     \makeatother
     ((*- block style_prompt *))
     \newcommand{\prompt}[4]{
-        \ttfamily\llap{{\color{#2}[#3]:\hspace{3pt}#4}}\vspace{-\baselineskip}
+        {\ttfamily\llap{{\color{#2}[#3]:\hspace{3pt}#4}}\vspace{-\baselineskip}}
     }
     ((* endblock style_prompt *))
     


### PR DESCRIPTION
Fixes #1151 by preventing `\ttfamily` to affect later markdown cells.