### PR TITLE
Enable configuring JQuery and RequireJS in HTML exporter

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -36,6 +36,24 @@ class HTMLExporter(TemplateExporter):
     exclude_anchor_links = Bool(False,
         help="If anchor links should be included or not.").tag(config=True)
 
+    require_js_url = Unicode(
+        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js",
+        help="""
+        URL to load require.js from.
+
+        Defaults to loading from cdnjs.
+        """
+    ).tag(config=True)
+
+    jquery_url = Unicode(
+        "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js",
+        help="""
+        URL to load jQuery from.
+
+        Defaults to loading from cdnjs.
+        """
+    ).tag(config=True)
+
     @default('file_extension')
     def _file_extension_default(self):
         return '.html'
@@ -144,4 +162,6 @@ class HTMLExporter(TemplateExporter):
         resources['include_css'] = resources_include_css
         resources['include_js'] = resources_include_js
         resources['include_url'] = resources_include_url
+        resources['require_js_url'] = self.require_js_url
+        resources['jquery_url'] = self.jquery_url
         return resources

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -137,24 +137,6 @@ class SlidesExporter(HTMLExporter):
         """
     ).tag(config=True)
 
-    require_js_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js",
-        help="""
-        URL to load require.js from.
-
-        Defaults to loading from cdnjs.
-        """
-    ).tag(config=True)
-
-    jquery_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js",
-        help="""
-        URL to load jQuery from.
-
-        Defaults to loading from cdnjs.
-        """
-    ).tag(config=True)
-
     font_awesome_url = Unicode(
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css",
         help="""

--- a/share/jupyter/nbconvert/templates/classic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/index.html.j2
@@ -13,10 +13,10 @@
 
 {%- block html_head_js -%}
 {%- block html_head_js_jquery -%}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+<script src="{{ resources.jquery_url }}"></script>
 {%- endblock html_head_js_jquery -%}
 {%- block html_head_js_requirejs -%}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<script src="{{ resources.require_js_url }}"></script>
 {%- endblock html_head_js_requirejs -%}
 {%- endblock html_head_js -%}
 


### PR DESCRIPTION
Add --HTMLExporter.jquery_url and --HTMLExporter.require_js_url
to enable users to configure the URL to use for these required
dependencies. By default these will be pointing to the CDNJS
hosted by Cloudfare.

Note that these configuration options were already available in
the slide exporter, and based on inheritance, they were just
moved to the HTML exporter and are now available for both exporters.