### PR TITLE
Use encodebytes instead of encodestring in Python 3.9.

### DIFF
--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -123,6 +123,6 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
             if os.path.isfile(output_filename):
                 with open(output_filename, 'rb') as f:
                     # PDF is a nb supported binary, data type, so base64 encode.
-                    return base64.encodestring(f.read())
+                    return base64.encodebytes(f.read())
             else:
                 raise TypeError("Inkscape svg to pdf conversion failed")


### PR DESCRIPTION
`encodestring` was deprecated and removed in Python 3.9 in favor of `encodebytes`. 