### PR TITLE
cElementTree no longer exists in Python 3.9

### DIFF
--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -19,8 +19,8 @@ except ImportError:
     from urllib2 import quote  # Py 2
 
 # defusedxml does safe(r) parsing of untrusted XML data
-from defusedxml import cElementTree as ElementTree
-from xml.etree.cElementTree import Element
+from defusedxml import ElementTree
+from xml.etree.ElementTree import Element
 
 from ipython_genutils import py3compat
 


### PR DESCRIPTION
cElementTree has been just backward compatible import for a long time so this change has no impact on performance.

Fixes: https://github.com/jupyter/nbconvert/issues/1221