### PR TITLE
Make template system backward compatible

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -10,6 +10,7 @@ from __future__ import print_function, absolute_import
 import os
 import uuid
 import json
+import warnings
 
 from jupyter_core.paths import jupyter_path
 from traitlets import HasTraits, Unicode, List, Dict, Bool, default, observe
@@ -535,3 +536,11 @@ class TemplateExporter(Exporter):
         root_dirs.extend(self.template_path)
         root_dirs.extend(jupyter_path())
         return root_dirs
+
+    def _init_resources(self, resources):
+        resources = super()._init_resources(resources)
+        # inline function to avoid pickle errors
+        def deprecated(msg):
+            warnings.warn(msg, DeprecationWarning)
+        resources['deprecated'] = deprecated
+        return resources

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -482,6 +482,9 @@ class TemplateExporter(Exporter):
             base_dir = os.path.join(root_dir, 'nbconvert', 'templates')
             paths.append(base_dir)
 
+            compatibility_dir = os.path.join(root_dir, 'nbconvert', 'templates', 'compatibility')
+            paths.append(compatibility_dir)
+
         additional_paths = self.template_data_paths
         for path in additional_paths:
             try:

--- a/nbconvert/exporters/tests/test_rst.py
+++ b/nbconvert/exporters/tests/test_rst.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import io
+import pytest
 import re
 
 import nbformat
@@ -33,6 +34,15 @@ class TestRSTExporter(ExportersTestsBase):
         Can a RSTExporter export something?
         """
         (output, resources) = RSTExporter().from_filename(self._get_notebook())
+        assert len(output) > 0
+
+    @onlyif_cmds_exist('pandoc')
+    def test_export_nbformat_template_v5_name(self):
+        """
+        We support the nbconvert v5 filename, but with a deprecation warning.
+        """
+        with pytest.warns(DeprecationWarning):
+            (output, resources) = RSTExporter(template_file='rst.tpl').from_filename(self._get_notebook())
         assert len(output) > 0
 
     @onlyif_cmds_exist('pandoc')

--- a/share/jupyter/nbconvert/templates/compatibility/display_priority.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/display_priority.tpl
@@ -1,0 +1,1 @@
+{%- extends 'base/display_priority.j2' -%}

--- a/share/jupyter/nbconvert/templates/compatibility/rst.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/rst.tpl
@@ -1,0 +1,1 @@
+{%- extends 'rst/index.rst.j2' -%}

--- a/share/jupyter/nbconvert/templates/compatibility/rst.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/rst.tpl
@@ -1,1 +1,2 @@
+{{ resources.deprecated("This template is deprecated, please use rst/index.rst.j2") }}
 {%- extends 'rst/index.rst.j2' -%}


### PR DESCRIPTION
Fixes #1158

This also makes nbconvert 6.0.0 compatible with voila (0.1.20 as of writing), and I guess many more projects.

The basic idea is to add templates with the old names in the compatibility subdirectory, which will be added to the search path. I've done this for `rst.tpl` and `display_priority.tpl`, but if people like this I can do it for the other old template filenames as well.

I think it does not bring an extra dev burden for this project while staying backward compatible. 

Should we try to make it fully backward compatible, including running tests?