### PR TITLE
move outerrorbackground color to be accessible to all style_* templates

### DIFF
--- a/share/jupyter/nbconvert/templates/latex/base.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/base.tex.j2
@@ -103,6 +103,9 @@ override this.-=))
     \definecolor{ansi-default-inverse-fg}{HTML}{FFFFFF}
     \definecolor{ansi-default-inverse-bg}{HTML}{000000}
 
+    % common color for the border for error outputs.
+    \definecolor{outerrorbackground}{HTML}{FFDFDF}
+
     % commands and environments needed by pandoc snippets
     % extracted from the output of `pandoc -s`
     \providecommand{\tightlist}{%

--- a/share/jupyter/nbconvert/templates/latex/style_jupyter.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/style_jupyter.tex.j2
@@ -95,7 +95,6 @@
     \definecolor{outcolor}{HTML}{D84315}
     \definecolor{cellborder}{HTML}{CFCFCF}
     \definecolor{cellbackground}{HTML}{F7F7F7}
-    \definecolor{outerrorbackground}{HTML}{FFDFDF}
     ((*- endblock style_colors *))
     
     % prompt


### PR DESCRIPTION
Moves the ```\definecolor``` so that it is accessible for all cell styles and does not cause an undefined macro error when using non-default cell styles.