### PR TITLE
Fix formatting of cell errors in exported latex/pdf

### DIFF
--- a/share/jupyter/nbconvert/templates/latex/document_contents.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/document_contents.tex.j2
@@ -11,15 +11,16 @@
     \end{Verbatim}
 ((* endblock data_text *))
 
-% Display python error text as-is
+% Display python error text with colored frame (saves printer ink vs bkgnd)
 ((* block error *))
-    \begin{Verbatim}[commandchars=\\\{\}]
-((( super() )))
+    \begin{Verbatim}[commandchars=\\\{\}, frame=single, framerule=2mm, rulecolor=\color{outerrorbackground}]
+(((- super() )))
     \end{Verbatim}
 ((* endblock error *))
-((* block traceback_line *))
-    ((( line | indent | strip_ansi | escape_latex )))
-((* endblock traceback_line *))
+% Display error lines with coloring
+((*- block traceback_line *))
+((( line | escape_latex | ansi2latex )))
+((*- endblock traceback_line *))
 
 % Display stream ouput with coloring
 ((* block stream *))

--- a/share/jupyter/nbconvert/templates/latex/style_jupyter.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/style_jupyter.tex.j2
@@ -95,6 +95,7 @@
     \definecolor{outcolor}{HTML}{D84315}
     \definecolor{cellborder}{HTML}{CFCFCF}
     \definecolor{cellbackground}{HTML}{F7F7F7}
+    \definecolor{outerrorbackground}{HTML}{FFDFDF}
     ((*- endblock style_colors *))
     
     % prompt


### PR DESCRIPTION
While investigating #1181, I noticed that cell errors are not formatted well in exported latex/pdf. Starting from a notebook with a cell that looks like this:

<img width="839" alt="image" src="https://user-images.githubusercontent.com/2263641/73798609-50318f80-4781-11ea-8f19-d6aced276385.png">

when you export to pdf, you end up with:

<img width="903" alt="image" src="https://user-images.githubusercontent.com/2263641/73798662-866f0f00-4781-11ea-8d9b-7bf7a1419532.png">

The pdf output in this case is significantly less legible than the initial error/trace from the live notebook.

This PR fixes the above by:

- correctly coloring error output
- correctly indenting error output lines
- ensuring that no extraneous newlines get inserted
- adding a colored background to the error output in the pdf that matches the output background from the live notebook

Here's what the pdf export looks like with the above fixes:

<img width="919" alt="image" src="https://user-images.githubusercontent.com/2263641/73798848-24fb7000-4782-11ea-9d63-b569d2b04e4b.png">

One thing to notice is that I only added the cell error background color to the edge of the background. This seems like a reasonable compromise between verisimilitude (w.r.t. the live notebook) and sparing expensive colored ink (since exporting a notebook to pdf is a common step before printing)