### PR TITLE
Fix Inkscape executable for macOS & Inkscape v1.0

### DIFF
--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -20,7 +20,11 @@ from .convertfigures import ConvertFiguresPreprocessor
 from shutil import which
 
 
+# inkscape path for darwin (macOS)
 INKSCAPE_APP = '/Applications/Inkscape.app/Contents/Resources/bin/inkscape'
+# Recent versions of Inkscpae (v1.0) moved the executable from 
+# Resources/bin/inkscape to MacOS/inkscape
+INKSCAPE_APP_v1 = '/Applications/Inkscape.app/Contents/MacOS/inkscape'
 
 if sys.platform == "win32":
     try:
@@ -85,6 +89,10 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
         if inkscape_path is not None:
             return inkscape_path
         if sys.platform == "darwin":
+            if os.path.isfile(INKSCAPE_APP_v1):
+                return INKSCAPE_APP_v1
+            # Order is important. If INKSCAPE_APP exists, prefer it over
+            # the executable in the MacOS directory.
             if os.path.isfile(INKSCAPE_APP):
                 return INKSCAPE_APP
         if sys.platform == "win32":


### PR DESCRIPTION
Starting with Inkscape v1.0 (currently beta), the executable for Inkscape (`inkscape`) can now be found inside the `Inkscape.app/Contents/MacOS` directory. Note that this file might also be present on versions prior to 1.0.
Thus, the order in which we check the presence of the executable is important. If the old `INKSCAPE_APP` is present, it should be preferred over the one in `Inkscape.app/Contents/MacOS`.

I haven't got the time and resources to test this on Inkscape v0.92.4 as there is
 > no .dmg file for macOS for the current Inkscape version at this time

(from https://inkscape.org/de/release/inkscape-0.92.4/mac-os-x/dmg/dl/)  
and Inkscape v0.92.2 is unsupported on macOS 10.15. I was only able to test this fix with the current beta `v1.0beta2` of Inkscape on macOS.