### PR TITLE
Only attempt grffile patch if needed

### DIFF
--- a/share/jupyter/nbconvert/templates/latex/base.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/base.tex.j2
@@ -34,8 +34,6 @@ override this.-=))
     \DeclareCaptionFormat{nocaption}{}
     \captionsetup{format=nocaption,aboveskip=0pt,belowskip=0pt}
 
-    \usepackage[Export]{adjustbox} % Used to constrain images to a maximum size
-    \adjustboxset{max size={0.9\linewidth}{0.9\paperheight}}
     \usepackage{float}
     \floatplacement{figure}{H} % forces figures to be placed at the correct location
     \usepackage{xcolor} % Allow colors to be defined
@@ -54,13 +52,21 @@ override this.-=))
     \usepackage{fancyvrb} % verbatim replacement that allows latex
     \usepackage{grffile} % extends the file name processing of package graphics 
                          % to support a larger range
-    \makeatletter % fix for grffile with XeLaTeX
-    \def\Gread@@xetex#1{%
-      \IfFileExists{"\Gin@base".bb}%
-      {\Gread@eps{\Gin@base.bb}}%
-      {\Gread@@xetex@aux#1}%
+    \makeatletter % fix for old versions of grffile with XeLaTeX
+    \@ifpackagelater{grffile}{2019/11/01}
+    {
+      % Do nothing on new versions
+    }
+    {
+      \def\Gread@@xetex#1{%
+        \IfFileExists{"\Gin@base".bb}%
+        {\Gread@eps{\Gin@base.bb}}%
+        {\Gread@@xetex@aux#1}%
+      }
     }
     \makeatother
+    \usepackage[Export]{adjustbox} % Used to constrain images to a maximum size
+    \adjustboxset{max size={0.9\linewidth}{0.9\paperheight}}
 
     % The hyperref package gives us a pdf with properly built
     % internal navigation ('pdf bookmarks' for the table of contents,


### PR DESCRIPTION
As of 2019/10/10, grrfile is only a stub package that imports graphicx. Newer versions of graphicx don't have issues with spaces in image names. Unfortunately, we cannot assume that people have up to date versions of those packages.

Fortunately, a TeX primative exists to check package versions, so this was a fairly simple fix. All I do is check the release date of grffile, and apply the patch only if it's an old version. I have also moved adjustbox below grffile just incase grffile importing graphicx overwrites adjustbox's "Export" option.

Fixes #1140 