### PR TITLE
Change of configuration of MathJax

### DIFF
--- a/share/jupyter/nbconvert/templates/base/mathjax.html.j2
+++ b/share/jupyter/nbconvert/templates/base/mathjax.html.j2
@@ -1,23 +1,42 @@
-{%- macro mathjax(url='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML') -%}
+
+{%- macro mathjax(url="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-MML-AM_CHTML-full,Safe") -%}
     <!-- Load mathjax -->
-    <script src="{{url}}"></script>
+    <script src="{{url}}"> </script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-        tex2jax: {
-            inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-            displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-            processEscapes: true,
-            processEnvironments: true
-        },
-        // Center justify equations in code and markdown cells. Elsewhere
-        // we use CSS to left justify single line equations in code cells.
-        displayAlign: 'center',
-        "HTML-CSS": {
-            styles: {'.MathJax_Display': {"margin": 0}},
-            linebreaks: { automatic: true }
+    init_mathjax = function() {
+        if (window.MathJax) {
+        // MathJax loaded
+            MathJax.Hub.Config({
+                TeX: {
+                    equationNumbers: {
+                    autoNumber: "AMS",
+                    useLabelIds: true
+                    }
+                },
+                tex2jax: {
+                    inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+                    displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+                    processEscapes: true,
+                    processEnvironments: true
+                },
+                displayAlign: 'center',
+                CommonHTML: {
+                    linebreaks: { 
+                    automatic: true 
+                    }
+                },
+                "HTML-CSS": {
+                    linebreaks: { 
+                    automatic: true 
+                    }
+                }
+            });
+        
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
         }
-    });
+    }
+    init_mathjax();
     </script>
     <!-- End of mathjax configuration -->
 {%- endmacro %}


### PR DESCRIPTION
This is a change to MahtJax 2.7.7 and by default, it will use the TeX fonts.

The original issue: https://github.com/jupyter/nbconvert/issues/1242.

Inspired by this [file](https://github.com/jupyter/nbviewer/blob/f69705373d1402afd924a77712e7c63659e2b57f/nbviewer/templates/notebook.html) used by `nbviewer`.

By the way, I don't know how to add a test to this specific script.