### PR TITLE
Fix Markdown embedding of images

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -29,8 +29,8 @@ from nbconvert.filters.strings import add_anchor
 
 
 class MathBlockGrammar(mistune.BlockGrammar):
-    """This defines a single regex comprised of the different patterns that 
-    identify math content spanning multiple lines. These are used by the 
+    """This defines a single regex comprised of the different patterns that
+    identify math content spanning multiple lines. These are used by the
     MathBlockLexer.
     """
     multi_math_str = "|".join([r"^\$\$.*?\$\$",
@@ -40,10 +40,10 @@ class MathBlockGrammar(mistune.BlockGrammar):
 
 
 class MathBlockLexer(mistune.BlockLexer):
-    """ This acts as a pass-through to the MathInlineLexer. It is needed in 
-    order to avoid other block level rules splitting math sections apart. 
+    """ This acts as a pass-through to the MathInlineLexer. It is needed in
+    order to avoid other block level rules splitting math sections apart.
     """
-    
+
     default_rules = (['multiline_math']
                      + mistune.BlockLexer.default_rules)
 
@@ -61,7 +61,7 @@ class MathBlockLexer(mistune.BlockLexer):
 
 
 class MathInlineGrammar(mistune.InlineGrammar):
-    """This defines different ways of declaring math objects that should be 
+    """This defines different ways of declaring math objects that should be
     passed through to mathjax unaffected. These are used by the MathInlineLexer.
     """
     inline_math = re.compile(r"^\$(.+?)\$|^\\\\\((.+?)\\\\\)", re.DOTALL)
@@ -72,12 +72,12 @@ class MathInlineGrammar(mistune.InlineGrammar):
 
 
 class MathInlineLexer(mistune.InlineLexer):
-    """This interprets the content of LaTeX style math objects using the rules 
-    defined by the MathInlineGrammar. 
-    
-    In particular this grabs ``$$...$$``, ``\\[...\\]``, ``\\(...\\)``, ``$...$``, 
-    and ``\begin{foo}...\end{foo}`` styles for declaring mathematics. It strips 
-    delimiters from all these varieties, and extracts the type of environment 
+    r"""This interprets the content of LaTeX style math objects using the rules
+    defined by the MathInlineGrammar.
+
+    In particular this grabs ``$$...$$``, ``\\[...\\]``, ``\\(...\\)``, ``$...$``,
+    and ``\begin{foo}...\end{foo}`` styles for declaring mathematics. It strips
+    delimiters from all these varieties, and extracts the type of environment
     in the last case (``foo`` in this example).
     """
     default_rules = (['block_math', 'inline_math', 'latex_environment']
@@ -107,7 +107,7 @@ class MarkdownWithMath(mistune.Markdown):
             kwargs['block'] = MathBlockLexer
         super().__init__(renderer, **kwargs)
 
-    
+
     def output_multiline_math(self):
         return self.inline(self.token["text"])
 

--- a/share/jupyter/nbconvert/templates/base/display_priority.j2
+++ b/share/jupyter/nbconvert/templates/base/display_priority.j2
@@ -1,4 +1,4 @@
-{%- extends 'null.j2' -%}
+{%- extends 'base/null.j2' -%}
 
 {#display data priority#}
 

--- a/share/jupyter/nbconvert/templates/markdown/index.md.j2
+++ b/share/jupyter/nbconvert/templates/markdown/index.md.j2
@@ -38,15 +38,27 @@
 {% endblock stream %}
 
 {% block data_svg %}
+    {% if "filenames" in output.metadata %}
 ![svg]({{ output.metadata.filenames['image/svg+xml'] | path2url }})
+    {% else %}
+![svg](data:image/svg;base64,{{ output.data['image/svg+xml'] }})
+    {% endif %}
 {% endblock data_svg %}
 
 {% block data_png %}
+    {% if "filenames" in output.metadata %}
 ![png]({{ output.metadata.filenames['image/png'] | path2url }})
+    {% else %}
+![png](data:image/png;base64,{{ output.data['image/png'] }})
+    {% endif %}
 {% endblock data_png %}
 
 {% block data_jpg %}
+    {% if "filenames" in output.metadata %}
 ![jpeg]({{ output.metadata.filenames['image/jpeg'] | path2url }})
+    {% else %}
+![jpeg](data:image/jpeg;base64,{{ output.data['image/jpeg'] }})
+    {% endif %}
 {% endblock data_jpg %}
 
 {% block data_latex %}

--- a/share/jupyter/nbconvert/templates/markdown/index.md.j2
+++ b/share/jupyter/nbconvert/templates/markdown/index.md.j2
@@ -1,4 +1,4 @@
-{% extends 'display_priority.j2' %}
+{% extends 'base/display_priority.j2' %}
 
 
 {% block in_prompt %}


### PR DESCRIPTION
Hello, 

this fixes embedding of images that are displayed as base64-embedded and not path to files (e.g. this happens with `matplotlib` images). (Fix #1240)

It also fixes path of templates from which the markdown one inherits from.