### PR TITLE
Fix memory leak in execute preprocessor

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -397,6 +397,7 @@ class ExecutePreprocessor(Preprocessor):
             try:
                 yield nb, self.km, self.kc
             finally:
+                self.kc.stop_channels()
                 for attr in ['nb', 'km', 'kc']:
                     delattr(self, attr)
 


### PR DESCRIPTION
There is a memory leak in the `ExecutePreprocessor` when using a kernel
manager. `KernelClient` (from jupyter_client) does not have a `__del__`
that invokes `stop_channels()`. So if `stop_channels()` is not
invoked explicitly and the `self.kc` object goes away, a memory leak
will occur.

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>