### PR TITLE
Rename ipywidgets block to jupyter widgets

### DIFF
--- a/docs/api_examples/template_path/project_templates/nbconvert/templates/classic_clone/index.html.j2
+++ b/docs/api_examples/template_path/project_templates/nbconvert/templates/classic_clone/index.html.j2
@@ -20,14 +20,14 @@
 {%- endblock html_head_js_requirejs -%}
 {%- endblock html_head_js -%}
 
-{% block ipywidgets %}
+{% block jupyter_widgets %}
 {%- if "widgets" in nb.metadata -%}
 <script>
 (function() {
   function addWidgetsRenderer() {
     var mimeElement = document.querySelector('script[type="application/vnd.jupyter.widget-view+json"]');
     var scriptElement = document.createElement('script');
-    var widgetRendererSrc = '{{ resources.ipywidgets_base_url }}@jupyter-widgets/html-manager@*/dist/embed-amd.js';
+    var widgetRendererSrc = '{{ resources.jupyter_widgets_base_url }}@jupyter-widgets/html-manager@*/dist/embed-amd.js';
     var widgetState;
 
     // Fallback for older version:
@@ -35,7 +35,7 @@
       widgetState = mimeElement && JSON.parse(mimeElement.innerHTML);
 
       if (widgetState && (widgetState.version_major < 2 || !widgetState.version_major)) {
-        widgetRendererSrc = '{{ resources.ipywidgets_base_url }}jupyter-js-widgets@*/dist/embed.js';
+        widgetRendererSrc = '{{ resources.jupyter_widgets_base_url }}jupyter-js-widgets@*/dist/embed.js';
       }
     } catch(e) {}
 
@@ -47,7 +47,7 @@
 }());
 </script>
 {%- endif -%}
-{% endblock ipywidgets %}
+{% endblock jupyter_widgets %}
 
 {% block extra_css %}
 {% endblock extra_css %}

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -255,8 +255,8 @@ class NbConvertApp(JupyterApp):
         if new:
             self.postprocessor_factory = import_item(new)
 
-    ipywidgets_base_url = Unicode("https://unpkg.com/",
-                                  help="URL base for ipywidgets package").tag(config=True)
+    jupyter_widgets_base_url = Unicode("https://unpkg.com/",
+                                       help="URL base for Jupyter widgets").tag(config=True)
 
 
     export_format = Unicode(
@@ -373,7 +373,7 @@ class NbConvertApp(JupyterApp):
 
         resources['output_files_dir'] = output_files_dir
 
-        resources['ipywidgets_base_url'] = self.ipywidgets_base_url
+        resources['jupyter_widgets_base_url'] = self.jupyter_widgets_base_url
 
         return resources
 

--- a/share/jupyter/nbconvert/templates/classic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/index.html.j2
@@ -20,14 +20,14 @@
 {%- endblock html_head_js_requirejs -%}
 {%- endblock html_head_js -%}
 
-{% block ipywidgets %}
+{% block jupyter_widgets %}
 {%- if "widgets" in nb.metadata -%}
 <script>
 (function() {
   function addWidgetsRenderer() {
     var mimeElement = document.querySelector('script[type="application/vnd.jupyter.widget-view+json"]');
     var scriptElement = document.createElement('script');
-    var widgetRendererSrc = '{{ resources.ipywidgets_base_url }}@jupyter-widgets/html-manager@*/dist/embed-amd.js';
+    var widgetRendererSrc = '{{ resources.jupyter_widgets_base_url }}@jupyter-widgets/html-manager@*/dist/embed-amd.js';
     var widgetState;
 
     // Fallback for older version:
@@ -35,7 +35,7 @@
       widgetState = mimeElement && JSON.parse(mimeElement.innerHTML);
 
       if (widgetState && (widgetState.version_major < 2 || !widgetState.version_major)) {
-        widgetRendererSrc = '{{ resources.ipywidgets_base_url }}jupyter-js-widgets@*/dist/embed.js';
+        widgetRendererSrc = '{{ resources.jupyter_widgets_base_url }}jupyter-js-widgets@*/dist/embed.js';
       }
     } catch(e) {}
 
@@ -47,7 +47,7 @@
 }());
 </script>
 {%- endif -%}
-{% endblock ipywidgets %}
+{% endblock jupyter_widgets %}
 
 {% block extra_css %}
 {% endblock extra_css %}


### PR DESCRIPTION
"ipywidgets" is python-specific. In the front-end, it is called jupyter widgets.