### PR TITLE
change default output format to notebook

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -263,7 +263,7 @@ class NbConvertApp(JupyterApp):
 
 
     export_format = Unicode(
-        'html',
+        'notebook',
         allow_none=False,
         help="""The export format to be used, either one of the built-in formats
         {formats}

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -179,11 +179,8 @@ class NbConvertApp(JupyterApp):
     examples = Unicode(u"""
         The simplest way to use nbconvert is
         
-        > jupyter nbconvert mynotebook.ipynb
-        
-        which will convert mynotebook.ipynb to the default format (probably HTML).
-        
-        You can specify the export format with `--to`.
+        > jupyter nbconvert mynotebook.ipynb --to html
+
         Options include {formats}.
         
         > jupyter nbconvert --to latex mynotebook.ipynb
@@ -263,7 +260,6 @@ class NbConvertApp(JupyterApp):
 
 
     export_format = Unicode(
-        'notebook',
         allow_none=False,
         help="""The export format to be used, either one of the built-in formats
         {formats}
@@ -495,15 +491,21 @@ class NbConvertApp(JupyterApp):
                 """
             )
             self.exit(1)
-        
-        # initialize the exporter
-        cls = get_exporter(self.export_format)
-        self.exporter = cls(config=self.config)
 
         # no notebooks to convert!
         if len(self.notebooks) == 0 and not self.from_stdin:
             self.print_help()
             sys.exit(-1)
+
+        if not self.export_format:
+            raise ValueError(
+                "Please specify an output format with '--to <format>'."
+                f"\nThe following formats are available: {get_export_names()}"
+            )
+
+        # initialize the exporter
+        cls = get_exporter(self.export_format)
+        self.exporter = cls(config=self.config)
 
         # convert each notebook
         if not self.from_stdin:

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -97,7 +97,7 @@ class TestNbConvertApp(TestsBase):
             test_output = 'success!'
             with open(template, 'w') as f:
                 f.write(test_output)
-            self.nbconvert('--log-level 0 notebook2 --template-file %s' % template)
+            self.nbconvert('--log-level 0 notebook2 --to html --template-file %s' % template)
             assert os.path.isfile('notebook2.html')
             with open('notebook2.html') as f:
                 text = f.read()
@@ -111,7 +111,7 @@ class TestNbConvertApp(TestsBase):
             test_output = 'success!'
             with open(template, 'w') as f:
                 f.write(test_output)
-            self.nbconvert('--log-level 0 notebook2 --template-file %s' % template)
+            self.nbconvert('--log-level 0 notebook2 --to html --template-file %s' % template)
             assert os.path.isfile('notebook2.html')
             with open('notebook2.html') as f:
                 text = f.read()


### PR DESCRIPTION
As discussed in #1045, this default makes notebook-to-notebook preprocessor transformations nicer and does not favour html arbitrarily. 

I know @takluyver suggested adding a warning if no preprocessors are configured, but I'm not sure how to detect if there has been no other changes in configuration. We could just add a warning that says: ```Default output has been changed to notebook. For the old behaviour add: --to html``` if the ```--to``` flag has not been used. We could then remove the warning in 6.1