### PR TITLE
Stop raising CellExecutionError with error ioPub message

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -472,9 +472,6 @@ class ExecutePreprocessor(Preprocessor):
                               in cell.metadata.get("tags", []))
 
         if self.force_raise_errors or not cell_allows_errors:
-            for out in cell.outputs:
-                if out.output_type == 'error':
-                    raise CellExecutionError.from_cell_and_msg(cell, out)
             if (reply is not None) and reply['content']['status'] == 'error':
                 raise CellExecutionError.from_cell_and_msg(cell, reply['content'])
         return cell, resources


### PR DESCRIPTION
https://github.com/jupyter/nbconvert/issues/1160

Stop raising `CellExecutionError` if the cell output contains an `error` message but  returns `execute_reply` with an `ok` status. This makes nbconvert consistent with the batch-execution behavior (`Run all cells`) of classic Jupyter and Jupyter Lab.

@MSeal Is this good enough? 