### PR TITLE
Fix error in docstring => latex/pdf export by converting ansi escapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,6 @@ docs/source/config_options.rst
 .settings
 
 # VSCode
+*.code-workspace
+.history
 .vscode

--- a/share/jupyter/nbconvert/templates/latex/document_contents.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/document_contents.tex.j2
@@ -6,9 +6,9 @@
 
 % Displaying simple data text
 ((* block data_text *))
-    \begin{verbatim}
-((( output.data['text/plain'] )))
-    \end{verbatim}
+    \begin{Verbatim}[commandchars=\\\{\}]
+((( output.data['text/plain'] | escape_latex | ansi2latex )))
+    \end{Verbatim}
 ((* endblock data_text *))
 
 % Display python error text as-is


### PR DESCRIPTION
fixes jupyterlab/jupyterlab#4447

Currently, if you have a cell in a notebook with docstring output:

<img width="825" alt="image" src="https://user-images.githubusercontent.com/2263641/73702209-00d45c00-46ba-11ea-9f0f-36e86b5b24a2.png">

and you try to export it to pdf, you'll get an error:

<img width="905" alt="image" src="https://user-images.githubusercontent.com/2263641/73702370-97088200-46ba-11ea-858d-1e817000e3f6.png">

Here's the actual error text

```
! Text line contains an invalid character.
l.403 ^^[
         [0;31mSignature:^^[[0m ^^[[0msum^^[[0m^^[[0;34m(^^[[0m^^[[0miterabl...

? 
! Emergency stop.
l.403 ^^[
         [0;31mSignature:^^[[0m ^^[[0msum^^[[0m^^[[0;34m(^^[[0m^^[[0miterabl...

No pages of output.
Transcript written on notebook.log.
```

I've fixed this by handling `data_text` blocks (which are used for docstring output) in the latex template the same way as `stream` blocks (which are used for regular `stdout` and such): any potential latex command sequences are escaped, then the ansi codes are converted to latex.

If you want to reproduce the error, you'll have to use Jupyterlab, since notebook classic outputs docstrings to a separate pager area, rather than including them in cell output.