### PR TITLE
Changed from \ref to \hyperref to preserve markdown link text

### DIFF
--- a/nbconvert/filters/filter_links.py
+++ b/nbconvert/filters/filter_links.py
@@ -4,7 +4,7 @@ Converts links between notebooks to Latex cross-references.
 """
 import re
 
-from pandocfilters import RawInline, applyJSONFilters
+from pandocfilters import RawInline, applyJSONFilters, stringify
 
 def resolve_references(source):
     """
@@ -26,7 +26,7 @@ def resolve_one_reference(key, val, fmt, meta):
     """
     
     if key == 'Link':
-        text = val[1][0]['c']
+        text = stringify(val[1])
         target = val[2][0]
         m = re.match(r'#(.+)$', target)
         if m:

--- a/nbconvert/filters/filter_links.py
+++ b/nbconvert/filters/filter_links.py
@@ -19,20 +19,21 @@ def resolve_one_reference(key, val, fmt, meta):
     """
     This takes a tuple of arguments that are compatible with ``pandocfilters.walk()`` that
     allows identifying hyperlinks in the document and transforms them into valid LaTeX 
-    \\ref{} calls so that linking to headers between cells is possible.
+    \\hyperref{} calls so that linking to headers between cells is possible.
 
     See the documentation in ``pandocfilters.walk()`` for further information on the meaning
     and specification of ``key``, ``val``, ``fmt``, and ``meta``. 
     """
     
     if key == 'Link':
+        text = val[1][0]['c']
         target = val[2][0]
         m = re.match(r'#(.+)$', target)
         if m:
             # pandoc automatically makes labels for headings.
             label = m.group(1).lower()
             label = re.sub(r'[^\w-]+', '', label) # Strip HTML entities
-            return RawInline('tex', r'Section \ref{%s}' % label)
+            return RawInline('tex', r'\hyperref[{label}]{{{text}}}'.format(label=label, text=text))
 
     # Other elements will be returned unchanged.
 


### PR DESCRIPTION
As discussed in #1203, I think it makes sense for the links in PDF's to preserve the behavior seen in Markdown and HTML. Using `\hyperref` instead of `\ref` enables custom link text as discussed in [this stackoverflow post](https://tex.stackexchange.com/questions/70143/cross-reference-with-custom-text).

I also checked to ensure that `\hyperref` would be available and the [pandoc documentation](https://pandoc.org/MANUAL.html#creating-a-pdf) says that it's a required package, so presumably it's in the pandoc latex template's preamble.