### PR TITLE
Support SQL syntax highlighting

### DIFF
--- a/nbconvert/preprocessors/highlightmagics.py
+++ b/nbconvert/preprocessors/highlightmagics.py
@@ -32,6 +32,7 @@ class HighlightMagicsPreprocessor(Preprocessor):
             '%%perl': 'perl',
             '%%ruby': 'ruby',
             '%%sh': 'sh',
+            '%%sql': 'sql',
     })
 
     # user defined language extensions


### PR DESCRIPTION
The SQL lexer is included with the standard Pygments install.  This change enables syntax highlighting when using sql magic such as https://github.com/catherinedevlin/ipython-sql.