### PR TITLE
Fixed python require for python 3 install patterns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,29 +4,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
-# the name of the package
-name = 'nbconvert'
-
-#-----------------------------------------------------------------------------
-# Minimal Python version sanity check
-#-----------------------------------------------------------------------------
-
-import sys
-
-v = sys.version_info
-if v[:2] < (3, 5):
-    error = "ERROR: %s requires Python version 3.5 or above." % name
-    print(error, file=sys.stderr)
-    sys.exit(1)
-
-#-----------------------------------------------------------------------------
-# get on with it
-#-----------------------------------------------------------------------------
-
 import os
 import io
+import sys
 
 from setuptools import setup
 from setuptools.command.bdist_egg import bdist_egg
@@ -38,6 +18,9 @@ from urllib.request import urlopen
 from distutils.cmd import Command
 from distutils.command.build import build
 from distutils.command.sdist import sdist
+
+# the name of the package
+name = 'nbconvert'
 
 pjoin = os.path.join
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
The sys check is not necessary with the `python_requires = '>=3.5',` line in setup