### PR TITLE
Update Inkscape command line options in svg2pdf

### DIFF
--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -59,7 +59,7 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
     @default('command')
     def _command_default(self):
         return self.inkscape + \
-               ' --without-gui --export-pdf="{to_filename}" "{from_filename}"'
+               ' --without-gui --export-file="{to_filename}" "{from_filename}"'
     
     inkscape = Unicode(help="The path to Inkscape, if necessary").tag(config=True)
     @default('inkscape')


### PR DESCRIPTION
With Inkscape version "Inkscape 1.0beta2 (2b71d25, 2019-12-03)" and nbconvert version 5.6.1, svg2pdf failed with Unknown option --export-pdf

Changing to --export-file fixed this issue.