### PR TITLE
Fix invalid HTML in lab template

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -24,7 +24,6 @@ a.anchor-link {
 
 {% endblock notebook_css %}
 
-
 {%- block body_header -%}
 {% if resources.theme == 'dark' %}
 <body class="jp-Notebook theme-dark">
@@ -32,3 +31,7 @@ a.anchor-link {
 <body class="jp-Notebook theme-light">
 {% endif %}
 {%- endblock body_header -%}
+
+{% block body_footer %}
+</body>
+{% endblock body_footer %}


### PR DESCRIPTION
The `body_footer` from the base template was closing other tags that are not in the lab template.