### PR TITLE
MRG: use Python 3 super syntax throughout

### DIFF
--- a/nbconvert/exporters/asciidoc.py
+++ b/nbconvert/exporters/asciidoc.py
@@ -47,5 +47,5 @@ class ASCIIDocExporter(TemplateExporter):
                 'enabled':True
                 },
         })
-        c.merge(super(ASCIIDocExporter, self).default_config)
+        c.merge(super().default_config)
         return c

--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -35,7 +35,7 @@ class FilenameExtension(Unicode):
 
     def validate(self, obj, value):
         # cast to proper unicode
-        value = super(FilenameExtension, self).validate(obj, value)
+        value = super().validate(obj, value)
 
         # check that it starts with a dot
         if value and not value.startswith('.'):
@@ -105,7 +105,7 @@ class Exporter(LoggingConfigurable):
         if config:
             with_default_config.merge(config)
 
-        super(Exporter, self).__init__(config=with_default_config, **kw)
+        super().__init__(config=with_default_config, **kw)
 
         self._init_preprocessors()
 

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -78,7 +78,7 @@ class HTMLExporter(TemplateExporter):
                 'enabled':True
                 }
             })
-        c.merge(super(HTMLExporter,self).default_config)
+        c.merge(super().default_config)
         return c
 
     @contextfilter
@@ -92,7 +92,7 @@ class HTMLExporter(TemplateExporter):
         return MarkdownWithMath(renderer=renderer).render(source)
 
     def default_filters(self):
-        for pair in super(HTMLExporter, self).default_filters():
+        for pair in super().default_filters():
             yield pair
         yield ('markdown2html', self.markdown2html)
 
@@ -101,7 +101,7 @@ class HTMLExporter(TemplateExporter):
         lexer = langinfo.get('pygments_lexer', langinfo.get('name', None))
         highlight_code = self.filters.get('highlight_code', Highlight2HTML(pygments_lexer=lexer, parent=self))
         self.register_filter('highlight_code', highlight_code)
-        return super(HTMLExporter, self).from_notebook_node(nb, resources, **kw)
+        return super().from_notebook_node(nb, resources, **kw)
 
     def _init_resources(self, resources):
         def resources_include_css(name):
@@ -139,7 +139,7 @@ class HTMLExporter(TemplateExporter):
             data = data.replace(b'\n', b'').decode('ascii')
             src = 'data:{mime_type};base64,{data}'.format(mime_type=mime_type, data=data)
             return jinja2.Markup(src)
-        resources = super(HTMLExporter, self)._init_resources(resources)
+        resources = super()._init_resources(resources)
         resources['theme'] = self.theme
         resources['include_css'] = resources_include_css
         resources['include_js'] = resources_include_js

--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -39,7 +39,7 @@ class LatexExporter(TemplateExporter):
     output_mimetype = 'text/latex'
 
     def default_filters(self):
-        for x in super(LatexExporter, self).default_filters():
+        for x in super().default_filters():
             yield x 
         yield ('resolve_references', resolve_references)
 
@@ -65,7 +65,7 @@ class LatexExporter(TemplateExporter):
                     'enabled':True
                  }
          })
-        c.merge(super(LatexExporter,self).default_config)
+        c.merge(super().default_config)
         return c
 
     def from_notebook_node(self, nb, resources=None, **kw):
@@ -74,10 +74,10 @@ class LatexExporter(TemplateExporter):
         highlight_code = self.filters.get('highlight_code', Highlight2Latex(pygments_lexer=lexer, parent=self))
         self.register_filter('highlight_code', highlight_code)
         
-        return super(LatexExporter, self).from_notebook_node(nb, resources, **kw)
+        return super().from_notebook_node(nb, resources, **kw)
 
     def _create_environment(self):
-        environment = super(LatexExporter, self)._create_environment()
+        environment = super()._create_environment()
 
         # Set special Jinja2 syntax that will not conflict with latex.
         environment.block_start_string = "((*"

--- a/nbconvert/exporters/markdown.py
+++ b/nbconvert/exporters/markdown.py
@@ -47,5 +47,5 @@ class MarkdownExporter(TemplateExporter):
                 'enabled':True
                 },
         })
-        c.merge(super(MarkdownExporter, self).default_config)
+        c.merge(super().default_config)
         return c

--- a/nbconvert/exporters/notebook.py
+++ b/nbconvert/exporters/notebook.py
@@ -29,7 +29,7 @@ class NotebookExporter(Exporter):
     export_from_notebook = "Notebook"
 
     def from_notebook_node(self, nb, resources=None, **kw):
-        nb_copy, resources = super(NotebookExporter, self).from_notebook_node(nb, resources, **kw)
+        nb_copy, resources = super().from_notebook_node(nb, resources, **kw)
         if self.nbformat_version != nb_copy.nbformat:
             resources['output_suffix'] = '.v%i' % self.nbformat_version
         else:

--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -172,7 +172,7 @@ class PDFExporter(LatexExporter):
         return self.run_command(self.bib_command, filename, 1, log_error, raise_on_failure)
     
     def from_notebook_node(self, nb, resources=None, **kw):
-        latex, resources = super(PDFExporter, self).from_notebook_node(
+        latex, resources = super().from_notebook_node(
             nb, resources=resources, **kw
         )
         # set texinputs directory, so that local files will be found

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -35,5 +35,5 @@ class RSTExporter(TemplateExporter):
                 'enabled':True
                 },
             })
-        c.merge(super(RSTExporter,self).default_config)
+        c.merge(super().default_config)
         return c

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -66,4 +66,4 @@ class ScriptExporter(TemplateExporter):
         # Fall back to plain script export
         self.file_extension = langinfo.get('file_extension', '.txt')
         self.output_mimetype = langinfo.get('mimetype', 'text/plain')
-        return super(ScriptExporter, self).from_notebook_node(nb, resources, **kw)
+        return super().from_notebook_node(nb, resources, **kw)

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -188,4 +188,4 @@ class SlidesExporter(HTMLExporter):
 
         nb = prepare(nb)
 
-        return super(SlidesExporter, self).from_notebook_node(nb, resources=resources, **kw)
+        return super().from_notebook_node(nb, resources=resources, **kw)

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -164,7 +164,7 @@ class TemplateExporter(Exporter):
                 'enabled': True
                 }
             })
-        c.merge(super(TemplateExporter, self).default_config)
+        c.merge(super().default_config)
         return c
 
     template_name = Unicode(help="Name of the template to use"
@@ -297,7 +297,7 @@ class TemplateExporter(Exporter):
         template_file : str (optional, kw arg)
             Template to use when exporting.
         """
-        super(TemplateExporter, self).__init__(config=config, **kw)
+        super().__init__(config=config, **kw)
 
         self.observe(self._invalidate_environment_cache,
                      list(self.traits(affects_environment=True)))
@@ -341,7 +341,7 @@ class TemplateExporter(Exporter):
           Additional resources that can be accessed read/write by
           preprocessors and filters.
         """
-        nb_copy, resources = super(TemplateExporter, self).from_notebook_node(nb, resources, **kw)
+        nb_copy, resources = super().from_notebook_node(nb, resources, **kw)
         resources.setdefault('raw_mimetypes', self.raw_mimetypes)
         resources['global_content_filter'] = {
                 'include_code': not self.exclude_code_cell,

--- a/nbconvert/exporters/tests/cheese.py
+++ b/nbconvert/exporters/tests/cheese.py
@@ -29,7 +29,7 @@ class CheesePreprocessor(Preprocessor):
         """
         Public constructor
         """
-        super(CheesePreprocessor, self).__init__(**kw)
+        super().__init__(**kw)
 
 
     def preprocess(self, nb, resources):

--- a/nbconvert/filters/highlight.py
+++ b/nbconvert/filters/highlight.py
@@ -25,7 +25,7 @@ __all__ = [
 class Highlight2HTML(NbConvertBase):
     def __init__(self, pygments_lexer=None, **kwargs):
         self.pygments_lexer = pygments_lexer or 'ipython3'
-        super(Highlight2HTML, self).__init__(**kwargs)
+        super().__init__(**kwargs)
     
     @observe('default_language')
     def _default_language_changed(self, change):
@@ -60,7 +60,7 @@ class Highlight2HTML(NbConvertBase):
 class Highlight2Latex(NbConvertBase):
     def __init__(self, pygments_lexer=None, **kwargs):
         self.pygments_lexer = pygments_lexer or 'ipython3'
-        super(Highlight2Latex, self).__init__(**kwargs)
+        super().__init__(**kwargs)
     
     @observe('default_language')
     def _default_language_changed(self, change):

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -50,7 +50,7 @@ class MathBlockLexer(mistune.BlockLexer):
     def __init__(self, rules=None, **kwargs):
         if rules is None:
             rules = MathBlockGrammar()
-        super(MathBlockLexer, self).__init__(rules, **kwargs)
+        super().__init__(rules, **kwargs)
 
     def parse_multiline_math(self, m):
         """Add token to pass through mutiline math."""
@@ -86,7 +86,7 @@ class MathInlineLexer(mistune.InlineLexer):
     def __init__(self, renderer, rules=None, **kwargs):
         if rules is None:
             rules = MathInlineGrammar()
-        super(MathInlineLexer, self).__init__(renderer, rules, **kwargs)
+        super().__init__(renderer, rules, **kwargs)
 
     def output_inline_math(self, m):
         return self.renderer.inline_math(m.group(1) or m.group(2))
@@ -105,7 +105,7 @@ class MarkdownWithMath(mistune.Markdown):
             kwargs['inline'] = MathInlineLexer
         if 'block' not in kwargs:
             kwargs['block'] = MathBlockLexer
-        super(MarkdownWithMath, self).__init__(renderer, **kwargs)
+        super().__init__(renderer, **kwargs)
 
     
     def output_multiline_math(self):
@@ -129,7 +129,7 @@ class IPythonRenderer(mistune.Renderer):
         return highlight(code, lexer, formatter)
 
     def header(self, text, level, raw=None):
-        html = super(IPythonRenderer, self).header(text, level, raw=raw)
+        html = super().header(text, level, raw=raw)
         if self.options.get("exclude_anchor_links"):
             return html
         anchor_link_text = self.options.get('anchor_link_text', u'¶')
@@ -172,7 +172,7 @@ class IPythonRenderer(mistune.Renderer):
             mime_type = preferred_mime_type
             data = attachment[mime_type]
             src = 'data:' + mime_type + ';base64,' + data
-        return super(IPythonRenderer, self).image(src, title, text)
+        return super().image(src, title, text)
 
 
 def markdown2html_mistune(source):

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -43,7 +43,7 @@ class DottedOrNone(DottedObjectName):
 
     def validate(self, obj, value):
         if value is not None and len(value) > 0:
-            return super(DottedOrNone, self).validate(obj, value)
+            return super().validate(obj, value)
         else:
             return value
             
@@ -282,7 +282,7 @@ class NbConvertApp(JupyterApp):
     def initialize(self, argv=None):
         """Initialize application, notebooks, writer, and postprocessor"""
         self.init_syspath()
-        super(NbConvertApp, self).initialize(argv)
+        super().initialize(argv)
         self.init_notebooks()
         self.init_writer()
         self.init_postprocessor()
@@ -337,7 +337,7 @@ class NbConvertApp(JupyterApp):
 
     def start(self):
         """Run start after initialization process has completed"""
-        super(NbConvertApp, self).start()
+        super().start()
         self.convert_notebooks()
 
     def init_single_notebook_resources(self, notebook_filename):

--- a/nbconvert/preprocessors/base.py
+++ b/nbconvert/preprocessors/base.py
@@ -38,7 +38,7 @@ class Preprocessor(NbConvertBase):
             Additional keyword arguments passed to parent
         """
         
-        super(Preprocessor, self).__init__(**kw)
+        super().__init__(**kw)
 
     def __call__(self, nb, resources):
         if self.enabled:

--- a/nbconvert/preprocessors/convertfigures.py
+++ b/nbconvert/preprocessors/convertfigures.py
@@ -22,7 +22,7 @@ class ConvertFiguresPreprocessor(Preprocessor):
         """
         Public constructor
         """
-        super(ConvertFiguresPreprocessor, self).__init__(**kw)
+        super().__init__(**kw)
 
 
     def convert_figure(self, data_format, data):

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -65,7 +65,7 @@ class CellExecutionError(ConversionException):
     failures gracefully.
     """
     def __init__(self, traceback):
-        super(CellExecutionError, self).__init__(traceback)
+        super().__init__(traceback)
         self.traceback = traceback
 
     def __str__(self):
@@ -432,7 +432,7 @@ class ExecutePreprocessor(Preprocessor):
 
         with self.setup_preprocessor(nb, resources, km=km):
             self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
-            nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
+            nb, resources = super().preprocess(nb, resources)
             info_msg = self._wait_for_reply(self.kc.kernel_info())
             nb.metadata['language_info'] = info_msg['content']['language_info']
             self.set_widgets_metadata()

--- a/nbconvert/preprocessors/highlightmagics.py
+++ b/nbconvert/preprocessors/highlightmagics.py
@@ -44,7 +44,7 @@ class HighlightMagicsPreprocessor(Preprocessor):
     def __init__(self, config=None, **kw):
         """Public constructor"""
 
-        super(HighlightMagicsPreprocessor, self).__init__(config=config, **kw)
+        super().__init__(config=config, **kw)
 
         # Update the default languages dict with the user configured ones
         self.default_languages.update(self.languages)

--- a/nbconvert/preprocessors/tests/fake_kernelmanager.py
+++ b/nbconvert/preprocessors/tests/fake_kernelmanager.py
@@ -11,18 +11,18 @@ class FakeCustomKernelManager(KernelManager):
     def __init__(self, *args, **kwargs):
         self.log.info('FakeCustomKernelManager initialized')
         self.expected_methods['__init__'] += 1
-        super(FakeCustomKernelManager, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def start_kernel(self, *args, **kwargs):
         self.log.info('FakeCustomKernelManager started a kernel')
         self.expected_methods['start_kernel'] += 1
-        return super(FakeCustomKernelManager, self).start_kernel(
+        return super().start_kernel(
             *args,
             **kwargs)
 
     def client(self, *args, **kwargs):
         self.log.info('FakeCustomKernelManager created a client')
         self.expected_methods['client'] += 1
-        return super(FakeCustomKernelManager, self).client(
+        return super().client(
             *args,
             **kwargs)

--- a/nbconvert/preprocessors/tests/test_clearmetadata.py
+++ b/nbconvert/preprocessors/tests/test_clearmetadata.py
@@ -13,7 +13,7 @@ class TestClearMetadata(PreprocessorTestsBase):
     """Contains test functions for clearmetadata.py"""
 
     def build_notebook(self):
-        notebook = super(TestClearMetadata, self).build_notebook()
+        notebook = super().build_notebook()
         # Add a test field to the first cell
         if 'metadata' not in notebook.cells[0]:
             notebook.cells[0].metadata = {}

--- a/nbconvert/preprocessors/tests/test_clearoutput.py
+++ b/nbconvert/preprocessors/tests/test_clearoutput.py
@@ -13,7 +13,7 @@ class TestClearOutput(PreprocessorTestsBase):
     """Contains test functions for clearoutput.py"""
 
     def build_notebook(self):
-        notebook = super(TestClearOutput, self).build_notebook()
+        notebook = super().build_notebook()
         # Add a test field to the first cell
         if 'metadata' not in notebook.cells[0]:
             notebook.cells[0].metadata = {}

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -502,7 +502,7 @@ while True: continue
 
         class WrappedPreProc(ExecutePreprocessor):
             def process_message(self, msg, cell, cell_index):
-                result = super(WrappedPreProc, self).process_message(msg, cell, cell_index)
+                result = super().process_message(msg, cell, cell_index)
                 if result:
                     outputs.append(result)
                 return result

--- a/nbconvert/preprocessors/tests/test_regexremove.py
+++ b/nbconvert/preprocessors/tests/test_regexremove.py
@@ -16,7 +16,7 @@ class TestRegexRemove(PreprocessorTestsBase):
     """Contains test functions for regexremove.py"""
 
     def build_notebook(self):
-        notebook = super(TestRegexRemove, self).build_notebook()
+        notebook = super().build_notebook()
         # Add a few empty cells
         notebook.cells.extend([
             nbformat.new_code_cell(''),

--- a/nbconvert/preprocessors/tests/test_tagremove.py
+++ b/nbconvert/preprocessors/tests/test_tagremove.py
@@ -19,7 +19,7 @@ class TestTagRemove(PreprocessorTestsBase):
         Build a notebook to have metadata tags for cells, output_areas, and
         individual outputs.
         """
-        notebook = super(TestTagRemove, self).build_notebook()
+        notebook = super().build_notebook()
         # Add a few empty cells
         notebook.cells[0].outputs.extend(
             [nbformat.new_output("display_data",

--- a/nbconvert/utils/base.py
+++ b/nbconvert/utils/base.py
@@ -26,4 +26,4 @@ class NbConvertBase(LoggingConfigurable):
     ).tag(config=True)
 
     def __init__(self, **kw):
-        super(NbConvertBase, self).__init__(**kw)
+        super().__init__(**kw)

--- a/nbconvert/utils/pandoc.py
+++ b/nbconvert/utils/pandoc.py
@@ -124,7 +124,7 @@ check_pandoc_version._cached = None
 class PandocMissing(ConversionException):
     """Exception raised when Pandoc is missing."""
     def __init__(self, *args, **kwargs):
-        super(PandocMissing, self).__init__( "Pandoc wasn't found.\n" +
+        super().__init__( "Pandoc wasn't found.\n" +
                                              "Please check that pandoc is installed:\n" +
                                              "http://pandoc.org/installing.html" )
 

--- a/nbconvert/utils/tests/test_pandoc.py
+++ b/nbconvert/utils/tests/test_pandoc.py
@@ -25,11 +25,11 @@ class TestPandoc(TestsBase):
     """Collection of Pandoc tests"""
 
     def __init__(self, *args, **kwargs):
-        super(TestPandoc, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.original_env = os.environ.copy()
 
     def setUp(self):
-        super(TestPandoc, self).setUp()
+        super().setUp()
         pandoc.check_pandoc_version._cached = None
 
     @onlyif_cmds_exist('pandoc')

--- a/nbconvert/writers/base.py
+++ b/nbconvert/writers/base.py
@@ -24,7 +24,7 @@ class WriterBase(NbConvertBase):
         """
         Constructor
         """
-        super(WriterBase, self).__init__(config=config, **kw)
+        super().__init__(config=config, **kw)
 
 
     def write(self, output, resources, **kw):

--- a/nbconvert/writers/files.py
+++ b/nbconvert/writers/files.py
@@ -41,7 +41,7 @@ class FilesWriter(WriterBase):
             ensure_dir_exists(new)
 
     def __init__(self, **kw):
-        super(FilesWriter, self).__init__(**kw)
+        super().__init__(**kw)
         self._build_directory_changed({'new': self.build_directory})
     
     def _makedir(self, path):


### PR DESCRIPTION
Are y'all in the market for Python 3 refactorings?

Here I did a perl pie conversion of all instances of `super(MyClass,
self).something` to `super().something`.