### PR TITLE
Use body data attribute from JupyterLab

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -26,9 +26,9 @@ a.anchor-link {
 
 {%- block body_header -%}
 {% if resources.theme == 'dark' %}
-<body class="jp-Notebook theme-dark">
+<body class="jp-Notebook" data-jp-theme-light="false" data-jp-theme-name="JupyterLab Dark">
 {% else %}
-<body class="jp-Notebook theme-light">
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
 {% endif %}
 {%- endblock body_header -%}
 


### PR DESCRIPTION
The `theme-dark` CSS class is not in the JupyterLab DOM and is not used anywhere.

This was an artifact of old Voilà code.