### PR TITLE
Make "lab" the default template for html export

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -60,7 +60,7 @@ class HTMLExporter(TemplateExporter):
 
     @default('template_name')
     def _template_name_default(self):
-        return 'classic'
+        return 'lab'
 
     @default('template_data_paths')
     def _template_data_paths_default(self):

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -398,7 +398,7 @@ class TestExporter(ExportersTestsBase):
         nb_no_output_prompt, resources_no_output_prompt = exporter_no_output_prompt.from_filename(self._get_notebook())
 
         assert not resources_no_output_prompt['global_content_filter']['include_output_prompt']
-        assert "Out[" not in nb_no_output_prompt
+        assert "Out[1]" not in nb_no_output_prompt
 
     def test_remove_elements_with_tags(self):
 

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -328,10 +328,8 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile('notebook_tags.html')
             with open("notebook_tags.html",'r') as f:
                 text = f.read()
-                assert 'code_cell rendered celltag_mycelltag celltag_mysecondcelltag">' in text
-                assert 'code_cell rendered">' in text    
-                assert 'text_cell rendered celltag_mymarkdowncelltag">' in text
-                assert 'text_cell rendered">' in text    
+                assert 'celltag_mycelltag celltag_mysecondcelltag' in text
+                assert 'celltag_mymarkdowncelltag' in text
             
                 
     def test_no_input(self):

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -311,13 +311,13 @@ class TestNbConvertApp(TestsBase):
             with open("notebook1.html",'r') as f:
                 text = f.read()
                 assert "In&nbsp;[" not in text
-                assert "Out[" not in text
+                assert "Out[6]" not in text
             self.nbconvert('notebook1.ipynb --log-level 0 --to html')
             assert os.path.isfile('notebook1.html')
             with open("notebook1.html",'r') as f:
                 text2 = f.read()
                 assert "In&nbsp;[" in text2
-                assert "Out[" in text2
+                assert "Out[6]" in text2
 
     def test_cell_tag_output(self):
         """
@@ -344,7 +344,7 @@ class TestNbConvertApp(TestsBase):
             with open("notebook1.html",'r') as f:
                 text = f.read()
                 assert "In&nbsp;[" not in text
-                assert "Out[" not in text
+                assert "Out[6]" not in text
                 assert ('<span class="n">x</span>'
                         '<span class="p">,</span>'
                         '<span class="n">y</span>'
@@ -360,7 +360,7 @@ class TestNbConvertApp(TestsBase):
             with open("notebook1.html",'r') as f:
                 text2 = f.read()
                 assert "In&nbsp;[" in text2
-                assert "Out[" in text2
+                assert "Out[6]" in text2
                 assert ('<span class="n">x</span>'
                         '<span class="p">,</span>'
                         '<span class="n">y</span>'

--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -8,7 +8,8 @@
 {%- if not resources.global_content_filter.include_input -%}
 {%- set no_input_class="jp-mod-noInput" -%}
 {%- endif -%}
-<div class="jp-Cell jp-CodeCell jp-Notebook-cell {{ no_output_class }} {{ no_input_class }}">
+<div class="jp-Cell jp-CodeCell jp-Notebook-cell {{ no_output_class }} {{ no_input_class }} {{ celltags(cell) }}">
+">
 {{ super() }}
 </div>
 {%- endblock codecell %}
@@ -89,7 +90,7 @@
 {%- if resources.global_content_filter.include_input_prompt-%}
     {{ self.empty_in_prompt() }}
 {%- endif -%}
-<div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput{{ celltags(cell) }}" data-mime-type="text/markdown">
+<div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput {{ celltags(cell) }}" data-mime-type="text/markdown">
 {{ cell.source  | markdown2html | strip_files_prefix }}
 </div>
 </div>


### PR DESCRIPTION
This 7 characters' change makes the "lab" template the default for exporting to html.

The reason is that:

 - Nbconvert 6.0 is a major release and good time to make that change.
 - The classic notebook has been in maintainance mode for a while and JupyterLab has reached 2.0. Even though there are many people using the classic notebook, the front-end that we are now pushing is JupyterLab.
 -  The lab template enables the use of JupyterLab CSS themes. It is also the default basebase template for Voilà.

- [x] @SylvainCorlay 
- [x] @MSeal
- [x] @blink1073 
- [ ] @mpacer 
- [X] @maartenbreddels
- [ ] @minrk
- [x] @Carreau 