### PR TITLE
Fix example widget notebook

### DIFF
--- a/nbconvert/tests/files/Widget_List.ipynb
+++ b/nbconvert/tests/files/Widget_List.ipynb
@@ -2,95 +2,18 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "source": [
-    "[Index](Index.ipynb) - [Back](Widget Basics.ipynb) - [Next](Widget Events.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Widget List"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Complete list"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "For a complete list of the GUI widgets available to you, you can list the registered widget types.  `Widget` and `DOMWidget`, not listed below, are base classes."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'Jupyter.Accordion': ipywidgets.widgets.widget_selectioncontainer.Accordion,\n",
-       " 'Jupyter.BoundedFloatText': ipywidgets.widgets.widget_float.BoundedFloatText,\n",
-       " 'Jupyter.BoundedIntText': ipywidgets.widgets.widget_int.BoundedIntText,\n",
-       " 'Jupyter.Box': ipywidgets.widgets.widget_box.Box,\n",
-       " 'Jupyter.Button': ipywidgets.widgets.widget_button.Button,\n",
-       " 'Jupyter.Checkbox': ipywidgets.widgets.widget_bool.Checkbox,\n",
-       " 'Jupyter.ColorPicker': ipywidgets.widgets.widget_color.ColorPicker,\n",
-       " 'Jupyter.Controller': ipywidgets.widgets.widget_controller.Controller,\n",
-       " 'Jupyter.ControllerAxis': ipywidgets.widgets.widget_controller.Axis,\n",
-       " 'Jupyter.ControllerButton': ipywidgets.widgets.widget_controller.Button,\n",
-       " 'Jupyter.Dropdown': ipywidgets.widgets.widget_selection.Dropdown,\n",
-       " 'Jupyter.FloatProgress': ipywidgets.widgets.widget_float.FloatProgress,\n",
-       " 'Jupyter.FloatRangeSlider': ipywidgets.widgets.widget_float.FloatRangeSlider,\n",
-       " 'Jupyter.FloatSlider': ipywidgets.widgets.widget_float.FloatSlider,\n",
-       " 'Jupyter.FloatText': ipywidgets.widgets.widget_float.FloatText,\n",
-       " 'Jupyter.HBox': ipywidgets.widgets.widget_box.HBox,\n",
-       " 'Jupyter.HTML': ipywidgets.widgets.widget_string.HTML,\n",
-       " 'Jupyter.Image': ipywidgets.widgets.widget_image.Image,\n",
-       " 'Jupyter.IntProgress': ipywidgets.widgets.widget_int.IntProgress,\n",
-       " 'Jupyter.IntRangeSlider': ipywidgets.widgets.widget_int.IntRangeSlider,\n",
-       " 'Jupyter.IntSlider': ipywidgets.widgets.widget_int.IntSlider,\n",
-       " 'Jupyter.IntText': ipywidgets.widgets.widget_int.IntText,\n",
-       " 'Jupyter.Label': ipywidgets.widgets.widget_string.Label,\n",
-       " 'Jupyter.PlaceProxy': ipywidgets.widgets.widget_box.PlaceProxy,\n",
-       " 'Jupyter.Play': ipywidgets.widgets.widget_int.Play,\n",
-       " 'Jupyter.Proxy': ipywidgets.widgets.widget_box.Proxy,\n",
-       " 'Jupyter.RadioButtons': ipywidgets.widgets.widget_selection.RadioButtons,\n",
-       " 'Jupyter.Select': ipywidgets.widgets.widget_selection.Select,\n",
-       " 'Jupyter.SelectMultiple': ipywidgets.widgets.widget_selection.SelectMultiple,\n",
-       " 'Jupyter.SelectionSlider': ipywidgets.widgets.widget_selection.SelectionSlider,\n",
-       " 'Jupyter.Tab': ipywidgets.widgets.widget_selectioncontainer.Tab,\n",
-       " 'Jupyter.Text': ipywidgets.widgets.widget_string.Text,\n",
-       " 'Jupyter.Textarea': ipywidgets.widgets.widget_string.Textarea,\n",
-       " 'Jupyter.ToggleButton': ipywidgets.widgets.widget_bool.ToggleButton,\n",
-       " 'Jupyter.ToggleButtons': ipywidgets.widgets.widget_selection.ToggleButtons,\n",
-       " 'Jupyter.VBox': ipywidgets.widgets.widget_box.VBox,\n",
-       " 'Jupyter.Valid': ipywidgets.widgets.widget_bool.Valid,\n",
-       " 'jupyter.DirectionalLink': ipywidgets.widgets.widget_link.DirectionalLink,\n",
-       " 'jupyter.Link': ipywidgets.widgets.widget_link.Link}"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import ipywidgets as widgets\n",
-    "widgets.Widget.widget_types"
+    "import ipywidgets as widgets"
    ]
   },
   {
@@ -108,7 +31,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 8 widgets distributed with IPython that are designed to display numeric values.  Widgets exist for displaying integers and floats, both bounded and unbounded.  The integer widgets share a similar naming scheme to their floating point counterparts.  By replacing `Float` with `Int` in the widget name, you can find the Integer equivalent."
+    "There are many widgets distributed with ipywidgets that are designed to display numeric values.  Widgets exist for displaying integers and floats, both bounded and unbounded.  The integer widgets share a similar naming scheme to their floating point counterparts.  By replacing `Float` with `Int` in the widget name, you can find the Integer equivalent."
    ]
   },
   {
@@ -126,8 +49,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b59af7d27c594924957e1aa26257751f"
-      }
+       "model_id": "900a279374724477aa598b64f8b23103",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntSlider(value=7, continuous_update=False, description='Test:', max=10)"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -144,8 +72,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
-    "    slider_color='white'\n",
+    "    readout_format='d'\n",
     ")"
    ]
   },
@@ -168,8 +95,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a7e2b9cc83b647cea830e0bf9c99a446"
-      }
+       "model_id": "41aa649b6f92435789ad05d6694d3979",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=7.5, continuous_update=False, description='Test:', max=10.0, readout_format='.1f')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -187,7 +119,6 @@
     "    orientation='horizontal',\n",
     "    readout=True,\n",
     "    readout_format='.1f',\n",
-    "    slider_color='white'\n",
     ")"
    ]
   },
@@ -206,8 +137,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5e54ffd534404973b0f98d8573716a3d"
-      }
+       "model_id": "8090e9058047406c9192f1f87605f75e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=7.5, continuous_update=False, description='Test:', max=10.0, orientation='vertical', readout…"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -225,7 +161,51 @@
     "    orientation='vertical',\n",
     "    readout=True,\n",
     "    readout_format='.1f',\n",
-    "    slider_color='white'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### FloatLogSlider"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `FloatLogSlider` has a log scale, which makes it easy to have a slider that covers a wide range of positive magnitudes. The `min` and `max` refer to the minimum and maximum exponents of the `base`, and the `value` refers to the actual value of the slider."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e7307a79e0b940fe93b22363a7acbae1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatLogSlider(value=10.0, description='Log Slider', max=10.0, min=-10.0, step=0.2)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "widgets.FloatLogSlider(\n",
+    "    value=10,\n",
+    "    base=10,\n",
+    "    min=-10, # max exponent of base\n",
+    "    max=10, # min exponent of base\n",
+    "    step=0.2, # exponent step\n",
+    "    description='Log Slider'\n",
     ")"
    ]
   },
@@ -238,14 +218,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "887e65a5714e483798a9b84f0d936a52"
-      }
+       "model_id": "c6fd73ecfd494cffb6e40003dbbaa2c2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntRangeSlider(value=(5, 7), continuous_update=False, description='Test:', max=10)"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -262,9 +247,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
-    "    slider_color='white',\n",
-    "    color='black'\n",
+    "    readout_format='d',\n",
     ")"
    ]
   },
@@ -277,14 +260,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d332c8df94ee42afb4d079dce40785f3"
-      }
+       "model_id": "96217540c98840768a45b109f8909b27",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatRangeSlider(value=(5.0, 7.5), continuous_update=False, description='Test:', max=10.0, readout_format='.1f…"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -301,9 +289,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
-    "    slider_color='white',\n",
-    "    color='black'\n",
+    "    readout_format='.1f',\n",
     ")"
    ]
   },
@@ -316,14 +302,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6716ba9736a74e4a957e91902a418922"
-      }
+       "model_id": "847242b521014f4898f9037b01b78b98",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntProgress(value=7, description='Loading:', max=10)"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -354,14 +345,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4a8d047af2e645beb6a06f3d3a87f415"
-      }
+       "model_id": "03dd979c243747bda108752309931db9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=7.5, bar_style='info', description='Loading:', max=10.0)"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -383,19 +379,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The numerical text boxes that impose some limit on the data (range, integer-only) impose that restriction when the user presses enter.\n",
+    "\n",
     "### BoundedIntText"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "78808aec127a42a68cc8578100bdd20a"
-      }
+       "model_id": "c692115e21264cbea36e9a71738dfead",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "BoundedIntText(value=7, description='Text:', max=10)"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -425,14 +428,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6e06309ba65e41e4ab9a287ec3036d9c"
-      }
+       "model_id": "dcf141916aef43c09cc1178957387339",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "BoundedFloatText(value=7.5, description='Text:', max=10.0, step=0.1)"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -445,8 +453,7 @@
     "    max=10.0,\n",
     "    step=0.1,\n",
     "    description='Text:',\n",
-    "    disabled=False,\n",
-    "    color='black'\n",
+    "    disabled=False\n",
     ")"
    ]
   },
@@ -459,14 +466,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e47d8b43215e48d9bb8c532860d80216"
-      }
+       "model_id": "609fc788fb2041ddbdbea60833f7badc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntText(value=7, description='Any:')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -493,14 +505,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "21b9cd5e4f0d43dab1dd0a3ccc8034d7"
-      }
+       "model_id": "a5669796f20942638b17f63d89f5a666",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatText(value=7.5, description='Any:')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -510,8 +527,7 @@
     "widgets.FloatText(\n",
     "    value=7.5,\n",
     "    description='Any:',\n",
-    "    disabled=False,\n",
-    "    color='black'\n",
+    "    disabled=False\n",
     ")"
    ]
   },
@@ -542,14 +558,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8acf995f75ad4ddc86fa68ca00fd92c8"
-      }
+       "model_id": "98768dcd13004995a26343792098f450",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ToggleButton(value=False, description='Click me', icon='check', tooltip='Description')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -579,14 +600,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e3d375dec35c455d8029d9328d1a55a0"
-      }
+       "model_id": "035fe1c814fd4531acdced08bd020b9d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Checkbox(value=False, description='Check me')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -611,14 +637,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f91ffb7111314c72b41ea6dfc617e374"
-      }
+       "model_id": "231497b8422a46a6953ec8d68367c3df",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Valid(value=False, description='Valid!')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -628,7 +659,6 @@
     "widgets.Valid(\n",
     "    value=False,\n",
     "    description='Valid!',\n",
-    "    disabled=False\n",
     ")"
    ]
   },
@@ -647,7 +677,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are four widgets that can be used to display single selection lists, and one that can be used to display multiple selection lists.  All inherit from the same base class.  You can specify the **enumeration of selectable options by passing a list**.  You can **also specify the enumeration as a dictionary**, in which case the **keys will be used as the item displayed** in the list and the corresponding **value will be returned** when an item is selected."
+    "There are several widgets that can be used to display single selection lists, and two that can be used to select multiple values.  All inherit from the same base class.  You can specify the **enumeration of selectable options by passing a list** (options are either (label, value) pairs, or simply values for which the labels are derived by calling `str`)."
    ]
   },
   {
@@ -663,14 +693,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6e182a69a1cd4a4194639cee8d84099a"
-      }
+       "model_id": "5930139c8f4b45ad812a21f336a511ae",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Dropdown(description='Number:', index=1, options=('1', '2', '3'), value='2')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -682,7 +717,6 @@
     "    value='2',\n",
     "    description='Number:',\n",
     "    disabled=False,\n",
-    "    button_style='' # 'success', 'info', 'warning', 'danger' or ''\n",
     ")"
    ]
   },
@@ -690,19 +724,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following is also valid:"
+    "The following is also valid, displaying the words `'One', 'Two', 'Three'` as the dropdown choices but returning the values `1, 2, 3`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "35544158b22549a4a6f904b33213252d"
-      }
+       "model_id": "9f8ad824c2a34110a10af40c8e08daf9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Dropdown(description='Number:', index=1, options=(('One', 1), ('Two', 2), ('Three', 3)), value=2)"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -710,7 +749,7 @@
    ],
    "source": [
     "widgets.Dropdown(\n",
-    "    options={'One': 1, 'Two': 2, 'Three': 3},\n",
+    "    options=[('One', 1), ('Two', 2), ('Three', 3)],\n",
     "    value=2,\n",
     "    description='Number:',\n",
     ")"
@@ -729,14 +768,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6fe505cb796242c9af5949d296e7d047"
-      }
+       "model_id": "823c6dd9efad4992aeb019b94f63d15b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "RadioButtons(description='Pizza topping:', options=('pepperoni', 'pineapple', 'anchovies'), value='pepperoni')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -764,14 +808,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d669c4295cbf4833b0c096e39129b22c"
-      }
+       "model_id": "6df3a3fe02bb4149a2bec37be4a3666e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Select(description='OS:', index=2, options=('Linux', 'Windows', 'OSX'), value='OSX')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -780,7 +829,8 @@
    "source": [
     "widgets.Select(\n",
     "    options=['Linux', 'Windows', 'OSX'],\n",
-    "#     value='OSX',\n",
+    "    value='OSX',\n",
+    "    # rows=10,\n",
     "    description='OS:',\n",
     "    disabled=False\n",
     ")"
@@ -795,14 +845,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7d73679710a4455c9c7609beac8da45f"
-      }
+       "model_id": "acff2c29635946478ac8cee9d4d4ecf3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SelectionSlider(continuous_update=False, description='I like my eggs ...', index=1, options=('scrambled', 'sun…"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -816,9 +871,48 @@
     "    disabled=False,\n",
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
-    "    readout=True,\n",
-    "#     readout_format='i',\n",
-    "#     slider_color='black'\n",
+    "    readout=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SelectionRangeSlider\n",
+    "\n",
+    "The value, index, and label keys are 2-tuples of the min and max values selected. The options must be nonempty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "71842466a7c3448881c37c5f88460b15",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SelectionRangeSlider(description='Months (2015)', index=(0, 11), options=(('Jan', datetime.date(2015, 1, 1)), …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import datetime\n",
+    "dates = [datetime.date(2015,i,1) for i in range(1,13)]\n",
+    "options = [(i.strftime('%b'), i) for i in dates]\n",
+    "widgets.SelectionRangeSlider(\n",
+    "    options=options,\n",
+    "    index=(0,11),\n",
+    "    description='Months (2015)',\n",
+    "    disabled=False\n",
     ")"
    ]
   },
@@ -835,14 +929,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa12c076ae4b4ba68aa0dbaf1f6e9c80"
-      }
+       "model_id": "bcfce0d42db14c708259607736602179",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ToggleButtons(description='Speed:', options=('Slow', 'Regular', 'Fast'), tooltips=('Description of slow', 'Des…"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -854,8 +953,8 @@
     "    description='Speed:',\n",
     "    disabled=False,\n",
     "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
-    "    tooltip='Description',\n",
-    "#     icon='check' \n",
+    "    tooltips=['Description of slow', 'Description of regular', 'Description of fast'],\n",
+    "#     icons=['check'] * 3\n",
     ")"
    ]
   },
@@ -869,14 +968,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c063c53a85a442f78ef47c9f62a83b8d"
-      }
+       "model_id": "a8661e762bf14bf3a28d9a5255337543",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SelectMultiple(description='Fruits', index=(1,), options=('Apples', 'Oranges', 'Pears'), value=('Oranges',))"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -886,6 +990,7 @@
     "widgets.SelectMultiple(\n",
     "    options=['Apples', 'Oranges', 'Pears'],\n",
     "    value=['Oranges'],\n",
+    "    #rows=10,\n",
     "    description='Fruits',\n",
     "    disabled=False\n",
     ")"
@@ -906,7 +1011,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 4 widgets that can be used to display a string value.  Of those, the `Text` and `Textarea` widgets accept input.  The `Label` and `HTML` widgets display the string as either Label or HTML respectively, but do not accept input."
+    "There are several widgets that can be used to display a string value.  The `Text` and `Textarea` widgets accept input.  The `HTML` and `HTMLMath` widgets display a string as HTML (`HTMLMath` also renders math). The `Label` widget can be used to construct a custom control label."
    ]
   },
   {
@@ -922,14 +1027,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "786e43e0ce2c44b99d13cbaf5569f637"
-      }
+       "model_id": "ebd0457751e441e4a18c0b19c5b3ae44",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Text(value='Hello World', description='String:', placeholder='Type something')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -953,14 +1063,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "15ece8b84daa470f8938a138c2433389"
-      }
+       "model_id": "7193b362ed0f4200a01d8c71095fe25d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Textarea(value='Hello World', description='String:', placeholder='Type something')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -983,50 +1098,57 @@
     }
    },
    "source": [
-    "### Label"
+    "### Label\n",
+    "\n",
+    "The `Label` widget is useful if you need to build a custom description next to a control using similar styling to the built-in control descriptions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c96f1b7c2637417285865c724b2364ca"
-      }
+       "model_id": "4fd3732a16a144caa2b18720ef1f08d9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='The $m$ in $E=mc^2$:'), FloatSlider(value=0.0)))"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
     }
    ],
    "source": [
-    "widgets.Label(\n",
-    "    value=\"$$\\\\frac{n!}{k!(n-k)!} = \\\\binom{n}{k}$$\",\n",
-    "    placeholder='Some LaTeX',\n",
-    "    description='Some LaTeX',\n",
-    "    disabled=False\n",
-    ")"
+    "widgets.HBox([widgets.Label(value=\"The $m$ in $E=mc^2$:\"), widgets.FloatSlider()])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## HTML"
+    "### HTML"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ba868fda4d02439a8deb8b680ce80cb9"
-      }
+       "model_id": "8717ac2d097441e9bd4978443f6da52f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HTML(value='Hello <b>World</b>', description='Some HTML', placeholder='Some HTML')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1037,7 +1159,41 @@
     "    value=\"Hello <b>World</b>\",\n",
     "    placeholder='Some HTML',\n",
     "    description='Some HTML',\n",
-    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### HTML Math"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "52a07264d52e4b0fa37bc6b341555e12",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HTMLMath(value='Some math and <i>HTML</i>: \\\\(x^2\\\\) and $$\\\\frac{x+1}{x-1}$$', description='Some HTML', place…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "widgets.HTMLMath(\n",
+    "    value=r\"Some math and <i>HTML</i>: \\(x^2\\) and $$\\frac{x+1}{x-1}$$\",\n",
+    "    placeholder='Some HTML',\n",
+    "    description='Some HTML',\n",
     ")"
    ]
   },
@@ -1050,27 +1206,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5faca03ffc1447d0bff708566d2c068e"
-      }
+       "model_id": "cade29a9b6f34fadbf36883d78ade0cb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Image(value=b'\\x89PNG\\r\\n\\x1a\\n\\x00\\x00\\x00\\rIHDR\\x00\\x00\\x00d\\x00\\x00\\x00G\\x08\\x02\\x00\\x00\\x00~\\xb8u\\x9b\\x00\\…"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
     }
    ],
    "source": [
-    "file = open(\"images/WidgetArch.png\", \"rb\")\n",
+    "file = open(\"testimage.png\", \"rb\")\n",
     "image = file.read()\n",
     "widgets.Image(\n",
     "    value=image,\n",
     "    format='png',\n",
     "    width=300,\n",
-    "    height=400\n",
+    "    height=400,\n",
     ")"
    ]
   },
@@ -1087,14 +1248,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "12a9cb1f7c6f429887047437349a1efd"
-      }
+       "model_id": "929f2abd63624e94ac29a8a7820ec245",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='Click me', icon='check', style=ButtonStyle(), tooltip='Click me')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1114,6 +1280,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Output\n",
+    "\n",
+    "The `Output` widget can capture and display stdout, stderr and [rich output generated by IPython](http://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#module-IPython.display). For detailed documentation, see the [output widget examples](https://ipywidgets.readthedocs.io/en/latest/examples/Output Widget.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Play (Animation) widget"
    ]
   },
@@ -1121,19 +1296,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Play` widget is useful to perform animations by iterating on a sequence of integers with a certain speed."
+    "The `Play` widget is useful to perform animations by iterating on a sequence of integers with a certain speed. The value of the slider below is linked to the player."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a388a02e48954671b68dc718f299bc2f"
-      }
+       "model_id": "3f71a71a7af341a2a69f423d4cbfa008",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Play(value=50, description='Press play'), IntSlider(value=0)))"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1158,19 +1338,60 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Color picker"
+    "## Date picker\n",
+    "\n",
+    "The date picker widget works in Chrome, Firefox and IE Edge, but does not currently work in Safari because it does not support the HTML date input field."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c056cc916b2e446dbb1692ee68810233"
-      }
+       "model_id": "ce0d60101a5a4762ac52b60159817270",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "DatePicker(value=None, description='Pick a Date')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "widgets.DatePicker(\n",
+    "    description='Pick a Date',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Color picker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7cfdb695c61941959b405c0bd1dd0e28",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ColorPicker(value='blue', description='Pick a color')"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1180,7 +1401,8 @@
     "widgets.ColorPicker(\n",
     "    concise=False,\n",
     "    description='Pick a color',\n",
-    "    value='blue'\n",
+    "    value='blue',\n",
+    "    disabled=False\n",
     ")"
    ]
   },
@@ -1188,19 +1410,62 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Controller"
+    "## File Upload\n",
+    "\n",
+    "The `FileUpload` allows to upload any type of file(s) as bytes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e9b8104b92fd41b398562e22edffdb81"
-      }
+       "model_id": "390a8d90df58477facd911357ef828fa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FileUpload(value={}, description='Upload')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "widgets.FileUpload(\n",
+    "    accept='',  # Accepted file extension e.g. '.txt', '.pdf', 'image/*', 'image/*,.pdf'\n",
+    "    multiple=False  # True to accept multiple files upload else False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controller\n",
+    "\n",
+    "The `Controller` allows a game controller to be used as an input device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd431edda13e42b384c3fdf0da876c8e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Controller()"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1216,7 +1481,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Layout widgets"
+    "## Container/Layout widgets\n",
+    "\n",
+    "These widgets are used to hold other widgets, called children. Each has a `children` property that may be set either when the widget is created or later."
    ]
   },
   {
@@ -1224,6 +1491,31 @@
    "metadata": {},
    "source": [
     "### Box"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e6414e51a6b84b77bbca07174042f407",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Box(children=(Label(value='0'), Label(value='1'), Label(value='2'), Label(value='3')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "items = [widgets.Label(str(i)) for i in range(4)]\n",
+    "widgets.Box(items)"
    ]
   },
   {
@@ -1235,14 +1527,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "261e5c581b0447169eb939ec57ae2004"
-      }
+       "model_id": "cc87bd8da3484961bb490f6dd9a916f4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='0'), Label(value='1'), Label(value='2'), Label(value='3')))"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1262,14 +1559,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "53da5ce19e2440eeb48d9894da634e98"
-      }
+       "model_id": "03bb2698030e48c590b7917360bb3725",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(VBox(children=(Label(value='0'), Label(value='1'))), VBox(children=(Label(value='2'), Label(val…"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1277,7 +1579,9 @@
    ],
    "source": [
     "items = [widgets.Label(str(i)) for i in range(4)]\n",
-    "widgets.HBox([widgets.VBox([items[0], items[1]]), widgets.VBox([items[2], items[3]])])"
+    "left_box = widgets.VBox([items[0], items[1]])\n",
+    "right_box = widgets.VBox([items[2], items[3]])\n",
+    "widgets.HBox([left_box, right_box])"
    ]
   },
   {
@@ -1289,14 +1593,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "453127d40389487cb3e36e95d8b59d60"
-      }
+       "model_id": "ff697b7cefa34a4bba21a8021995bae2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Accordion(children=(IntSlider(value=0), Text(value='')), _titles={'0': 'Slider', '1': 'Text'})"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1313,38 +1622,114 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Tabs"
+    "### Tabs\n",
+    "\n",
+    "In this example the children are set after the tab is created. Titles for the tabs are set in the same way they are for `Accordion`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3a305f92e48542b59098381a161fde9a"
-      }
+       "model_id": "592cd261e1e14f70b59e056dda9f9f20",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Tab(children=(Text(value='', description='P0'), Text(value='', description='P1'), Text(value='', description='…"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
     }
    ],
    "source": [
-    "list = ['P0', 'P1', 'P2', 'P3', 'P4']\n",
-    "children = [widgets.Text(description=name) for name in list]\n",
-    "tab = widgets.Tab(children=children)\n",
+    "tab_contents = ['P0', 'P1', 'P2', 'P3', 'P4']\n",
+    "children = [widgets.Text(description=name) for name in tab_contents]\n",
+    "tab = widgets.Tab()\n",
+    "tab.children = children\n",
+    "for i in range(len(children)):\n",
+    "    tab.set_title(i, str(i))\n",
     "tab"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
+   "metadata": {},
    "source": [
-    "[Index](Index.ipynb) - [Back](Widget Basics.ipynb) - [Next](Widget Events.ipynb)"
+    "### Accordion and Tab use `selected_index`, not value\n",
+    "\n",
+    "Unlike the rest of the widgets discussed earlier, the container widgets `Accordion` and `Tab` update their `selected_index` attribute when the user changes which accordion or tab is selected. That means that you can both see what the user is doing *and* programmatically set what the user sees by setting the value of `selected_index`.\n",
+    "\n",
+    "Setting `selected_index = None` closes all of the accordions or deselects all tabs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the cells below try displaying or setting the `selected_index` of the `tab` and/or `accordion`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tab.selected_index = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accordion.selected_index = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Nesting tabs and accordions\n",
+    "\n",
+    "Tabs and accordions can be nested as deeply as you want. If you have a few minutes, try nesting a few accordions or putting an accordion inside a tab or a tab inside an accordion. \n",
+    "\n",
+    "The example below makes a couple of tabs with an accordion children in one of them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "20fa8782d12a4ff6b6a0e2475be79593",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Tab(children=(Accordion(children=(IntSlider(value=0), Text(value='')), selected_index=None, _titles={'0': 'Sli…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "tab_nest = widgets.Tab()\n",
+    "tab_nest.children = [accordion, accordion]\n",
+    "tab_nest.set_title(0, 'An accordion')\n",
+    "tab_nest.set_title(1, 'Copy of the accordion')\n",
+    "tab_nest"
    ]
   }
  ],
@@ -1364,3374 +1749,1707 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.7.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "016ea837a5d242c3840091b092e51f2d": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "00e918754ce3473987c4ac8b68d2aa64": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "035fe1c814fd4531acdced08bd020b9d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "CheckboxModel",
+      "state": {
+       "description": "Check me",
+       "disabled": false,
+       "layout": "IPY_MODEL_f1d4f927cfe04ac5b8784495a911569a",
+       "style": "IPY_MODEL_68cade49753a451ebff709ea1bce25b2",
+       "value": false
+      }
+     },
+     "038eb3f451d74fa485a78b19d7ff6c98": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "03bb2698030e48c590b7917360bb3725": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_19136da8d2ff44f4952e094ee80b2b7a",
+        "IPY_MODEL_a326834ae4984777bd48e84b0783e086"
+       ],
+       "layout": "IPY_MODEL_586c578b082049069483c78be61401b8"
+      }
+     },
+     "03dd979c243747bda108752309931db9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "info",
+       "description": "Loading:",
+       "layout": "IPY_MODEL_d74712fbafbb462aacfa22022d962aaa",
+       "max": 10,
+       "style": "IPY_MODEL_e85adb3440784b0fa3fb45747a792635",
+       "value": 7.5
+      }
+     },
+     "04a6c32fdfaf4e5186b95d48d912409b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "04dcbf013c294e69a7f6f09eb643caa4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0863b101fbd741d1a487843907da3b70": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "09bb3f943ad441a4b775f30e64098d16": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0bd3f78432cd4db9acab71fe81d79918": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0c19bce9461b4019a752a077a071d693": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "10ca989ef6eb4c459266c44999d0066b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "134a3c21e8084b3b8fdce65629d4fcfc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "154a6e22eb05444ab5cc3664454cd7ca": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "19136da8d2ff44f4952e094ee80b2b7a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_dfb871f032ce46398953670eede31aa8",
+        "IPY_MODEL_795e4e83becb46cb9e2ce6568b3e52ab"
+       ],
+       "layout": "IPY_MODEL_ef64bc2bcae54900a7b6c58618dfd4ae"
+      }
+     },
+     "1d08477048c641978807b98886b5b7fe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1dcd36317f414f6d979a0a80c0658a20": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "P4",
+       "layout": "IPY_MODEL_d23acd51730f4c51b71f610e7958e7a8",
+       "style": "IPY_MODEL_0863b101fbd741d1a487843907da3b70"
+      }
+     },
+     "1e325582b42744cea09cbef4861791d1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "20fa8782d12a4ff6b6a0e2475be79593": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TabModel",
+      "state": {
+       "_titles": {
+        "0": "An accordion",
+        "1": "Copy of the accordion"
+       },
+       "children": [
+        "IPY_MODEL_ff697b7cefa34a4bba21a8021995bae2",
+        "IPY_MODEL_ff697b7cefa34a4bba21a8021995bae2"
+       ],
+       "layout": "IPY_MODEL_d6afc68827cc4354bbff5a857e754f5c"
+      }
+     },
+     "231497b8422a46a6953ec8d68367c3df": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ValidModel",
+      "state": {
+       "description": "Valid!",
+       "layout": "IPY_MODEL_b018e1cfbaaf4feda8e277c5b27cc4ad",
+       "style": "IPY_MODEL_350651b22bda442e89b2c31c0d1af181"
+      }
+     },
+     "23e838c1a76d4f0aad12bdf2b8225a12": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "260c10d89a5943988afeefed0bbfa0df": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2a0afd8e637c4f809c1da6e1449f56bf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2eb456965b8e44399ea612590a08e244": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2f06cb6df4ef433eb0da36bc7f592af5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "LabelModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LabelModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LabelView",
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_d3a80abfb5a645558f4dfbd94304ffae",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": "0"
-      }
-     },
-     "067da89376f04e298a72261d10c7650a": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "07e24822058240ba862e20fa6cf02a27": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "08cfa62812e245ec838c5c971696818f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LabelModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LabelModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LabelView",
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_3832d950aa9e490cb1c6855448b0992f",
-       "msg_throttle": 1,
-       "placeholder": "​",
+       "layout": "IPY_MODEL_eca4345e6d0d4a1abcafacce461803d7",
+       "style": "IPY_MODEL_cb7bcde2dd664b21b3e5af5b1c27056e",
        "value": "2"
       }
      },
-     "0b2631a5ca9f45e59278df4f59394281": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "323e892406cd4c428e9e0d3a50e934bc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "350651b22bda442e89b2c31c0d1af181": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3588b17584d44b6f8bc0c2f6bb4d1995": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "38dedb3a22f7455dbc369f897ffd9c11": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "LabelModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LabelModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LabelView",
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_2a42b49ab17442aa9ca9d6770aa8af5c",
-       "msg_throttle": 1,
-       "placeholder": "​",
+       "layout": "IPY_MODEL_598af5eb6dc4473cbfbc8ecd10ad9538",
+       "style": "IPY_MODEL_ba3d23bdea80492c9fe170cc7d835660",
+       "value": "2"
+      }
+     },
+     "38e92957ff814f648355507fba1efdc2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "390a8d90df58477facd911357ef828fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FileUploadModel",
+      "state": {
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_23e838c1a76d4f0aad12bdf2b8225a12",
+       "style": "IPY_MODEL_c067bbcce1984f77a3f84947cfad1a46"
+      }
+     },
+     "396218b29fae4e49aab649f23ba9271d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_09bb3f943ad441a4b775f30e64098d16",
+       "style": "IPY_MODEL_8c203e0890c84b1e9548f48d9c341760",
        "value": "1"
       }
      },
-     "0c1d7e6695354a2a958b21f255b7f29b": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "0c5f090e8288472f80cc7661fcad30b2": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "12a9cb1f7c6f429887047437349a1efd": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "ButtonModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "ButtonModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "ButtonView",
-       "button_style": "",
-       "description": "Click me",
-       "disabled": false,
-       "icon": "check",
-       "layout": "IPY_MODEL_26352c5321464787842fff0e4e8b3e5e",
-       "msg_throttle": 1,
-       "tooltip": "Click me"
-      }
-     },
-     "140f80d916a745ae956f06b4f8a8f73f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "15ece8b84daa470f8938a138c2433389": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "TextareaModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "TextareaModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "TextareaView",
-       "description": "String:",
-       "disabled": false,
-       "layout": "IPY_MODEL_35d5b43dae50413ca8256ad84fec0363",
-       "msg_throttle": 1,
-       "placeholder": "Type something",
-       "value": "Hello World"
-      }
-     },
-     "1654741e7d0a4bfb9008b25ce5ae0b89": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "3afb971b70db448f8533ccbcd79add82": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "TextModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "TextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "TextView",
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_f1a8e14609fb47c4b8865849488511f0",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": ""
+       "layout": "IPY_MODEL_e756063607f74ab9b545082e7b57b1f7",
+       "style": "IPY_MODEL_7b7607f095fc4840842fee5b9eea53e5"
       }
      },
-     "165e9979258c48fd829666b0ba7aa7ca": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "3b5dc9fd4be74759a0fdbc33624292a7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3f4d3d533ac1485d9261d15466ceb172": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3f71a71a7af341a2a69f423d4cbfa008": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_48b16c2cb388479c95098c6f7ab13ed0",
+        "IPY_MODEL_df4231d6e4284db2b84ffc2e28997aa3"
+       ],
+       "layout": "IPY_MODEL_00e918754ce3473987c4ac8b68d2aa64"
+      }
+     },
+     "41078ec3634f4a8db9d2e97ee24cd40b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "LabelModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LabelModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LabelView",
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_38212e65eb0b43dfba113efa910f994f",
-       "msg_throttle": 1,
-       "placeholder": "​",
+       "layout": "IPY_MODEL_3b5dc9fd4be74759a0fdbc33624292a7",
+       "style": "IPY_MODEL_5b5bee1cf34d4c2c9745f6c1eb265dd9",
        "value": "3"
       }
      },
-     "209bfbc1dbab45ccaffdd3f14f9b0b0a": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
+     "41aa649b6f92435789ad05d6694d3979": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatSliderModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "21b9cd5e4f0d43dab1dd0a3ccc8034d7": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "FloatTextModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "FloatTextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "FloatTextView",
-       "description": "Any:",
-       "disabled": false,
-       "layout": "IPY_MODEL_140f80d916a745ae956f06b4f8a8f73f",
-       "msg_throttle": 1,
+       "continuous_update": false,
+       "description": "Test:",
+       "layout": "IPY_MODEL_f970119cba234e2e89dbe8f00a276b2b",
+       "max": 10,
+       "readout_format": ".1f",
+       "step": 0.1,
+       "style": "IPY_MODEL_1d08477048c641978807b98886b5b7fe",
        "value": 7.5
       }
      },
-     "2344fbaf3fe341458e7781ec178d1ed3": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "451615e6cc664f1ca018e19c1ef76dc2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
+      "state": {}
      },
-     "23c54815d17d4dd1a64534e350b88f1c": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LinkModel",
+     "48b16c2cb388479c95098c6f7ab13ed0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "PlayModel",
       "state": {
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LinkModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": null,
-       "msg_throttle": 1,
-       "source": [
-        "IPY_MODEL_8eb44729a8c04a41a6ed6bc20724afc8",
-        "value"
-       ],
-       "target": [
-        "IPY_MODEL_418b7b263f654ed9af540ff708571f51",
-        "value"
-       ]
-      }
-     },
-     "261e5c581b0447169eb939ec57ae2004": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "HBoxModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_8656dfd33b1c46bfb3ebe65071038b84",
-        "IPY_MODEL_e5dcca0da2484a68a6d7d2c4b6204545",
-        "IPY_MODEL_08cfa62812e245ec838c5c971696818f",
-        "IPY_MODEL_36cead4f09324a48901f8e3c8ca65220"
-       ],
-       "layout": "IPY_MODEL_78582a251f4b48e9b6a4fb0b79e318f6",
-       "msg_throttle": 1,
-       "overflow_x": "",
-       "overflow_y": ""
-      }
-     },
-     "26352c5321464787842fff0e4e8b3e5e": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "2a42b49ab17442aa9ca9d6770aa8af5c": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "2eceb520afd04cee88fa33fba5d277e8": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "TextModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "TextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "TextView",
-       "description": "P0",
-       "disabled": false,
-       "layout": "IPY_MODEL_8c3fe85543944693831dd00b1c7e939f",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": ""
-      }
-     },
-     "3404dfa67d2e4536bb9f64014724d5f7": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "35544158b22549a4a6f904b33213252d": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "DropdownModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "DropdownModel",
-       "_options_labels": [
-        "Three",
-        "One",
-        "Two"
-       ],
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "DropdownView",
-       "button_style": "",
-       "description": "Number:",
-       "disabled": false,
-       "layout": "IPY_MODEL_f23cfdd8a9bd4f4f881a7dba98a11ba4",
-       "msg_throttle": 1,
-       "value": "Two"
-      }
-     },
-     "35d5b43dae50413ca8256ad84fec0363": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "36ce07efb0af4b7bb8fa5ecc20a75446": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "36cead4f09324a48901f8e3c8ca65220": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LabelModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LabelModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LabelView",
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_a15bf7e4a11c4fd2bd7befcd22954b2b",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": "3"
-      }
-     },
-     "38212e65eb0b43dfba113efa910f994f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "3832d950aa9e490cb1c6855448b0992f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "396043a6467e4cba8cdd244be57d9478": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "TextModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "TextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "TextView",
-       "description": "P2",
-       "disabled": false,
-       "layout": "IPY_MODEL_ea82f97ebc8d4d11a41fb54b4c654a6d",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": ""
-      }
-     },
-     "3a305f92e48542b59098381a161fde9a": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "TabModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "TabModel",
-       "_titles": {},
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "TabView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_2eceb520afd04cee88fa33fba5d277e8",
-        "IPY_MODEL_e06b0e2dc4184c1b932d2377256f1699",
-        "IPY_MODEL_396043a6467e4cba8cdd244be57d9478",
-        "IPY_MODEL_9588a3f4aea842a689483210e3e85af1",
-        "IPY_MODEL_e84e0f448b9e45ecbbcf969244e3a881"
-       ],
-       "layout": "IPY_MODEL_b7a3a5eb23cf4b04a59db57f8046bbc8",
-       "msg_throttle": 1,
-       "overflow_x": "",
-       "overflow_y": "",
-       "selected_index": 0
-      }
-     },
-     "3d53699ff99a4fdc87909434e78128e4": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "3d64356313794db080d8cf770efcd8d3": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "3dc0d036b79f4356b66804e5350e5f1c": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "418b7b263f654ed9af540ff708571f51": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "IntSliderModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "IntSliderModel",
-       "_range": false,
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "IntSliderView",
-       "continuous_update": true,
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_36ce07efb0af4b7bb8fa5ecc20a75446",
-       "max": 100,
-       "min": 0,
-       "msg_throttle": 1,
-       "orientation": "horizontal",
-       "readout": true,
-       "readout_format": "d",
-       "slider_color": null,
-       "step": 1,
+       "description": "Press play",
+       "layout": "IPY_MODEL_5dbb57473ce442be95ed0a07b5e89f56",
+       "style": "IPY_MODEL_de13d0355c6d4a2b9316672bc6934801",
        "value": 50
       }
      },
-     "453127d40389487cb3e36e95d8b59d60": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "AccordionModel",
+     "494158494996463db0a7d963c5271a27": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "AccordionModel",
-       "_titles": {
-        "0": "Slider",
-        "1": "Text"
-       },
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "AccordionView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_976e5fe5e6dd42f4a2a5446d3da4ad0d",
-        "IPY_MODEL_1654741e7d0a4bfb9008b25ce5ae0b89"
-       ],
-       "layout": "IPY_MODEL_6bfc0caf794b4acfa60c1e2cc5a24d2e",
-       "msg_throttle": 1,
-       "overflow_x": "",
-       "overflow_y": "",
-       "selected_index": 0
+       "description_width": ""
       }
      },
-     "4a8d047af2e645beb6a06f3d3a87f415": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "ProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "ProgressModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "ProgressView",
-       "bar_style": "info",
-       "description": "Loading:",
-       "disabled": false,
-       "layout": "IPY_MODEL_50b86474be2d46418972bc60423001dc",
-       "max": 10,
-       "min": 0,
-       "msg_throttle": 1,
-       "orientation": "horizontal",
-       "step": 0.1,
-       "value": 7.5
-      }
-     },
-     "50b86474be2d46418972bc60423001dc": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "49d605fd694c46d6a0ac936d6becbec0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
+      "state": {}
      },
-     "50bd83bb64f747538455f07b1c403130": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "49f0fdfe199c4ac4b776b8d8ca75c039": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
+      "state": {}
      },
-     "53aea1b1788240b4a6fc7103923cbc61": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "4b932535cf844e6ab601ab75f888c09f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
+      "state": {}
      },
-     "53da5ce19e2440eeb48d9894da634e98": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "HBoxModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_bf0e7471d56b40389ed58a513ad7852b",
-        "IPY_MODEL_b6253d1f165f4a689836ddbdab177a05"
-       ],
-       "layout": "IPY_MODEL_b6ac090042a54f00ac29523e2eaa6cd3",
-       "msg_throttle": 1,
-       "overflow_x": "",
-       "overflow_y": ""
-      }
-     },
-     "5694e208e8484e84b6cb9b3912fa355a": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "5e54ffd534404973b0f98d8573716a3d": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "4dae83cdf2c14744a15b7afe4afbdf18": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "FloatSliderModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "FloatSliderModel",
-       "_range": false,
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "FloatSliderView",
-       "continuous_update": false,
-       "description": "Test:",
-       "disabled": false,
-       "layout": "IPY_MODEL_aa14e7ac85aa42898abc65809702244f",
-       "max": 10,
-       "min": 0,
-       "msg_throttle": 1,
-       "orientation": "vertical",
-       "readout": true,
-       "readout_format": ".1f",
-       "slider_color": "white",
+       "layout": "IPY_MODEL_b88e771825244b5f90859aad40ae4f24",
        "step": 0.1,
-       "value": 7.5
+       "style": "IPY_MODEL_88f65ff1addb428290726c11935e6ad3"
       }
      },
-     "5faca03ffc1447d0bff708566d2c068e": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "ImageModel",
+     "4fd3732a16a144caa2b18720ef1f08d9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
       "state": {
-       "_b64value": "iVBORw0KGgoAAAANSUhEUgAAATIAAAGxCAYAAADh4jqzAAAKQWlDQ1BJQ0MgUHJvZmlsZQAASA2dlndUU9kWh8+9N73QEiIgJfQaegkg0jtIFQRRiUmAUAKGhCZ2RAVGFBEpVmRUwAFHhyJjRRQLg4Ji1wnyEFDGwVFEReXdjGsJ7601896a/cdZ39nnt9fZZ+9917oAUPyCBMJ0WAGANKFYFO7rwVwSE8vE9wIYEAEOWAHA4WZmBEf4RALU/L09mZmoSMaz9u4ugGS72yy/UCZz1v9/kSI3QyQGAApF1TY8fiYX5QKUU7PFGTL/BMr0lSkyhjEyFqEJoqwi48SvbPan5iu7yZiXJuShGlnOGbw0noy7UN6aJeGjjAShXJgl4GejfAdlvVRJmgDl9yjT0/icTAAwFJlfzOcmoWyJMkUUGe6J8gIACJTEObxyDov5OWieAHimZ+SKBIlJYqYR15hp5ejIZvrxs1P5YjErlMNN4Yh4TM/0tAyOMBeAr2+WRQElWW2ZaJHtrRzt7VnW5mj5v9nfHn5T/T3IevtV8Sbsz55BjJ5Z32zsrC+9FgD2JFqbHbO+lVUAtG0GQOXhrE/vIADyBQC03pzzHoZsXpLE4gwnC4vs7GxzAZ9rLivoN/ufgm/Kv4Y595nL7vtWO6YXP4EjSRUzZUXlpqemS0TMzAwOl89k/fcQ/+PAOWnNycMsnJ/AF/GF6FVR6JQJhIlou4U8gViQLmQKhH/V4X8YNicHGX6daxRodV8AfYU5ULhJB8hvPQBDIwMkbj96An3rWxAxCsi+vGitka9zjzJ6/uf6Hwtcim7hTEEiU+b2DI9kciWiLBmj34RswQISkAd0oAo0gS4wAixgDRyAM3AD3iAAhIBIEAOWAy5IAmlABLJBPtgACkEx2AF2g2pwANSBetAEToI2cAZcBFfADXALDIBHQAqGwUswAd6BaQiC8BAVokGqkBakD5lC1hAbWgh5Q0FQOBQDxUOJkBCSQPnQJqgYKoOqoUNQPfQjdBq6CF2D+qAH0CA0Bv0BfYQRmALTYQ3YALaA2bA7HAhHwsvgRHgVnAcXwNvhSrgWPg63whfhG/AALIVfwpMIQMgIA9FGWAgb8URCkFgkAREha5EipAKpRZqQDqQbuY1IkXHkAwaHoWGYGBbGGeOHWYzhYlZh1mJKMNWYY5hWTBfmNmYQM4H5gqVi1bGmWCesP3YJNhGbjS3EVmCPYFuwl7ED2GHsOxwOx8AZ4hxwfrgYXDJuNa4Etw/XjLuA68MN4SbxeLwq3hTvgg/Bc/BifCG+Cn8cfx7fjx/GvyeQCVoEa4IPIZYgJGwkVBAaCOcI/YQRwjRRgahPdCKGEHnEXGIpsY7YQbxJHCZOkxRJhiQXUiQpmbSBVElqIl0mPSa9IZPJOmRHchhZQF5PriSfIF8lD5I/UJQoJhRPShxFQtlOOUq5QHlAeUOlUg2obtRYqpi6nVpPvUR9Sn0vR5Mzl/OX48mtk6uRa5Xrl3slT5TXl3eXXy6fJ18hf0r+pvy4AlHBQMFTgaOwVqFG4bTCPYVJRZqilWKIYppiiWKD4jXFUSW8koGStxJPqUDpsNIlpSEaQtOledK4tE20Otpl2jAdRzek+9OT6cX0H+i99AllJWVb5SjlHOUa5bPKUgbCMGD4M1IZpYyTjLuMj/M05rnP48/bNq9pXv+8KZX5Km4qfJUilWaVAZWPqkxVb9UU1Z2qbapP1DBqJmphatlq+9Uuq43Pp893ns+dXzT/5PyH6rC6iXq4+mr1w+o96pMamhq+GhkaVRqXNMY1GZpumsma5ZrnNMe0aFoLtQRa5VrntV4wlZnuzFRmJbOLOaGtru2nLdE+pN2rPa1jqLNYZ6NOs84TXZIuWzdBt1y3U3dCT0svWC9fr1HvoT5Rn62fpL9Hv1t/ysDQINpgi0GbwaihiqG/YZ5ho+FjI6qRq9Eqo1qjO8Y4Y7ZxivE+41smsImdSZJJjclNU9jU3lRgus+0zwxr5mgmNKs1u8eisNxZWaxG1qA5wzzIfKN5m/krCz2LWIudFt0WXyztLFMt6ywfWSlZBVhttOqw+sPaxJprXWN9x4Zq42Ozzqbd5rWtqS3fdr/tfTuaXbDdFrtOu8/2DvYi+yb7MQc9h3iHvQ732HR2KLuEfdUR6+jhuM7xjOMHJ3snsdNJp9+dWc4pzg3OowsMF/AX1C0YctFx4bgccpEuZC6MX3hwodRV25XjWuv6zE3Xjed2xG3E3dg92f24+ysPSw+RR4vHlKeT5xrPC16Il69XkVevt5L3Yu9q76c+Oj6JPo0+E752vqt9L/hh/QL9dvrd89fw5/rX+08EOASsCegKpARGBFYHPgsyCRIFdQTDwQHBu4IfL9JfJFzUFgJC/EN2hTwJNQxdFfpzGC4sNKwm7Hm4VXh+eHcELWJFREPEu0iPyNLIR4uNFksWd0bJR8VF1UdNRXtFl0VLl1gsWbPkRoxajCCmPRYfGxV7JHZyqffS3UuH4+ziCuPuLjNclrPs2nK15anLz66QX8FZcSoeGx8d3xD/iRPCqeVMrvRfuXflBNeTu4f7kufGK+eN8V34ZfyRBJeEsoTRRJfEXYljSa5JFUnjAk9BteB1sl/ygeSplJCUoykzqdGpzWmEtPi000IlYYqwK10zPSe9L8M0ozBDuspp1e5VE6JA0ZFMKHNZZruYjv5M9UiMJJslg1kLs2qy3mdHZZ/KUcwR5vTkmuRuyx3J88n7fjVmNXd1Z752/ob8wTXuaw6thdauXNu5Tnddwbrh9b7rj20gbUjZ8MtGy41lG99uit7UUaBRsL5gaLPv5sZCuUJR4b0tzlsObMVsFWzt3WazrWrblyJe0fViy+KK4k8l3JLr31l9V/ndzPaE7b2l9qX7d+B2CHfc3em681iZYlle2dCu4F2t5czyovK3u1fsvlZhW3FgD2mPZI+0MqiyvUqvakfVp+qk6oEaj5rmvep7t+2d2sfb17/fbX/TAY0DxQc+HhQcvH/I91BrrUFtxWHc4azDz+ui6rq/Z39ff0TtSPGRz0eFR6XHwo911TvU1zeoN5Q2wo2SxrHjccdv/eD1Q3sTq+lQM6O5+AQ4ITnx4sf4H++eDDzZeYp9qukn/Z/2ttBailqh1tzWibakNml7THvf6YDTnR3OHS0/m/989Iz2mZqzymdLz5HOFZybOZ93fvJCxoXxi4kXhzpXdD66tOTSna6wrt7LgZevXvG5cqnbvfv8VZerZ645XTt9nX297Yb9jdYeu56WX+x+aem172296XCz/ZbjrY6+BX3n+l37L972un3ljv+dGwOLBvruLr57/17cPel93v3RB6kPXj/Mejj9aP1j7OOiJwpPKp6qP6391fjXZqm99Oyg12DPs4hnj4a4Qy//lfmvT8MFz6nPK0a0RupHrUfPjPmM3Xqx9MXwy4yX0+OFvyn+tveV0auffnf7vWdiycTwa9HrmT9K3qi+OfrW9m3nZOjk03dp76anit6rvj/2gf2h+2P0x5Hp7E/4T5WfjT93fAn88ngmbWbm3/eE8/syOll+AAAACXBIWXMAABcSAAAXEgFnn9JSAAAB1WlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOkNvbXByZXNzaW9uPjU8L3RpZmY6Q29tcHJlc3Npb24+CiAgICAgICAgIDx0aWZmOlBob3RvbWV0cmljSW50ZXJwcmV0YXRpb24+MjwvdGlmZjpQaG90b21ldHJpY0ludGVycHJldGF0aW9uPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KsOMy3QAAQABJREFUeAHtXQe4FEW2LhRzQsyCIigGBHNW5HpNmIVdAyZQXMOiu4hZDKiL4ZneGteE7qorCqu4a06AcUXBRUxgQgUDgjkj9Dt/7TtlTc90z8y9U8305T/fd293VzhV/ff0P6eqTp1pFYkYChEgAkQgxwgskOO+s+tEgAgQAYsAiYwfBCJABHKPAIks94+QN0AEiACJjJ8BIkAEco8AiSz3j5A3QASIAImMnwEiQARyjwCJLPePkDdABIgAiYyfASJABHKPAIks94+QN0AEiACJjJ8BIkAEco8AiSz3j5A3QASIAImMnwEiQARyjwCJLPePkDdABIgAiYyfASJABHKPAIks94+QN0AEiACJjJ8BIkAEco8AiSz3j5A3QASIAImMnwEiQARyjwCJLPePkDdABIgAiYyfASJABHKPAIks94+QN0AEiACJjJ8BIkAEco9A69B3MGLECDN06FAze/bs0E1RPxEgAnWOQLt27czw4cNN27Zta9tT/K5lSGlsbMTvZvKPGPAzwM+A/QyMHDmy5pQT3CKbM2eOZd4hQ4aYHj161JaFqY0IEIHcIDBw4EAzceJEM3fu3Jr3OTiRaY+7dOliGhoa9JJHIkAE5jME2rRpE+yOOdkfDFoqJgJEICsESGRZIc12iAARCIYAiSwYtFRMBIhAVgiQyLJCmu0QASIQDAESWTBoqZgIEIGsECCRZYU02yECRCAYAiSyYNBSMREgAlkhQCLLCmm2QwSIQDAESGTBoKViIkAEskKARJYV0myHCBCBYAiQyIJBS8VEgAhkhQCJLCuk2Q4RIALBECCRBYOWiokAEcgKARJZVkizHSJABIIhQCILBi0VEwEikBUCJLKskGY7RIAIBEOARBYMWiomAkQgKwRIZFkhzXaIABEIhgCJLBi0VEwEiEBWCJDIskKa7RABIhAMARJZMGipmAgQgawQIJFlhTTbIQJEIBgCJLJg0FIxESACWSFAIssKabZDBIhAMARIZMGgpWIiQASyQoBElhXSbIcIEIFgCJDIgkFLxUSACGSFAIksK6TZDhEgAsEQIJEFg5aKiQARyAoBEllWSLMdIkAEgiHQOphmKm4SAj/88INZbLHFmlQ3iiLTqlWriurOmTPHoK1vv/3WzJo1y3zyySdmjTXWMGuuuWZF9fNY6Ouvv7bYLrTQQk3q/k8//WS+++47Az3A65dffjEbb7yxWWKJJZqkj5VqhwCJrHZYNkvTjz/+aDbffHPz/vvvmxtvvNEccMABFevDC7X33nubF1980bz66qtmpZVWMmPGjDEPPPCAeeuttyxRff755wZ/eBFBYKhTSo466ihz4YUXmp133tnWBTHq3wILLODOkabXW221lfnb3/5mllpqKavyzjvvNMOHDzfvvvuubQ/lWrdubV/4LbbYwuy4447mN7/5TVnSRf9POeUU880335i11lrLHHTQQeawww4zCy+8cKmuF6XNnTvX3H333WbYsGFm3Lhx5quvvjILLrig2XLLLc3AgQPNfvvt5+p88cUX5rbbbjPjx483H3/8scUKeH355ZcWL5AYvijisswyy5jnn3/erLfeevEsXmeJgDycoNKjRw88/Ug+UEHbybvy5557zuIErPbcc097O/LyRLfeemskZJR6e0Iaru79998f+dfQV83fgAEDohEjRlRVB/qvu+4628eHH364orq77bZbNGPGjMT7EosnEmIs0rX99ttHQvqJ9TRDLM1o3333LarvYyGEbYsLqUfrr79+alm/nn8upBpNnz5dm+UxBYGQXMA5MvlU1oPgm18Fwz3Iqaeeavr162e6du1qLQvNjx9hOajMnDnTvPbaa3pZcPSHnThfZZVV7B+GlLBSzj33XHP++eebZZddtqBeuYu1117bCPnaYlOnTnXFMew688wzzeGHH271L7300i7voYceMo2NjQaWTilBP2CJxeWpp54yffv2LWkdaVkhFiOEZ0aNGqVJJY/XXHONTYc1BissLj5eyEP/gdmqq65qhPhM7969zYMPPmiv43V5nS0CHFpmi3dia/5waYUVVrDlRo4caY942TGsAsFgyBcXDEtVZs+ebc477zxzzDHHGLF47HCuTZs2Bn+XXXaZOf30021RsaDM0UcfrdUKjj6RYc4Mw0YMoTA0A+HqHyphSLXtttu64V7btm2dLrS3ww47uGsMZ++9915zxRVX2OEYhsFnn322ufjii10ZnMiXurnnnntsGoalRxxxhJk0aZJ54YUXbNpdd91lNtlkEzvstAneP9w/2sSQWkWsP9OrVy+z8sorm5dfftmMHTvWDr1B4JDll1/efPTRR+add94xmDtUvDD3teSSS9qhZfv27c17771nh8i2Ev/VFwIplmBNskKakzXpYJ0oeeyxx9zQRkjIDp/EInBp8qmJhGAisXiKenzBBRe4ckI6RfmacPPNN7tyaC9J5IV25QYNGpRUrGT6448/7urK3FHJMjJ3Fe211162nBBFhKGdL0I2TofMFbqsm266KVJMhFgiIR2XpydiZbm6Mi8X3XHHHZpVcPz0008jWeQoSCt1sdpqq1l9QtalsplWBQIhuYBDyzr5XvGHUYsvvri1fuQzUtA7DIH69+9fNKzyLTLUTRKdjEd+WjnfIuvUqVOSupLp/vARq6GlBEM23AcEw2hYW748+eST7lLLIQHngwcPtnnTpk0zjzzyiCuHEyxkYEiqMnToUGvJ6rV/XHHFFY1vPfp5/rliloaXX57n8wYBEtm8wb2o1TiR+SSGuSQMfyBPPPGEueWWWwrq+yuQaa4biyyyiKuX5oLgk5G+yK5imRN/Xumzzz5LLC0WkcvDKqovuEfIoosuaue6/LzTTjvN6NBbFkL8LCMWm3WLQOJ2221nTj755IL8plwoZml4NUUv69QWARJZbfFssrY4kcFdQQUvLuabVGCV6IIA0jCPpJJGZP48nF9H6+rRt/Bef/11m4y5J/hOYd4tTeDyoJJEZLCmLr/8clsM81CbbbaZVjHff/+9GT16tL1GuhKJFkD5Qw891F5i4t8XuFioYKHEJ1VNr/aomKXhVa1Olq89Ar++AbXXTY1VIOATE4YxvgWAIRpe3g033NBqBKH4E+T+S5ZGZL6Vpy9oqS76fUE7IBOUx4odfNROPPHEUtVsmt9GnMgmT55sfdSwCotzyJFHHllwr7DG1EKDv1kp2XTTTW0ycMAKpYqSbocOHcwee+yhyc066v2k4dWsBli5JgiQyGoCY/OVpFlkIDJYFxdddJFrCBbahx9+aK996y2NyH7++WdXH6txSeL3BWX8erieMmUKDiXFt8jQx4022sj+wapcd911zRlnnGHn/1C5oaHBXHrppQV6xA/OXcPNwRcMobG6+Oyzz7rkl156yZ6jXSVHOBbXwhqDYr33NLxcZ3gyzxD4dfwyz7rAhoGATx6YG/LJSSfNe/bsaed+nnnmGWu1YGL7hhtuMMstt5wDUa0Zl+Cd6EuJpDQLw7fI4HbRvXt367UPIgG5HHfccZ7WwlO1YJAKcpk4cWJBgY4dOxpZsTS77LKLwf3A094XePOrYI7rkksuMRjqYlsQMPL1oxyIbJ999rF5eu/qVqF6mnNUzNLwao5+1q0NAiSy2uDYbC0+kWEo5w8tfYfXs846y+y66662vb/+9a/mnHPOMViBU8ELnyT6UiIfK3xJ4hMZ/Lmw2FCp+BYZfK8w6Q4rS3WCBMWlo6Q6OPL6Q0XcS9r9QIlaZCBc+H/Bx833ISvZUBWJilkaXlWoY9FACHBoGQjYatXGiQxDI537AgnAURMCSwb7FSF4ya6//nq3ioc0OK0mib6UyE8jCCUdlNtggw1wqFi0z6iAoSX2XcIJFcNKCBYqlHxsgvcP5XyB9QfHV3jpY74MzsC4d98VAk6yaqXphve4O4evs9pzxSwNr2p1snztESCR1R7TJmn0yQNDS4hvlfn5mGdSwUZn3x8q7YXTlxJ1feJUXXr029K0So9+n3XYiA3fY2QTO44YJu6+++4l59leeeUV1wx2J8A6wyZueOKLo6159NFHrXf/22+/bWDtQeBbhx0CECwiQLBZHe3VQhSzNLxq0Q51NA8BElnz8KtZbf9FUZcDf57MJyhEulALRzz9jU8AtbDI/GFU0l7IpBv3+4xVRRWsdsKBFf5wWM2EZekPI1HOn0/DPsYkweop9luqqBuG7zyLlVW11LRcU45KZD7+TdHDOmERIJGFxbdi7T55qFXjk4JPdBh2+vNM6u2Oxnzn2Hjj8AVT8fVpmh79eS5sQq9G/D7HN2JjlwDm3HB/CFeEuT5YVCo+kcnWIE0uefTn7XQVE4sS3bp1s+UnTJhgjj/+eDckjyuBFQfLVq25eL5eK2ZpeGlZHucdApzsn3fYF7TsuwsokekRBeMvEvzKsGoJFwyQgkqam4DfRlyf1sdRh7Y4R2y0Aw880A4JsegA4tEjSBPDWliH2JgNZ1W/z75FBl0QkA3m9bARHJP7iJqBYSMcbdXbH7sJ/N0F/61Z+B9zZyoSAklPrTc/YpZBEN0CLhlXXXWVs2CR/o9//MNadPjyAFFj5TdJFLM0vJLqMj07BEhk2WGd2pJuu0EhnfPSISbS1DLAOQRkg72E+tL+N9UYuDckib+6CQ/6JPH3WoIMNNxNUnmkg3jgWe9bZLpAEa+HsD5YWUQAR5AQAhxi65EKQuSUE6xQYpgKIgKRg1yBGwgelp3uhABJIkIHhrZwpMX8mu8Hp07GSe0BMwwr1bUjqRzT5y0CHFrOW/xd67o6iAlyeKZD/JA9OrntKsjJIYccYmNiaRqssW222UYvi45wTlXxfc80TY86PNPrSo6wbuBZDzcIlc6dO+tp0REkrBFa4TsmkTlcGV2VdQkJJ34/QVAq8D3r06ePXtojrD3EDvNJDKuiCO+TJoqZfrmklWXePERAJkSDSsjQHUE7nrHyN998MxJHzsgPmyNDr0hiaEXiAZ/YGxnyRBKrLBILJUIIm3IiIaYjce6M5IVOLSqEGMnHMhJijcRajLp06RLhWSJ6rSw2RAivI5PrkcwzRRIfLBKryOkTiysSKyiSYa9LK3UiK5hWD9oRUokk/lqEqK3iAFyqeFGaLB7YviG6qxBpQb4MeyOE/UG/ZXho7wXt4A/3IwErIxn6FtQpdSErppGQmC1fKp9plSMQkgtaoRvycIMJtqFg+Ryx0/UbOFhjLVAx5qHgm+X7Z5W6TUzQlyuj9eBekTaXhnLQp+Uq1av6qzni44dN4quvvrp1z6imLspWct/YGYGFB7QFywqrntXcE6xN+K7pfFm1fWT5/yIQkgs4R1bnnzJ/zimtq9W8mOVIDO1AX7kJ97T+VJoHcvBXICutp+UquW8Mo9OG0qor6YhFDEp9I8A5svp+PuwdESACFSBAIqsAJBYhAkSgvhEgkdX382HviAARqAABElkFILEIESAC9Y0Aiay+nw97RwSIQAUIkMgqAIlFiAARqG8ESGT1/XzYOyJABCpAgERWAUgsQgSIQH0jQCKr7+fD3hEBIlABAiSyCkBiESJABOobARJZfT8f9o4IEIEKECCRVQASixABIlDfCJDI6vv5sHdEgAhUgACJrAKQWIQIEIH6RoBEVt/Ph70jAkSgAgRIZBWAxCJEgAjUNwIksvp+PuwdESACFSBAIqsAJBYhAkSgvhEgkdX382HviAARqAABElkFILEIESAC9Y0Aiay+nw97RwSIQAUIkMgqAIlFiAARqG8ESGT1/XzYOyJABCpAgERWAUgsQgSIQH0jQCKr7+fD3hEBIlABAiSyCkBiESJABOobARJZfT8f9o4IEIEKEGhdQZmaFBk0aJAZMmRITXRRCREgAvlDYOrUqcE6HZzIOnXqZMaOHWumTZsW7CaomAgQgfwgAE6otbSKRGqt1Nc3e/ZsM27cOIMjhQgQgfkbgXbt2pnOnTvXHITgRFbzHlMhESACRCCGACf7Y4DwkggQgfwhQCLL3zNjj4kAEYghQCKLAcJLIkAE8ocAiSx/z4w9JgJEIIYAiSwGCC+JABHIHwIksvw9M/aYCBCBGAIkshggvCQCRCB/CJDI8vfM2GMiQARiCJDIYoDwkggQgfwhQCLL3zNjj4kAEYghQCKLAcJLIkAE8ocAiSx/z4w9JgJEIIYAiSwGCC+JABHIHwLB45GNGDHCDB06lGF88vfZYI+JQM0RQBif4cOHm7Zt29ZWN+KRhZTGxkbEO+MfMeBngJ8B+xkYOXJkzSknuEU2Z84cy7wIc92jR4/asjC1EQEikBsEBg4caCZOnGjmzp1b8z4HJzLtcZcuXUxDQ4Ne8kgEiMB8hkCbNm2C3TEn+4NBS8VEgAhkhQCJLCuk2Q4RIALBECCRBYOWiokAEcgKARJZVkizHSJABIIhQCILBi0VEwEikBUCJLKskGY7RIAIBEOARBYMWiomAkQgKwRIZFkhzXaIABEIhgCJLBi0VEwEiEBWCJDIskKa7RABIhAMARJZMGipmAgQgawQIJFlhTTbIQJEIBgCJLJg0FIxESACWSFAIssKabZDBIhAMARIZMGgpWIiQASyQoBElhXSbIcIEIFgCJDIgkFLxUSACGSFAIksK6TZDhEgAsEQIJEFg5aKiQARyAoBEllWSLMdIkAEgiFAIgsGLRUTASKQFQIksqyQZjtEgAgEQ4BEFgxaKiYCRCArBEhkWSHNdogAEQiGAIksGLRUTASIQFYIkMiyQprtEAEiEAwBElkwaKmYCBCBrBAgkWWFNNshAkQgGAIksmDQUjERIAJZIUAiywpptkMEiEAwBFoH00zFdYnADz/8YBZbbLG67FuoTv3000/mu+++M19//bX55JNPzC+//GI23nhjs8QSS4RqknozRoAWWcaAV9PceeedZzbYYAPz9NNPV1PNlv3222/N9ttvb/bbbz8zZ84cm3bjjTea5ZZbzmyzzTYu7aGHHjINDQ1mvfXWM+3atTNbbbWVOfjgg81ZZ51lRo8eXXW7P/74o7n99ttNr169zFprrWUWX3xxs+KKK5o999zT3HXXXSX1XXHFFWaVVVYxSy+9tGnTpo1ZdtllTdu2bW1fV1hhBVt/pZVWMiuvvLLVOXLkSKfniy++MFdeeaXp27ev2WWXXcxmm21mOnXqZOuDsBdYYAGz6KKLWl0dO3Y0W2+9tenevbu91zfeeMPpAcH96U9/Mttuu63p2rWr2Xvvvc3VV19tic8V4kn9IhAFlh49ekRy99Hdd98duKWWp75z584WOyGzqm/uzDPPtHWB/XPPPWfry4vu0l566SWbtvrqq7s0lI3/denSJZIXOhJrpmwfXn311UhIoEiHr1OItUjP+uuvn1rHr49zITSrQyyrqNq6qmvhhReOpk+fbvVMmzYtUqw1X48LLrhgNHjw4Ojnn38u6jcTqkMgJBfQIpNPbL0KhkSQV155xbz22msVd3P27Nnm+uuvd+Vbt/7vDMKXX37p0mCxwZr54IMPXFqrVq3M2muvbVZbbTWDc8jrr79ujjvuOANr5v7773dl4yd/+ctfzOabb26EzOJZBdcjRowouhdYYJUKLKw//vGPtjj6//HHHxdV1b5rBiw9WHyrrrqqEeIzvXv3Ng8++KC9Rpl99tnHvPXWW1rcWn1CYPYa1uzQoUPNHnvsYeS1dWV4Ul8IcI6svp5HQW/at2/viObRRx+1L2FBgYSLhx9+2Hz22Wc2d5FFFjHdunWz52KFuBoYsoEIfHn55ZfNhhtuaJNAdBha3nHHHQZDuVmzZpm99trLXHvttebYY4/1q1nS9NNAAocccojZYost7DDxP//5jxGr0P4hD2374hPZ+eefb4d1mMcC8eof+oNh8XbbbWc6dOhgqy+//PLmo48+Mu+8844dKmNYij/MfS255JIG84HA8L333jNK5n67OAeu48ePt8kgPFxvueWWZubMmWbAgAFGRhI277HHHrNfKIqPTeS/+kGgOuOw+tIhzcnqe5OvGkcffbQbcgmJVNz5I4880tXbaaedXD2Z/3HpMicUyRyRu5ZPZCQWoCvrnwgxRssss4wti6HWE0884bKhR8jD6RGLLpo4caLL909mzJgRTZkyxU+y54ceeqitL5ZU9NVXXxXlNyVBrEqrE/ecJn369HF9v+6664qKXnrppZF8GUS4L1kwKMpnQuUIhOQCDi3r5zulqCebbLKJS/v3v//tzsudwCJTwZBI5ZtvvtFTOwmPYZovOpzy03C+6667WqsM5xhqnX766Ti1csIJJ1irCRewkDBkwwJFKYElJnNRRVlqkcHiglVUC1lqqaWsGiw2pIlO+MNa7devX1HRE0880chcmrXGyukqqsyEzBDg0DIzqKtvCKtrKhgqTp061ayxxhqaVPKIYZRMXru83Xff3Z03lcigQL5N7XANQ7xx48aZN9980+q98847nf5bb73VrLnmmu660hMlLyWfSuullcOQGrLQQgulFXNzbCBZrG6WEhAspb4RKPxKru++zne9W3fdde28kN64rDTqaeLxqaeecnlwf8DkvYoSGawPWF++RRafINc6egQhyAqmXloi07klJMKlw7f+XMEKTuCyAcF8lwwt7Tl8vt5//32DhYumiM4H+vdYSo9aiLC6MEdIyScCJLI6fm4gF0xuq8jck54mHn2fszixwJqC6BDJJ6+kYaU2NHfuXKPDMKRhRRWT+CoYYibJ999/b1cFn3/+eQOixQqs+rahjvYLOuE/BhKSOTlrfWLy/tNPP01SnZguMzc2TwktqSD8z1R22203c9RRR9nFC/RViV/zeaxfBEhk9ftsbM/84SXcMMoJXkAVf1iJVUC1fJTIfGul3AsPtwr/xYYl4xMZHGnjAlLFiimGjLAMYbVhiAqH03XWWceuJqKOrxeE6VthIEF/qBxvI+la/L5sFlYv0+Twww83ihMIE07DxxxzjO0r5u4wPzhs2LCCPqbpY968QYBENm9wr7jVHXfc0ZWdNGmSOy91gm04OneFOSKfBH2y0LkgkJuKTrjrdfwI9wMVuD9gi8/nn39uk2DNwfM+LiAgECDIKS5wmZBVQpusFhkuNtpoIyMriXZHAo433XST2XTTTePVy14rkZUjaPT9vvvuM5dccoltx5+ng9UId4z+/fvb+8VQl1KfCHCyvz6fi+sV/JawxUdcF+xkP8hK9wjC4gFJwMqBYMimpAELyd9T6ROZToTDz0oFQ7okQd2LL77YZcO/CsNSENqECRPsMBGEBXLzBdt8LrvsMgMrEQSBfsM3TZ171ddNiQxbqsaMGeOccX1d1Z4rkQGvcgIfs5NOOsn+oSzud/LkybavIFssoIB4L7zwQgPHX0r9IUAiq79nUtAjEIb4gpm///3v1rMchAGHzWeffdY0NDTYlx6Ehj2Eb7/9tqvrW3JIbA6RgcSUdLAfE57+EHVMxfmLL75YRGQgrkGDBiHbCSwcDNcgahkqkWEY6s/buUpNOFEiw6JBtQLSxZ5N/PUTlwzs3UQfK5mjrLYtlq8NAhxa1gbHoFqwGVoF82QYEv7ud7+z1heGP+JQajCX5A89GxsbtYo9KlngQgnEt8iSXAxgjWBTt8q5557rLL2ePXtqshHHUetJ7xISTvzFCGx7gvh9S6hWdbISmU/gVSuRCnDLUH8+XVFtih7WCYsAiSwsvjXRvvPOOzs9L7zwgrnhhhsKVhAx7Bk4cKCLVoEJblhtvvgvtA4t/Rczvm0IdeGSAGsQJAnB/BUsFBVYVti7CMFexXPOOUezSh5BwNjypKI+Zzr8072lmt+coxJZmkWGIS62RMGaTBJ8UWD4DMECBaU+ESCR1edzKegVNjuDRCCjRo0yJ598sj3HSqBOsmO1DSQHwTAzvrdQyQL56iQKB1sVDBl9QVgbWHXvvvuuTYbTKvYdxt00MEmuq5+wyuAJn0RImC+DhQdBHb0nndfDfs5aia58+gQe133aaaeZs88+24buwY6EUoIN42oxxucAS5Vn2rxBgHNk8wb3qluFiwDcHfyXHcSA1Ubf1wyKdSjkN+LPPSmR+W4NvuVyzz332IlvJR3ogQuCOo/6euF7hTk0kCt8ty6//HLz+OOP243lsArhRAvCxGZzxA1TwaZytch0qIttWP/85z+tLxk2tOMPK6M4on+wJCXskL3fpG1Qql/vN43I9t13XxvRA6R3wAEHmCeffNJG8IAOWHQgZsSEg+CLAZvmKXWKQOVbPptWMuRG0ab1KJ+1EFNMPkLuD3G4xJKxNyNk4tJRRtwJim7Sry+BE22+rD66emIhRYh75m8Ahy4hj0gIqEhfPGHIkCERdPh9TDqX1dRIXBmcCiG8iur5+sRx1dUvdSK7GqxOmbgvlW3ThMCi3/72t65tcdWIJMRPJEEhI7GCXTraFUJL1MOMyhAIyQX4Fg0qITsftON1plzmaiKN6IAXSywX10NEscBLiHS8uDKJ7/L0RKyaSCwxW0aGUzZZrKyCl9UnCpyD2GQBQVWUPYolVkQAcZ0yPItk5bVAlx+tI14+6VqszgId8QslKFlZjWcVXIPMZOEkEguuJBYylI5klTaS+b2CeryoHoGQXMChpbwpeRDMKZ1xxhl2yCYvacEwB3syMQzCNiGsZupQzb8vbPVBQEKEm0Yoa8hhhx1mJ+kR7BBzYvD4xzwQhqb4gx9YOYdSvw24fGAYiQCMt912m5GQPXZYiNVJePNDJzzpdWirdRHo8JZbbrH+aHDZwMID/rCSiiEdymMBA/N0mBdEH0vtJFB9OB5//PF2qLjDDjv4yUXn0I/FE2CBYSRWVTHBj2Ev5vCAucZzK6rMhLpBoBV4NWRv4Os0duxYO1GM+PGU5iEAz33MVcUn3aHVd5ZtXivZ11ZXEN+Jt7m9AB4gZ50vq0QfFirwpREn20rqskw6AiG5gBZZOvZ1lwvrK0nU4z8pv57Ta0lgep9NwUNdU1QHj/lAgO4X+XhO7CURIAIpCJDIUsBhFhEgAvlAgESWj+fEXhIBIpCCAIksBRxmEQEikA8ESGT5eE7sJREgAikIkMhSwGEWESAC+UCARJaP58ReEgEikIIAiSwFHGYRASKQDwRIZPl4TuwlESACKQiQyFLAYRYRIAL5QIBElo/nxF4SASKQggCJLAUcZhEBIpAPBEhk+XhO7CURIAIpCJDIUsBhFhEgAvlAgESWj+fEXhIBIpCCAIksBRxmEQEikA8ESGT5eE7sJREgAikIkMhSwGEWESAC+UCARJaP58ReEgEikIIAiSwFHGYRASKQDwRIZPl4TuwlESACKQiQyFLAYRYRIAL5QIBElo/nxF4SASKQggCJLAUcZhEBIpAPBEhk+XhO7CURIAIpCJDIUsBhFhEgAvlAgESWj+fEXhIBIpCCQOuUvJpmDRo0yAwZMqSmOqmMCBCB/CAwderUYJ0NTmSdOnUyY8eONdOmTQt2E1RMBIhAfhAAJ9RaWkUitVbq65s9e7YZN26cwZFCBIjA/I1Au3btTOfOnWsOQnAiq3mPqZAIEAEiEEOAk/0xQHhJBIhA/hAgkeXvmbHHRIAIxBAgkcUA4SURIAL5Q4BElr9nxh4TASIQQ4BEFgOEl0SACOQPARJZ/p4Ze0wEiEAMARJZDBBeEgEikD8ESGT5e2bsMREgAjEESGQxQHhJBIhA/hAgkeXvmbHHRIAIxBAgkcUA4SURIAL5Q4BElr9nxh4TASIQQ4BEFgOEl0SACOQPARJZ/p4Ze0wEiEAMgeCBFUeMGGGGDh3KeGQx4HlJBOZHBBCPbPjw4aZt27a1vX0EVgwpjY2NCNzIP2LAzwA/A/YzMHLkyJpTTnCLbM6cOZZ5Ea+/R48etWVhaiMCRCA3CAwcONBMnDjRzJ07t+Z9Dk5k2uMuXbqYhoYGveSRCBCB+QyBNm3aBLtjTvYHg5aKiQARyAoBEllWSLMdIkAEgiFAIgsGLRUTASKQFQIksqyQZjtEgAgEQ4BEFgxaKiYCRCArBEhkWSHNdogAEQiGAIksGLRUTASIQFYIkMiyQprtEAEiEAwBElkwaKmYCBCBrBAgkWWFNNshAkQgGAIksmDQUjERIAJZIUAiywpptkMEiEAwBEhkwaClYiJABLJCgESWFdJshwgQgWAIkMiCQUvFRIAIZIUAiSwrpNkOESACwRAgkQWDloqJABHICgESWVZIsx0iQASCIUAiCwYtFRMBIpAVAiSyrJBmO0SACARDgEQWDFoqJgJEICsESGRZIc12iAARCIYAiSwYtFRMBIhAVgiQyLJCmu0QASIQDAESWTBoqZgIEIGsECCRZYU02yECRCAYAiSyYNBSMREgAlkhQCLLCmm2QwSIQDAESGTBoKViIkAEskKARJYV0nXezi+//GK+/PLLqnsZRZGZO3du1fVYgQjUEgESWS3RzJmud99915xyyilmzTXXNIsuuqhZdtllzQorrGAGDBhgZsyYkXo3b7zxhjnyyCPN8ssvb5ZZZhnTq1cv88EHH5Ss89lnn5lrrrnGfPLJJyXz/cRXXnnF9OvXzwwePNiAXFXuv/9+869//UsvE4+zZ882V1xxhTn44IPNM888k1iOGS0MAflGDSo9evSIBLLo7rvvDtoOlVeHwEMPPRQtvfTS9tng+cT/2rVrF82cObOk0iuvvDJaZJFFiuoIEUavvvpqUZ29997bll155ZWjyZMnF+Vrwq233hotvPDCTu+NN95os1566aWoVatWNn3QoEFavOgohBltu+22rj7ugVI/CITkAlpkLeyLqZLbufrqq82ee+5pvv7668Ti06dPN6NGjSrKv+uuu8wf/vAH89NPP9m8BRb49SP0xRdfWL1fffWVqydkaB588EF7DYtsp512Mh9++KHLx4m8atYCgyX2888/uzxYZ5Dbb7/dlsH55Zdfbs4991ycFsibb75pttxyS/Pss8+6dNzD559/7q550nIR+PVT2HLvkXfmISBWjzn++OPNnDlzbCqGk0OGDDH33HOPueWWW0z//v2NWDI2b4011vBqGjN+/Hhz+OGHu7TTTz/dzqthSHnIIYfY9KlTpxYQzbhx4wqGiCCx3XbbzSjZ/fjjj6ZPnz7mggsucHr1REnIJyfkob833XSTFjOjR482W2+9tcFQOS6qI57O6xaGQGjDM6Q5GbrvLU3/Dz/8EK222mpu6NXQ0BCJlVR0mzI3FU2ZMqUg/fvvv4/at2/v6l500UUF+WJJRZtvvrnNX2ihhZzeq666ytWRV8edr7vuutF1110XdevWzaUhf8kll3TXJ5xwgm1jueWWc2mqY8EFF4wwzDzxxBOj1q1bu3yxEKPFFlvMXQthFvSTF/MOgZBcQIushX0xpd3Otdde64Z1Qmhm5MiRZqWVViqqIiRhOnfuXJA+fPhwM23aNJu2xx57mFNPPbUgX8jLWVWYcL/jjjts/qxZs1y53r17m2222cZeYyh47LHHmkmTJtlrmQMzZ555pnn66addee2bWlVLLLGEgRWIhQlYlBhmXnbZZc7iQ59ffvllO7yFEpSTeUCnjyctFwESWct9tgV3hhffH74NGzbMiKVTUCbtAquOKmeffbaeFhwx/7XhhhvaNAxhITqExTmGkBgG7r///rh0gpXS++67z5x//vkGQ02VFVdc0bp2iA1hkzDUxT3IQoVp06aNFrPHAw44wLz44otmgw02cHN/qE+ZPxBoPX/cJu8S80dqHW266aZ20r1SVDDPhfkxyFZbbWW22GKLxKp9+/Y1MuSzlhasI1hRKt99952RVUkD666xsdEuAkAf5uWUdNT6Qh1YZFhMgGUFgkN9iAyJzQsvvGAuvfRSuzgAEsO8m4rqUItO03lsuQiQyFrusy24s9dff91d//73v3fnlZw88sgjrljPnj3deakTDB9BZJAnn3zSyJyXK/btt9/acwwjjz76aPvnMv//xHfKVXKDDhCZ1kfRtdde29xwww3x6vZadWj9koWY2KIQ4NCyRT3O5JvxiQxuCtXIW2+95YrvvPPO7rzUSYcOHQyGgJAJEyYUENk333xj09P++S4hGHJClAwrqY/yqkPrI43SshEgkbXs5+vuzvfUV6JxmWVO3n77bVeia9eu7jzpBNYS5OOPP3YkhOtKiEjdMlBeRYkMvmtYSCgnpXSUq8P8fCNAIsv386u49z55+RZWJQp0tRLbkSpZBYQjKgRllYRw7Q8NcV1K1JpCnpJWNTpQRxcMtH6pdpjWshAgkbWs55l4N9hPqaIuD3pd7rjOOuvYIpWQGCbk4VoBWWuttQqIrFqLTHcN+ERWTodvjWl92xn+a9EIkMha9OP99ebWX399d3HzzTe780pONttsM1vs/fffd9ZOUj3ZH+lcLvbaay8DnzSVai0y+KZBqtHhW3RaX9vnseUiQCJruc+24M46duxoXR6QOHbsWOu3VVAg5WL77be3ufAJk83/iSVl54C5+OKLbT4swO7du7uJdyTq/sxEBZLhW1TisW+L+uRUTkep+mntMa9lIEAiaxnPsaK7QHgeFbhgYFWxlICw4NoAr3k4o8JHC75bkJNOOslO4tsL7x9C7iB0jobqgeMqhnY+CcGHrJz45UsRWTkdpeqXa5P5+UeARJb/Z1jxHUg4Het/hQofffSR2W677exGcX/IhwgWGBLCz8snLUTMALEgthiGmrDqVLBRHCR277332iQ4uar3vj+nhQ3q5aQUEVWjo1T9cm0yP/8IkMjy/wwrvgMQEULqqKMohoJHHHGEDagIb31428MPDFuAICgnMcTsOebYsLcRVhZIEBbaqquuarBLAMNWHXLCYkJgQxVtC9errLKKJice27Zt6/LU+lId6D9WTtOkVP208sxrGQiQyFrGc6z4LjB39cADDxSsJmJYiH2K2AfpWz8Yfvorfwj/gz2RSy21lG0PfmL+8BST69iIDotMRX3KcL3RRhtpcuJRV0ixtWnxxRe35VRHly5d7BanxMqSoWVRRgkwrTzzWggCoYN6hAzdEbrvLVm/OLlGBx10UCSk5ELeyEc6EuKKxPM/uu222xJvX3YJRAceeKCLEiukE8lwNHr00UdL1pFAiJGQWyQT8SXz/USJVxZJdI1IhrUuWdw5Ilk4iGTjuktLO/nzn/9s7yEeiiitDvPCIxCSC1qh+yE5GUMQzKdg6LHffvuFbIq6m4AAJvaxoRz+X/DXwkZrtbjKqUNdBErEEFOHgeXqMH/+RSAkF3DT+Pz7ubJ3Xir2WKWQoK6/Y6DSeixHBGqNAOfIao0o9REBIpA5AiSyzCFng0SACNQaARJZrRGlPiJABDJHgESWOeRskAgQgVojQCKrNaLURwSIQOYIkMgyh5wNEgEiUGsESGS1RpT6iAARyBwBElnmkLNBIkAEao0AiazWiFIfESACmSNAIssccjZIBIhArREgkdUaUeojAkQgcwRIZJlDzgaJABGoNQIkslojSn1EgAhkjgCJLHPI2SARIAK1RoBEVmtEqY8IEIHMESCRZQ45GyQCRKDWCJDIao0o9REBIpA5AiSyzCFng0SACNQaARJZrRGlPiJABDJHgESWOeRskAgQgVojQCKrNaLURwSIQOYIkMgyh5wNEgEiUGsESGS1RpT6iAARyBwBElnmkLNBIkAEao0AiazWiFIfESACmSNAIssccjZIBIhArREgkdUaUeojAkQgcwRaZ9XioEGDzJAhQ7Jqju0QASJQZwhMnTo1WI+CE1mnTp3M2LFjzbRp04LdBBUTASKQHwTACbWWVpFIrZX6+mbPnm3GjRtncKQQASIwfyPQrl0707lz55qDEJzIat5jKiQCRIAIxBDgZH8MEF4SASKQPwRIZPl7ZuwxESACMQRIZDFAeEkEiED+ECCR5e+ZscdEgAjEECCRxQDhJREgAvlDgESWv2fGHhMBIhBDgEQWA4SXRIAI5A8BEln+nhl7TASIQAwBElkMEF4SASKQPwRIZPl7ZuwxESACMQRIZDFAeEkEiED+ECCR5e+ZscdEgAjEECCRxQDhJREgAvlDgESWv2fGHhMBIhBDIHhgxREjRpihQ4cyHlkMeF4SgfkRAcQjGz58uGnbtm1tbx+BFUNKY2MjAjfyjxjwM8DPgP0MjBw5suaUE9wimzNnjmVexOvv0aNHbVmY2ogAEcgNAgMHDjQTJ040c+fOrXmfgxOZ9rhLly6moaFBL3kkAkRgPkOgTZs2we6Yk/3BoKViIkAEskKARJYV0myHCBCBYAiQyIJBS8VEgAhkhQCJLCuk2Q4RIALBECCRBYOWiokAEcgKARJZVkizHSJABIIhQCILBi0VEwEikBUCJLKskGY7RIAIBEOARBYMWiomAkQgKwRIZFkhzXaIABEIhgCJLBi0VEwEiEBWCJDIskKa7RABIhAMARJZMGipmAgQgawQIJFlhTTbIQJEIBgCJLJg0FIxESACWSGQWTyyrG6I7WSDgIT4NPhbYIGmfRf+8ssv5ttvvzUhY1TVGgkECf3hhx9sv2fNmmU++eQTs8Yaa5g111yz1k0V6HvrrbfMYostZtq3b1+QzotfEWjap/DX+i3+bPr06aZbt27myCOPtC9utTd8++232/r/+te/bNUrrrjCrLLKKmbppZe2L/Gyyy5r45cvt9xyZoUVVjArrriiWWmllczKK69s1lprLSNhgYuaBIHce++95ne/+51Ze+21bdl9993XphUVLpGAvvTt29fW3W677cyAAQPM6NGjK4rc+cYbb1gsll9+ebPMMsuYXr16mQ8++KBEK8VJ7777rjnllFPsi7/ooosa3DvuGe3PmDHDVRg3bpzp2bOn+fe//+3S4iefffaZ2WOPPcyoUaNc1ueff2423XRTiy36BpJEG8AW/VV8gS2eAfr+zTffuPpjxowxJ598sgGW3bt3N+uvv757VgsttJBp3bq1WWqppWxa165dzU477WSf0dFHH+104KQ5+BYokgvgveGGG9q+gDwpCQjUPHh2TKGEt7Zxuu++++5YTj4u77jjDhdr/p577qmq0/LBi+SFsvV32WUXW1deDqdPHknZc3npCtq8//77ow022CCxHtr5+OOPC+r4FxdffHFiXfRtwoQJfvGC8yuvvDJaZJFFiuoLWUSvvvpqQdn4xUMPPRQJeRfVVQzkRymimTNn2mq4B6Tvt99+cTX2evbs2ZF+rvbaay9XRn7oJlG/thM/Xnfddba+/CBG1XVVlxCx60Nz8HVKvJPf/OY3rl/yReDl5O9Un1kILoCVEVRCdj5ox/9f+bBhw9wH6be//W1VTYr15eruvvvutq5YQC5NX4SkowzbogsvvNC1+dJLL0WtWrUqqg9y8dM32mij6Ouvv3b19OSf//xnQV2QLIjSb18sj+jJJ5/UKu4Yf9HRN7+eDLGiL7/80pX3T6666qpowQUXLCjv19Xzm266yVZbb731bNktt9zSV+POjzvuOKcL5KXy+OOPu3TVmXYUazb68MMPbfWzzjqrZF0fV5yLJWf/cL/o37nnnhuJJWh1NAdfvQf/iC8VbV+sMj8rl+chuYBEVuYj8eijj7oPuAxVIpknKVPj1+xNNtnE1T377LNtBiwIfbnOP//8SH6MIRo/fnz0xBNPRP/4xz+im2++Ofrzn/8cyZA0mjp16q/K5Oyiiy5ydRdeeOEIOvEiyo85WOLCN50SRr9+/Qrq4mLrrbd29Q899NDoxx9/tHVleBbJ8MvlydCqoC4IVOZoXP7pp59u25MhZXTIIYe49BNOOKGgHi5uueUWl4/7hvUmP0QTwbpFXv/+/SNYY8gDEUHw0uJ69dVXt9f+P59w+vTp42dZHBVbmbeKnn32WWsp4vjAAw9EsK6vueYa+wey/umnnwrqyzRC9PLLL0dTpkyJZKgb/fzzz/aLRHX+5S9/KSgfv2gqvnE9eu1/VqodDaiOejqSyObh08AwTT/IOIJ0KhEQjF/vmWeesdVAIEjHN+1XX31ViSpX5o9//KPTCTIoJeuss44tA9LFEExl8uTJru5qq61mX1LNwxGkKfNLtl/XX3+9y/r+++8jmWR2dUGmvuBl33zzzW0+rDmZAHfZMjEeoS3FQX58piBfC8rEvyUPvVZ9MleoSfY4ePBgp2vHHXcsIqJ33nnH5Q8aNKigblMv8MWi/X/ssccS1TQV3ySFL7zwgmt35513TiqWq/SQRMbJfvmUpolODGuZ559/Xk9Tj4888ojLx4+RbrXVVvYak88QTEBjwr8aEQvKFT/mmGPcuZ68//77BitcEBnmGSFhzbKTxnoh1prB5LUvHTp0MGJ5mWnTppmjjjrKZeHHVJEGweT6qaee6vJwAj0XXHCBTRPiNGL1uPxrr73WCKHbayE0u3CBhYy4iBVpOnfu7JK1b/pTgvK2GiEm+0PPKLTZZpvZhQ2xSl0dnCi2OO/UqRMOzRZM7qssvvjielp0xKS8SjX4ap34UaxtmwRsxEKPZ/M6hgCJLAZIqUusYKm8+OKLepp6fOqpp1z+rrvuavCBhCh5+S+IK1jmRHXghYoTwqeffmpkYtitPGL1DuSh4pOaDNk0uei46qqrFqTJUMxd68vlEv7/BKt3WFmD3HrrrfYIElKCQ4LMNVrytpll/ilByTyfdXXYf//9DVZ7Idtss42RIahdPYyrUWyR3hR84/pwLfOPLlkJ1iV4J03F11PhTmUobPSLUIbuRuYMXR5PSiNAIiuNS0EqXBRUYLVUIj6RwZJRUavqo48+MjK0tMl4YWFNwaJJE32R4LoAgS+WDHeMzE3Z5XkZ9tr0HXbYwTz44IP2XP/5Fo+6gmhe0hFuEKoTFuUWW2yRVNS6cyBz0qRJRuaZDFwt1F0ApAqyq1SUyGTYajp27OhcUGSIZe8XrhWlRLFF3uuvv26LAFP4e/nuHaXqJqVpX5Cf5jPXFHyT2pR5QJuF533OOeckFWO6hwCJzAMj6dS3yGQuxMgkcVJRm46hmMw52XN8+OETpQInUAh0YMiJFwUvJhwr4fcEyypJlMhAfJA//OEPRlwVzP/+7/860oClhm9z+KP5gnsAKUBkdc00NjYaWXGzflggHQzf4qJWAdL9e4iXw3Xv3r1dskykOyJB4u9//3uXV8mJTx7ikmGr4MsE/U4b3im2qCBuENaagi74jAGXE088sZLmC8r4uPj9KigkF03BN64D1/Dnwx/kiCOOcM/MJvBfIgIkskRofs0Qvy1LNkiBFaTf9r+WKDzz59Fkib5gSOU7YOKn430rTCbW3XxUocb/XunQEn347rvvzBdffFFUDEQIB15xZTCwaFTwEt54442OCPCyyIKBdQqFZzqGm3jR1QJDPZ1vwzmsoTTBHBvIGCJuAwUYAYNqRAnbrwNn1HLiY4uy/v3jWlYjcahKfB1LLrlkYt2m4FtKmVpjsLr1vFQ5phUiQCIrxKPkFayqhoYGl4fhU5r4ZBAfUvlWg/h7GXEhMOL4aY8gHwzDksS3BGGVYTL9hhtuMOLGYWQ10WA+BX2F1Qiv/4033rjAwpOVPiOrp7YcrBSfHGBFXn755XYi/U9/+pPtwttvv+26Ak/2coJdBhDMF/lDOSW4cvU1X4fOeo3jmDFj7DNI20XgYwsrd88993T4yoqvm2fz9ZY794kszSKDnmrxjbctTsMG82MQLOaIW0q8CK+TEAi9fhtyyTV033398D8SDO2fbLNxWWIZRfAvkpfIpe22226urFg+Lh0ncBuAnu233976cBVklrk49thjnd4333yzZGks28PRU/t64IEHliyHRPjEvffee5HMmVkveiE2Ww9HuI+o64Rs70nU4WforoV99tknkuGu6wN8s6oReYld3UsuuSSSVVR3LcPxSF1Z4jqffvppVw5+ebUQ+PMplnCxqEbK4evrgi+g+h3CZ893Y/HL5fk8JBfQIpNPaSXiD61eeeUVVwUrhfj2xMqailoy2OgrTpKabI9qNWD4J75kBXnlLvzJbH81za+HCXlYaSriJOtcIDRNj7DeYC3BckE5nUPC0PW1114z4pNmi/qrgVo3fsRQV8jVJmOPqL+RupwFG9flT+ZjkUH82uwwGOWwnxLzguKoHK9mVzg1EdMBtRDfItO5yUr1lsPX14O9sxiSQ7B3M74q7ZfleTECJLJiTEqmYFUKLz1EiQw+Uw8//LBNwyohXji80GLl2LRtt922YPkeiUpktkCV/3wiw0JBkqBdnU/DPJy/gppUB+lwE1HBiir8tSBYUfXb1jL+EfNv6vclHul2FVXzxalUTys6+kSGaBMQrN7pkBdzidjYHb+v5mCb1DGfyOJzcEl1ktLj+Go5PCOdD8MXFDauU6pDgERWBV6wBCBwncDE8RlnnFFQG5Ed8ELDooFgziQuIDqIP98VL5N07b9UpeaRtB7mqJRUkAYyAMnCJwwkkCS+jxysMRn+2qLQBYstSaAfq4QQWGK6goeVUcjYsWPNfffdZ88r+ecTGSwwFfHsN6eddpq9RJsgTH8+UrFFgabgq+34Rx/zNIusKfhqO3//+9/d4giirMR9+bQcjykIhB5zhxwXh+57XD/2JAqU9k/nj3AtL65L13wcsccvLtg/iDwJIRPPKnt9wAEHuHbEvSOxPDaaaz8w3yUk4q7Fx6xoaw8UYU5GN5DLpLbbwiSLHLauhMCJhMCL2pRVV3sv2t5dd93lymDvqKbLy5m4vUuIPxIiiC699FI7b+jPS8mChtOnJ7KQ4fTiOWjUDH+D/3/+8x8t3qzjZZdd5tq67bbbSurCXlS9z2rxBX7YF4r6wB1zky1VQnJB+TVtQZjyXwRgYcH0x7e9br3BKiMsDgwb4JyqgvkR9XbXNBzVkkKsLfhFYYgINwr8wfrAEd/8aAcuEfCf0vkefwvO0KFDrYUVd1WQMD8FTpSywdvOgUEXVvzgdoEtNIiThj5CZOO69VmC4ygElo7qvfrqqw1WVxH/C0NNWA/ygbTlhEztliXM70Awn+XPFe6999425hmsV1ixuBdYhVilVVcG3O/BBx9ssGIHwSqub5EhPy4Sesf2B7HI8Bxk/6qRTeEOW5SHZSwLHXZIrLjqERYzcF933XWNLMyYJZZYIt6Eu/bnMZOGllgdbiq+2PEge0Rte4cffjiDJzrkqzwJzf4hWTh030vp11hZArP9FkXECYgQk/tWRh5C6ZQShH7RupUesWoH8aNfoC6sHPnw2xVCWGEIFeTrHDhwoOsCVvSEPFy+zPnZyBOI2CDzaS4dVhkiP/iCOGRCeq4MQtnoCpu2B2tC/Of8avZcFj4icc51dVEeViI2hsN6ka1ELg/lsNInc18uTRYginQiQYaWkRCrKydboyLEPNP+VHqUhYwoaQUY7fjWISzGJGkKvjLv6DbkAz+sILdkCckF8OgOKiE7H7TjCcplRdC9LHiRsGyucthhh7k8sZg0ueAocyCuTKUvG0gD8txzz1VUFyF5EAMsLnBb8IfE8fbhtoE2SglcNHzS8euK9RYhFleSyNxbAYn6df1zcdC1KsTh2N2nH7Qwrh/RLrRPGN6LL5yr5+tNOweJp4XIQcBIrY+wQ2lSLb4I6qi6EZCxpUtILiCRVfnpQVgbWb208blkL2JBbVgy8KWSoVGEWF2lRFY3nQUkQxqrC9aJbAGKxA3Czjch1A9eYMQlg3UiE85OFYIPIsAjgg/K8NO9CDJktfHGzjzzzEiGY658/AT+brJIEcl2JVsXPmIgAVgbMmSOFy+4BsHAL03bRf8RMwsx28oJLLODDjrIEY++wLD0YKXG55+AhewWiECCaYK2YZlqvDfZVG7vCwSFeb0uXbpEeIGgT4a6EeYZEQMNGGA+T1Zk09TbPERphcWEOGXlpBp80Q+Ec8KXGyzRli4hiawVwJMPVTCRyWI7h4RVL8yNtARBiByskJXyvAacWFFL2xOIfPEbTu0AAA2KSURBVAj8zJorWFHESiTm3nReq1KdcFfQuapK66Ac2sTcFFbX5AWvpqqti72dwA9tw1+qVpEq0BG4Muh96RxgVR1MKKw6E7JLJperg+1peHb+nGBJRS0kMSQXcLK/CR8SbO7GXynB5HAaiaFOLQhM24a/WFOJoCkkhnbRpvrUaT8qPaKuHymi0nqVlgN5VeLAW6k+LdcUrMrVwRfP/EJiimOoI/3IQiFLvUSACGSGAIksM6jZEBEgAqEQIJGFQpZ6iQARyAwBEllmULMhIkAEQiFAIguFLPUSASKQGQIkssygZkNEgAiEQoBEFgpZ6k1FQCOEpBZiJhGoEAESWYVA1VMxbNaWqLR2UzQ2aiN0jv5OJnyXxKPdhszWn3LDT6khtDX8q+D/hs3n2DSNOiiLHyqBYyp+wxNBEUeOHOluF7HI8JuS2PAN/y/8XiRCWssOBiN7O43s8XTx11ylhBM40mLDN4JNwpEWm7ZxH0mCDfCV/OITHEtxj9h8jlDeSYKN7/jBFWzyBhbAAOHBJapuUhWm5wWB0NsiQm5LCN33etSPLUvYLiOfr7J/2P4iscnstqlKymsZbBxXEaIs2w72O0qQSa1S8oh9kPoL4tqOHhGWJy4IjYP+o0zar4YLOUUSSNL1UXZbxFXZa2xF0hBK2q5/xFYr2XFQsi4Ta4NASC6gRSaf5jwJQsn4wf6079guhJBCGiYI6fC+h5Xlh//R8klHeMbjhzpUYP1BJGKF/Vk3RC9FaGxYZtjFAEGfYA0hxE8pwZYsieNv/MCN/vYhhNyRCBsFVRFmSF4fm4YfRYElFReE1sYvNOkPdiB/+vTpNhySXxaBJhGCyf/hEnjUwxpVgeWHMEUI8U3JIQK14dpkLSFZOLnVlpuDIITyYkcyJIoQLUJ+dTuS+GXuhhGWRz6G9k9CTNt0WBuaJr+4FEn8MRvkED/QgeCHKIcN6ghZI8TldOEEm65RFz+WEhdYMLCWEAoHZYQwIyGSeDG7UVvbRxBBhDzCBnVE1JDhna0rQ+KCuqWsNyE8p1t+OzOSYbK7L9WPo/yMnSuHE99iQ2QQBJrUjfgIvyO/c+D0SAy5spvnC5TzomIEQnIBo19U/Bjqv6AfFgYvpEZUQDQNvOAYqkks/qpuRObGbF0JHJlYD8SEaBNoIx6OBuGElGRk/s2G2vEVSVBGl3/88ce7LBCO1tMj2gBxIkYZYpppulh3NhqJXvv3iF9w0nRE+hCLy7WhJyA1+cEPVy5+D1qOx+YhQCJrHn7zRW3EzcLPiOGlxYuNn4VTkV8kt+mV/qyb1sNRgzUi9lqaIJAk2sZPwamASGV46wgiHvZIy6nFBPLSUEI6P4ZQQRLlNkKYIiUk/4gAkbAwJbKKzUc5X/yf0CsXT0xDALVv3z5CCGpKbREISWScI5O3Iu+C1UCEe9bwQEJcBj8Lp6LRIJoSJUPnwbDilyRof9asWTZb+4AL/LKUzrEhpLQMF0uq0J+hgw6sVCIUj7xCtizm+S644AIbCjsecURii9l5N4QC1x8GwQqsCnTovB3K9O3bV7NKHvFLTRD8WLH/a/ElCzOxrhAgkdXV42haZ/CL4zKEspXhPoF4/r7oT7khbj5+5g2CFx+uFXBdSBOQCiSNyOD6oL9hIN+6Th36peIvIGiaHvEbAXCFgPz1r3+1vyWgixb6y0iIZQU3CfyCOggJJDl8+HAXBkd/bcn/PchPP/3U3a8Eo3SLE9pu/IhfjdIQS/rbpPEyvK5PBBiPrD6fS8W9wg+G6G8iYiVQYtcXxUNDgD8IfjQFhIGYYEpgiJ2GQIc+AfiNq2WEAID401hrsLxkocHgx0n0x3JhMUkUWFsdVhryISAHn+BsovcPK6L4oRL0fcyYMdYigz8cCFj7juLwX/N/fNhTYRDsEuJbZP4qJfzgygnIs2vXrtbKI5GVQ6u+8mmR1dfzqLo3J510krM6TjjhBIMf542L/+s/sLCUxFAO5IShVJKoRYZ8uFxgyAoHXJAWyEdJDOQICwlDQYhv7YFE1MKymSX+weKCwFLErwppUEK/77ZAwj8dWvouFT6R+QSXoMImyyqtPZLI0lCqvzxaZPX3TCruEbzY8WvnEInh736JO67At2rw024oiy1CsITgXwX/syRRiwz5GKrhTwUWIHzK5NeQTO/eve1PommeTwSwcsoJrC0V+H0pkcGKBPGWC+OtQ2bVgSN+Uk/Fvw9NK3XU0N1p5F6qHtPmLQIksnmLf5Nbh6WESX0IrCHMLSVZPUpkmAPC0E0n8Ctp3LfIYIFhLkzn4zAcxWR6qd+F9IkAFlw5gSOrChYnlMiQhv6nOfWC6HQe0Lc28VuTKtBfCaHqooXO2Wl9HusbAQ4t6/v5JPYO3vBKKFj1S1oRhAIlsm7dulVFYqgLqwsCK04cSc2ECROMONVaPbCc8KOypaydddZZx9bDP101dQklTsaPH29T0R6GsD6RlRte+taY9hfKfCLDUDcusBqx8glyV1FCLfXDMlqGx/pDgERWf8+kbI9mzpxpBg8ebMthI3ep7Tu+EiUyP63Scx3SwepTkZ+cM5dccom9HDFihMHcXFywMVvrTJ48OZ5dcI2FA0z0Q2A1gvi0LtLK9V/nx1BW+4tzWHHYugUBCcdFfsPT4Ne98Cvx+NV3ELJuUUpbnIjr4fW8R4BENu+fQdU9gAWmQyCsGiYNKVWxujBgvqlawTwaBKujvqAPiIoBke1NRS4fWN3UuTdE0yi1P1T1IQKG6u/Xr59N9smpXL99i0z7q7rlR5PtKRYl8AXgy7777msXJ9A3WGby+5KWNKEDfm+U/CBAIsvPs7I9xQbpv/3tb/YcYXR22WWXsneg81xKfmUreAWUGFDXn39CEVhl6AMEVlrcNUK2+tg8WGTnnXeePY//k72Oti7SMYcFx16IT2Q6AW8zSvzzy2p/tdgRRxxhT7G4oVas5sHygyWGFU3MsQ0bNsxm7b///ok/96d1eawvBDjZX1/Po2xvlBxQsE+fPq48XkSdS1JfMc1Ui032RNoXF/nya+T2D46kOAcZYJUP80pwl4AnPESHahh2YcVStu+oWjt/BpcLuHxMmjTJyHYgI9ug7AomCjU0NNg+3nnnndZig0UE8sMOA5AiIk5gjg0uIBDk6RyX3gvS0yb6kZ9GZBh6NzY2GtlkbokWMdD8oTDmDUFmsj3J+q9Bn+KFc0pOEJAPaFAJub8qaMfrUDkiX+h+Svl42f2H2D8Zj08m80uRzFFF4v1u70JC3WC/T1V/Rx11lK0r4XlcPdluVBIVxPpCDDO0IWQYyeS5KydDxkgsLadDLCYbbULI1KWhHiJ0+IK9nUhHeRla+llF5+KG4nSJX11RPiJydOjQwZbBHk6xuCKZ27P9lKF5wX5QxemUU04p0sOE5iEQkgswwRlUQnY+aMfrULlYXQVEpi9d0hGboCEy9+Ne9KSy8fRNNtnE1h0wYICtC4LCJvAkwSZ1JVmE8/GDFIp1FYnrRmIfxA8tEqusQLXsELDlxTIsSC91MWPGDKf7f/7nf0oViWR4G4H04/fpX4svXNS/f39XBiRHqR0CIbmARFa755SJJglAGIn3unvZ9EVElAhER5WhU4SYXwjjM2rUKNsnWGaw0lAW5cT73kZr7dmzZyQOrVGvXr0ihPoBaSEuGaLQarwuRKxAecQxKyejR492McKuv/76guIgQegWx1fXd3HpiGBByWJEQVlcSNDEqHv37pGE6y7KK5UA3bA8p0yZUirbpiFCCCw/jawBPICLDC8j2S8ayVyijXqh8dsQWYNSOwRCElkrdFMeaDDBPMnYsWPtMreEWgnWzvymGPNNmNvCViH86VxWEg4alUI3RSeVa266WEd2czcWAXwXCl8v9kViXkxdI/y8LM4xLyjBF21TmAuMY4LFEUS/6Nix4zzrYxY4ZN1GSC7gZH/WT7NG7WFSHX+VSvxlrbReteWwAohoFmmi5JtWJmQeFjsQIjtJsOBQas9qUnmmz3sEFpj3XWAPiAARIALNQ4BE1jz8WJsIEIE6QIBEVgcPgV0gAkSgeQiQyJqHH2sTASJQBwiQyOrgIbALRIAINA8BElnz8GNtIkAE6gABElkdPAR2gQgQgeYhQCJrHn6sTQSIQB0gQCKrg4fALhABItA8BEhkzcOPtYkAEagDBEhkdfAQ2AUiQASahwCJrHn4sTYRIAJ1gEBmm8YR333IkCF1cMvsAhEgAvMCAQnMGazZ4ESGn/ZCGB//dw6D3Q0VEwEiUPcIgBNqLcHjkSE2uwTnK/rhilrfCPURASJQ/wjg90LxOwq1luBEVusOUx8RIAJEII4AJ/vjiPCaCBCB3CFAIsvdI2OHiQARiCNAIosjwmsiQARyhwCJLHePjB0mAkQgjgCJLI4Ir4kAEcgdAiSy3D0ydpgIEIE4AiSyOCK8JgJEIHcIkMhy98jYYSJABOIIkMjiiPCaCBCB3CFAIsvdI2OHiQARiCNAIosjwmsiQARyhwCJLHePjB0mAkQgjgCJLI4Ir4kAEcgdAiSy3D0ydpgIEIE4AiSyOCK8JgJEIHcIkMhy98jYYSJABOIIkMjiiPCaCBCB3CFAIsvdI2OHiQARiCNAIosjwmsiQARyh8D/Ad78u6wI2RqRAAAAAElFTkSuQmCC",
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "ImageModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "ImageView",
-       "format": "png",
-       "height": "400",
-       "layout": "IPY_MODEL_50bd83bb64f747538455f07b1c403130",
-       "msg_throttle": 1,
-       "width": "300"
+       "children": [
+        "IPY_MODEL_a1e428857ed543d0bcd12419a140b9a6",
+        "IPY_MODEL_4dae83cdf2c14744a15b7afe4afbdf18"
+       ],
+       "layout": "IPY_MODEL_2eb456965b8e44399ea612590a08e244"
       }
      },
-     "6716ba9736a74e4a957e91902a418922": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "ProgressModel",
+     "52a07264d52e4b0fa37bc6b341555e12": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLMathModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "ProgressModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "ProgressView",
-       "bar_style": "",
-       "description": "Loading:",
-       "disabled": false,
-       "layout": "IPY_MODEL_a4121d5b20b24abca54c26f690b8582a",
-       "max": 10,
-       "min": 0,
-       "msg_throttle": 1,
-       "orientation": "horizontal",
-       "step": 1,
-       "value": 7
+       "description": "Some HTML",
+       "layout": "IPY_MODEL_6b2683b0184146fe9bad3e56c2339ab3",
+       "placeholder": "Some HTML",
+       "style": "IPY_MODEL_2a0afd8e637c4f809c1da6e1449f56bf",
+       "value": "Some math and <i>HTML</i>: \\(x^2\\) and $$\\frac{x+1}{x-1}$$"
       }
      },
-     "675671fd9cb84dabbc494684c8563ca9": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "53e9cff815544fd2b7cf21f623ea3d5b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
+      "state": {}
+     },
+     "54ef622958f44411a0e3dd9cc1b8512d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "description_width": ""
       }
      },
-     "6bfc0caf794b4acfa60c1e2cc5a24d2e": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "580272bd24304a27901acca042999cb4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
+      "state": {}
+     },
+     "586c578b082049069483c78be61401b8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "592cd261e1e14f70b59e056dda9f9f20": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TabModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "_titles": {
+        "0": "0",
+        "1": "1",
+        "2": "2",
+        "3": "3",
+        "4": "4"
+       },
+       "children": [
+        "IPY_MODEL_5bc370f1b4cd4c15af7e9c2b99013fd8",
+        "IPY_MODEL_9902d30b0c7e466082e946aad58713a7",
+        "IPY_MODEL_c9aab996feee474396da46870ded182e",
+        "IPY_MODEL_fbd6a8d0fcfe47ca9d613460ce04c7ac",
+        "IPY_MODEL_1dcd36317f414f6d979a0a80c0658a20"
+       ],
+       "layout": "IPY_MODEL_98f35b3048fb4ad4b97830813b8c56a9",
+       "selected_index": 3
       }
      },
-     "6e06309ba65e41e4ab9a287ec3036d9c": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "FloatTextModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "FloatTextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "FloatTextView",
-       "description": "Text:",
-       "disabled": false,
-       "layout": "IPY_MODEL_f2c8d102cd5342b99e42685c2da1058b",
-       "max": 10,
-       "min": 0,
-       "msg_throttle": 1,
-       "step": 0.1,
-       "value": 7.5
-      }
-     },
-     "6e182a69a1cd4a4194639cee8d84099a": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "5930139c8f4b45ad812a21f336a511ae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "DropdownModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "DropdownModel",
        "_options_labels": [
         "1",
         "2",
         "3"
        ],
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "DropdownView",
-       "button_style": "",
        "description": "Number:",
-       "disabled": false,
-       "layout": "IPY_MODEL_3404dfa67d2e4536bb9f64014724d5f7",
-       "msg_throttle": 1,
-       "value": "2"
+       "index": 1,
+       "layout": "IPY_MODEL_8abc66a1d21a4143aba20affe2791893",
+       "style": "IPY_MODEL_b640344b4ce9483f8c1eb1accec5b31b"
       }
      },
-     "6fe505cb796242c9af5949d296e7d047": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "598af5eb6dc4473cbfbc8ecd10ad9538": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5b5bee1cf34d4c2c9745f6c1eb265dd9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5b71ec56890c41ea92ab28931f29b356": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5bc370f1b4cd4c15af7e9c2b99013fd8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "P0",
+       "layout": "IPY_MODEL_c83be8eed1b24f529cd630ba7849bff9",
+       "style": "IPY_MODEL_e5c506e01fb949ebbbd882ecaa6cca11"
+      }
+     },
+     "5d6dfecbdce94630a5b976743886caae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_9a904164751944739c0e8354a2d31f2c",
+       "style": "IPY_MODEL_638d66bac51d431283079fc13cf54471",
+       "value": "0"
+      }
+     },
+     "5dbb57473ce442be95ed0a07b5e89f56": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5eb2135b7b90441ca147dcdb423e11b3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5eb2f6edffbd420a8c6e64671c9ffcf5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "609fc788fb2041ddbdbea60833f7badc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Any:",
+       "layout": "IPY_MODEL_7d54d02236f04723b37ad56a860ab45a",
+       "step": 1,
+       "style": "IPY_MODEL_df99f53bcb5c4406807811a16321a6b2",
+       "value": 7
+      }
+     },
+     "62dc35d98b124fbb860cc71433f1374d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "638d66bac51d431283079fc13cf54471": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "66108e24c03d4e0a8496d0f7b88b9c5e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "674c413e5b6d4535b65ff2b11a831c35": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "68cade49753a451ebff709ea1bce25b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "69607ad701a740729934cc824ae60b82": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6a25c30366e84c8c82f5aab0eaefa780": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6b2683b0184146fe9bad3e56c2339ab3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6df3a3fe02bb4149a2bec37be4a3666e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SelectModel",
+      "state": {
+       "_options_labels": [
+        "Linux",
+        "Windows",
+        "OSX"
+       ],
+       "description": "OS:",
+       "index": 2,
+       "layout": "IPY_MODEL_6a25c30366e84c8c82f5aab0eaefa780",
+       "style": "IPY_MODEL_1e325582b42744cea09cbef4861791d1"
+      }
+     },
+     "6f10ef0d2d2242e7b04af8e0bd343724": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "71842466a7c3448881c37c5f88460b15": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SelectionRangeSliderModel",
+      "state": {
+       "_model_name": "SelectionRangeSliderModel",
+       "_options_labels": [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec"
+       ],
+       "_view_name": "SelectionRangeSliderView",
+       "description": "Months (2015)",
+       "index": [
+        0,
+        11
+       ],
+       "layout": "IPY_MODEL_580272bd24304a27901acca042999cb4",
+       "style": "IPY_MODEL_9124f145f2cf4c7e8bee6214f80b4785"
+      }
+     },
+     "7193b362ed0f4200a01d8c71095fe25d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextareaModel",
+      "state": {
+       "description": "String:",
+       "layout": "IPY_MODEL_62dc35d98b124fbb860cc71433f1374d",
+       "placeholder": "Type something",
+       "style": "IPY_MODEL_038eb3f451d74fa485a78b19d7ff6c98",
+       "value": "Hello World"
+      }
+     },
+     "73b095f2a6f444a8b4e46ae881920624": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "787d731d70ad4a2b86d2ef88a1344ee8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_49f0fdfe199c4ac4b776b8d8ca75c039",
+       "style": "IPY_MODEL_a9cdef23ee394ed0adcc647df833b53e",
+       "value": "3"
+      }
+     },
+     "795e4e83becb46cb9e2ce6568b3e52ab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_73b095f2a6f444a8b4e46ae881920624",
+       "style": "IPY_MODEL_dde741b0a4064eaf8c22dc856f005050",
+       "value": "1"
+      }
+     },
+     "79db6a6169a8408ebb5bb548ef4b244e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b2c8a53b2934f03b131ab2a4e94803d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b7607f095fc4840842fee5b9eea53e5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7cfdb695c61941959b405c0bd1dd0e28": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ColorPickerModel",
+      "state": {
+       "description": "Pick a color",
+       "disabled": false,
+       "layout": "IPY_MODEL_e6ff9a77a66d4d479e62aadcb457a502",
+       "style": "IPY_MODEL_69607ad701a740729934cc824ae60b82",
+       "value": "blue"
+      }
+     },
+     "7d54d02236f04723b37ad56a860ab45a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7dcdfac1330d4037b37c55d940d351b0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7e05e4f80924449fa7ab690f4aa09d95": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8090e9058047406c9192f1f87605f75e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatSliderModel",
+      "state": {
+       "continuous_update": false,
+       "description": "Test:",
+       "layout": "IPY_MODEL_91584febed5b40928a2c4a25ef2bc05b",
+       "max": 10,
+       "orientation": "vertical",
+       "readout_format": ".1f",
+       "step": 0.1,
+       "style": "IPY_MODEL_54ef622958f44411a0e3dd9cc1b8512d",
+       "value": 7.5
+      }
+     },
+     "8158b0907516446fa7b61b36f864af58": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "819aa731a0ee464c94c65d8da1924c2d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "823c6dd9efad4992aeb019b94f63d15b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "RadioButtonsModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "RadioButtonsModel",
        "_options_labels": [
         "pepperoni",
         "pineapple",
         "anchovies"
        ],
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "RadioButtonsView",
-       "button_style": "",
        "description": "Pizza topping:",
-       "disabled": false,
-       "icons": [],
-       "layout": "IPY_MODEL_d013d8c173114f46abfa4269e5331f4d",
-       "msg_throttle": 1,
-       "tooltips": [],
-       "value": "pepperoni"
+       "index": 0,
+       "layout": "IPY_MODEL_f0c52cce43074ccc9df9b73dba0f403d",
+       "style": "IPY_MODEL_aacf8ac27d0440e2bc2f5e1da35ec6a7"
       }
      },
-     "733615a32c09455baca0bb96342768f5": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "82542873f571491380be494d9b9721f7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "83a3e44999d94577bf97972fa6b8fadb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
+      "state": {}
      },
-     "78582a251f4b48e9b6a4fb0b79e318f6": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
+     "847242b521014f4898f9037b01b78b98": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntProgressModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "786e43e0ce2c44b99d13cbaf5569f637": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "TextModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "TextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "TextView",
-       "description": "String:",
-       "disabled": false,
-       "layout": "IPY_MODEL_c0474bbb166a45cd8cc596428e418d03",
-       "msg_throttle": 1,
-       "placeholder": "Type something",
-       "value": "Hello World"
-      }
-     },
-     "78808aec127a42a68cc8578100bdd20a": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "IntTextModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "IntTextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "IntTextView",
-       "description": "Text:",
-       "disabled": false,
-       "layout": "IPY_MODEL_0c1d7e6695354a2a958b21f255b7f29b",
+       "description": "Loading:",
+       "layout": "IPY_MODEL_ca77f11b03e342789d260d79acfcddc7",
        "max": 10,
-       "min": 0,
-       "msg_throttle": 1,
-       "step": 1,
+       "style": "IPY_MODEL_c5211ce5f43d4bde800dee7cecfb526a",
        "value": 7
       }
      },
-     "7d73679710a4455c9c7609beac8da45f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "SelectionSliderModel",
+     "86125fedf2574c9b9c3316531abf8660": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "SelectionSliderModel",
-       "_options_labels": [
-        "scrambled",
-        "sunny side up",
-        "poached",
-        "over easy"
-       ],
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "SelectionSliderView",
-       "continuous_update": false,
-       "description": "I like my eggs ...",
-       "disabled": false,
-       "layout": "IPY_MODEL_e807bc5903d3417bae8a4177e5b9c521",
-       "msg_throttle": 1,
-       "orientation": "horizontal",
-       "readout": true,
-       "value": "sunny side up"
+       "description_width": ""
       }
      },
-     "82a43dac4690465d9e8e66808ecdcc2d": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "8656dfd33b1c46bfb3ebe65071038b84": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LabelModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LabelModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LabelView",
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_a23626e48aa540d7b1117407ce9ad480",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": "0"
-      }
-     },
-     "887e65a5714e483798a9b84f0d936a52": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "IntSliderModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "IntSliderModel",
-       "_range": true,
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "IntSliderView",
-       "continuous_update": false,
-       "description": "Test:",
-       "disabled": false,
-       "layout": "IPY_MODEL_f77c3280ee964579ae59ebbc8e39780e",
-       "max": 10,
-       "min": 0,
-       "msg_throttle": 1,
-       "orientation": "horizontal",
-       "readout": true,
-       "readout_format": "d",
-       "slider_color": "white",
-       "step": 1,
-       "value": [
-        5,
-        7
-       ]
-      }
-     },
-     "8acf995f75ad4ddc86fa68ca00fd92c8": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "ToggleButtonModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "ToggleButtonModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "ToggleButtonView",
-       "button_style": "",
-       "description": "Click me",
-       "disabled": false,
-       "icon": "check",
-       "layout": "IPY_MODEL_902d582f038a48cbbe9437c0e980c657",
-       "msg_throttle": 1,
-       "tooltip": "Description",
-       "value": false
-      }
-     },
-     "8bceaa69a7a54522acf296c855079463": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "8c3fe85543944693831dd00b1c7e939f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "8d4e103dd42842dfb600d4db46352852": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "8eb44729a8c04a41a6ed6bc20724afc8": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "PlayModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "PlayModel",
-       "_playing": false,
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "PlayView",
-       "description": "Press play",
-       "disabled": false,
-       "interval": 100,
-       "layout": "IPY_MODEL_209bfbc1dbab45ccaffdd3f14f9b0b0a",
-       "max": 100,
-       "min": 0,
-       "msg_throttle": 1,
-       "step": 1,
-       "value": 50
-      }
-     },
-     "8f27c5c75ba24ab888f82bcc4f10ebe5": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "902d582f038a48cbbe9437c0e980c657": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "9588a3f4aea842a689483210e3e85af1": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "TextModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "TextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "TextView",
-       "description": "P3",
-       "disabled": false,
-       "layout": "IPY_MODEL_3dc0d036b79f4356b66804e5350e5f1c",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": ""
-      }
-     },
-     "976e5fe5e6dd42f4a2a5446d3da4ad0d": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "IntSliderModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "IntSliderModel",
-       "_range": false,
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "IntSliderView",
-       "continuous_update": true,
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_82a43dac4690465d9e8e66808ecdcc2d",
-       "max": 100,
-       "min": 0,
-       "msg_throttle": 1,
-       "orientation": "horizontal",
-       "readout": true,
-       "readout_format": "d",
-       "slider_color": null,
-       "step": 1,
-       "value": 0
-      }
-     },
-     "a15bf7e4a11c4fd2bd7befcd22954b2b": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "a23626e48aa540d7b1117407ce9ad480": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "a388a02e48954671b68dc718f299bc2f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "HBoxModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_8eb44729a8c04a41a6ed6bc20724afc8",
-        "IPY_MODEL_418b7b263f654ed9af540ff708571f51"
-       ],
-       "layout": "IPY_MODEL_b9bf797e9f414fb69bf8104be73f9516",
-       "msg_throttle": 1,
-       "overflow_x": "",
-       "overflow_y": ""
-      }
-     },
-     "a4121d5b20b24abca54c26f690b8582a": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "a7e2b9cc83b647cea830e0bf9c99a446": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "FloatSliderModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "FloatSliderModel",
-       "_range": false,
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "FloatSliderView",
-       "continuous_update": false,
-       "description": "Test:",
-       "disabled": false,
-       "layout": "IPY_MODEL_675671fd9cb84dabbc494684c8563ca9",
-       "max": 10,
-       "min": 0,
-       "msg_throttle": 1,
-       "orientation": "horizontal",
-       "readout": true,
-       "readout_format": ".1f",
-       "slider_color": "white",
-       "step": 0.1,
-       "value": 7.5
-      }
-     },
-     "aa14e7ac85aa42898abc65809702244f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "b3f69ae7d10b4dd7a64ed26c47cd047b": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "b59af7d27c594924957e1aa26257751f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "IntSliderModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "IntSliderModel",
-       "_range": false,
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "IntSliderView",
-       "continuous_update": false,
-       "description": "Test:",
-       "disabled": false,
-       "layout": "IPY_MODEL_0c5f090e8288472f80cc7661fcad30b2",
-       "max": 10,
-       "min": 0,
-       "msg_throttle": 1,
-       "orientation": "horizontal",
-       "readout": true,
-       "readout_format": "i",
-       "slider_color": "white",
-       "step": 1,
-       "value": 7
-      }
-     },
-     "b6253d1f165f4a689836ddbdab177a05": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "VBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "VBoxModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_fd8e8ff9da1f4b028003c9afc4f9410f",
-        "IPY_MODEL_165e9979258c48fd829666b0ba7aa7ca"
-       ],
-       "layout": "IPY_MODEL_07e24822058240ba862e20fa6cf02a27",
-       "msg_throttle": 1,
-       "overflow_x": "",
-       "overflow_y": ""
-      }
-     },
-     "b6ac090042a54f00ac29523e2eaa6cd3": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "b77e51cc846d49128532716088e935ad": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "b7a3a5eb23cf4b04a59db57f8046bbc8": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "b9bf797e9f414fb69bf8104be73f9516": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "ba868fda4d02439a8deb8b680ce80cb9": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "8717ac2d097441e9bd4978443f6da52f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "HTMLModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "HTMLModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "HTMLView",
        "description": "Some HTML",
-       "disabled": false,
-       "layout": "IPY_MODEL_e27db74b160b486c8e26c70af357c1a4",
-       "msg_throttle": 1,
+       "layout": "IPY_MODEL_38e92957ff814f648355507fba1efdc2",
        "placeholder": "Some HTML",
+       "style": "IPY_MODEL_8158b0907516446fa7b61b36f864af58",
        "value": "Hello <b>World</b>"
       }
      },
-     "bf0e7471d56b40389ed58a513ad7852b": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "VBoxModel",
+     "88f65ff1addb428290726c11935e6ad3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "VBoxModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "VBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_016ea837a5d242c3840091b092e51f2d",
-        "IPY_MODEL_0b2631a5ca9f45e59278df4f59394281"
-       ],
-       "layout": "IPY_MODEL_5694e208e8484e84b6cb9b3912fa355a",
-       "msg_throttle": 1,
-       "overflow_x": "",
-       "overflow_y": ""
+       "description_width": ""
       }
      },
-     "c0474bbb166a45cd8cc596428e418d03": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "8abc66a1d21a4143aba20affe2791893": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8c203e0890c84b1e9548f48d9c341760": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "description_width": ""
       }
      },
-     "c056cc916b2e446dbb1692ee68810233": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "ColorPickerModel",
+     "8d8c7442599d4b66a1bdc4d27cfa0b07": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "ColorPickerModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "ColorPickerView",
-       "concise": false,
-       "description": "Pick a color",
-       "layout": "IPY_MODEL_b3f69ae7d10b4dd7a64ed26c47cd047b",
-       "msg_throttle": 1,
-       "value": "blue"
+       "description_width": ""
       }
      },
-     "c063c53a85a442f78ef47c9f62a83b8d": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "SelectMultipleModel",
+     "900a279374724477aa598b64f8b23103": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntSliderModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "SelectMultipleModel",
-       "_options_labels": [
-        "Apples",
-        "Oranges",
-        "Pears"
-       ],
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "SelectMultipleView",
-       "description": "Fruits",
-       "disabled": false,
-       "layout": "IPY_MODEL_3d64356313794db080d8cf770efcd8d3",
-       "msg_throttle": 1,
-       "value": [
-        "Oranges"
-       ]
-      }
-     },
-     "c48163ca474341139e4cbeb0374f1d28": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "c96f1b7c2637417285865c724b2364ca": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LabelModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LabelModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LabelView",
-       "description": "Some LaTeX",
-       "disabled": false,
-       "layout": "IPY_MODEL_53aea1b1788240b4a6fc7103923cbc61",
-       "msg_throttle": 1,
-       "placeholder": "Some LaTeX",
-       "value": "$$\\frac{n!}{k!(n-k)!} = \\binom{n}{k}$$"
-      }
-     },
-     "ca01d3151fc24e0d90b8d9d4b05fcc50": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "d013d8c173114f46abfa4269e5331f4d": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "d332c8df94ee42afb4d079dce40785f3": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "FloatSliderModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "FloatSliderModel",
-       "_range": true,
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "FloatSliderView",
        "continuous_update": false,
        "description": "Test:",
-       "disabled": false,
-       "layout": "IPY_MODEL_733615a32c09455baca0bb96342768f5",
+       "layout": "IPY_MODEL_c7bddd70abea43aabf018069af51ca53",
        "max": 10,
-       "min": 0,
-       "msg_throttle": 1,
-       "orientation": "horizontal",
-       "readout": true,
-       "readout_format": ".2f",
-       "slider_color": "white",
+       "style": "IPY_MODEL_7e05e4f80924449fa7ab690f4aa09d95",
+       "value": 7
+      }
+     },
+     "9124f145f2cf4c7e8bee6214f80b4785": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "91584febed5b40928a2c4a25ef2bc05b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "929f2abd63624e94ac29a8a7820ec245": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Click me",
+       "icon": "check",
+       "layout": "IPY_MODEL_83a3e44999d94577bf97972fa6b8fadb",
+       "style": "IPY_MODEL_9dcec744fdd544f08dcf299940f6abc6",
+       "tooltip": "Click me"
+      }
+     },
+     "96217540c98840768a45b109f8909b27": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatRangeSliderModel",
+      "state": {
+       "_model_name": "FloatRangeSliderModel",
+       "_view_name": "FloatRangeSliderView",
+       "continuous_update": false,
+       "description": "Test:",
+       "layout": "IPY_MODEL_e6d54404c45445269ebe04c4c148597c",
+       "max": 10,
+       "readout_format": ".1f",
        "step": 0.1,
+       "style": "IPY_MODEL_b34559b51e5a4f3bbb46771023b8b818",
        "value": [
         5,
         7.5
        ]
       }
      },
-     "d3a80abfb5a645558f4dfbd94304ffae": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "9645a3abd2394befa4880849ba14c439": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "98768dcd13004995a26343792098f450": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "description": "Click me",
+       "icon": "check",
+       "layout": "IPY_MODEL_c127f121f54c4edc93483af8793ec782",
+       "style": "IPY_MODEL_5eb2135b7b90441ca147dcdb423e11b3",
+       "tooltip": "Description"
+      }
+     },
+     "98f35b3048fb4ad4b97830813b8c56a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
+      "state": {}
      },
-     "d669c4295cbf4833b0c096e39129b22c": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "SelectModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "SelectModel",
-       "_options_labels": [
-        "Linux",
-        "Windows",
-        "OSX"
-       ],
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "SelectView",
-       "description": "OS:",
-       "disabled": false,
-       "layout": "IPY_MODEL_ca01d3151fc24e0d90b8d9d4b05fcc50",
-       "msg_throttle": 1,
-       "value": "Linux"
-      }
-     },
-     "e06b0e2dc4184c1b932d2377256f1699": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "9902d30b0c7e466082e946aad58713a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "TextModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "TextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "TextView",
        "description": "P1",
-       "disabled": false,
-       "layout": "IPY_MODEL_c48163ca474341139e4cbeb0374f1d28",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": ""
+       "layout": "IPY_MODEL_efda474ceb1944b3abf51813c9dd6806",
+       "style": "IPY_MODEL_0bd3f78432cd4db9acab71fe81d79918"
       }
      },
-     "e27db74b160b486c8e26c70af357c1a4": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "99105fe0a12842178af5bf34886763a8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9a904164751944739c0e8354a2d31f2c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9dcec744fdd544f08dcf299940f6abc6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "9f8ad824c2a34110a10af40c8e08daf9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DropdownModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "_options_labels": [
+        "One",
+        "Two",
+        "Three"
+       ],
+       "description": "Number:",
+       "index": 1,
+       "layout": "IPY_MODEL_cc60cf34ded446ff87a7156be8f8680e",
+       "style": "IPY_MODEL_82542873f571491380be494d9b9721f7"
       }
      },
-     "e3d375dec35c455d8029d9328d1a55a0": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "CheckboxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "CheckboxModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "CheckboxView",
-       "description": "Check me",
-       "disabled": false,
-       "layout": "IPY_MODEL_2344fbaf3fe341458e7781ec178d1ed3",
-       "msg_throttle": 1,
-       "value": false
-      }
-     },
-     "e47d8b43215e48d9bb8c532860d80216": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "IntTextModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "IntTextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "IntTextView",
-       "description": "Any:",
-       "disabled": false,
-       "layout": "IPY_MODEL_b77e51cc846d49128532716088e935ad",
-       "msg_throttle": 1,
-       "value": 7
-      }
-     },
-     "e5dcca0da2484a68a6d7d2c4b6204545": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "a1e428857ed543d0bcd12419a140b9a6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "LabelModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LabelModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LabelView",
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_8f27c5c75ba24ab888f82bcc4f10ebe5",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": "1"
+       "layout": "IPY_MODEL_10ca989ef6eb4c459266c44999d0066b",
+       "style": "IPY_MODEL_3f4d3d533ac1485d9261d15466ceb172",
+       "value": "The $m$ in $E=mc^2$:"
       }
      },
-     "e807bc5903d3417bae8a4177e5b9c521": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "a326834ae4984777bd48e84b0783e086": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_38dedb3a22f7455dbc369f897ffd9c11",
+        "IPY_MODEL_41078ec3634f4a8db9d2e97ee24cd40b"
+       ],
+       "layout": "IPY_MODEL_04a6c32fdfaf4e5186b95d48d912409b"
+      }
+     },
+     "a4bba5e46daf4b09bde561ead851e8ef": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a5669796f20942638b17f63d89f5a666": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatTextModel",
+      "state": {
+       "description": "Any:",
+       "layout": "IPY_MODEL_e1945b3d92f748e7b2267d7e6707029f",
+       "step": null,
+       "style": "IPY_MODEL_86125fedf2574c9b9c3316531abf8660",
+       "value": 7.5
+      }
+     },
+     "a8661e762bf14bf3a28d9a5255337543": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SelectMultipleModel",
+      "state": {
+       "_options_labels": [
+        "Apples",
+        "Oranges",
+        "Pears"
+       ],
+       "description": "Fruits",
+       "index": [
+        1
+       ],
+       "layout": "IPY_MODEL_451615e6cc664f1ca018e19c1ef76dc2",
+       "rows": 5,
+       "style": "IPY_MODEL_7dcdfac1330d4037b37c55d940d351b0"
+      }
+     },
+     "a8977af75efc4b5ea256e6135aa39099": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a9cdef23ee394ed0adcc647df833b53e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "description_width": ""
       }
      },
-     "e84e0f448b9e45ecbbcf969244e3a881": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "TextModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "TextModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "TextView",
-       "description": "P4",
-       "disabled": false,
-       "layout": "IPY_MODEL_8d4e103dd42842dfb600d4db46352852",
-       "msg_throttle": 1,
-       "placeholder": "​",
-       "value": ""
-      }
-     },
-     "e9b8104b92fd41b398562e22edffdb81": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "ControllerModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "ControllerModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "ControllerView",
-       "axes": [],
-       "buttons": [],
-       "connected": false,
-       "index": 0,
-       "layout": "IPY_MODEL_067da89376f04e298a72261d10c7650a",
-       "mapping": "",
-       "msg_throttle": 1,
-       "name": "",
-       "timestamp": 0
-      }
-     },
-     "ea82f97ebc8d4d11a41fb54b4c654a6d": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "aa68c9873a734057b3ae3bb3150e5b1d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
+      "state": {}
+     },
+     "aacf8ac27d0440e2bc2f5e1da35ec6a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "description_width": ""
       }
      },
-     "ec8b67763ae344279d46f3717f3ce3c1": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "acff2c29635946478ac8cee9d4d4ecf3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SelectionSliderModel",
+      "state": {
+       "_options_labels": [
+        "scrambled",
+        "sunny side up",
+        "poached",
+        "over easy"
+       ],
+       "continuous_update": false,
+       "description": "I like my eggs ...",
+       "index": 1,
+       "layout": "IPY_MODEL_79db6a6169a8408ebb5bb548ef4b244e",
+       "style": "IPY_MODEL_3588b17584d44b6f8bc0c2f6bb4d1995"
+      }
+     },
+     "b018e1cfbaaf4feda8e277c5b27cc4ad": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b34559b51e5a4f3bbb46771023b8b818": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "description_width": ""
       }
      },
-     "f1a8e14609fb47c4b8865849488511f0": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "b3a24607a26d4a6db3c25ba9811e0329": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_e4b8cc72664b4af9957e48ac2caa71b7",
+       "style": "IPY_MODEL_8d8c7442599d4b66a1bdc4d27cfa0b07",
+       "value": "3"
+      }
+     },
+     "b44fdad619a340a8912851d84be35ba5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b640344b4ce9483f8c1eb1accec5b31b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b88e771825244b5f90859aad40ae4f24": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ba3d23bdea80492c9fe170cc7d835660": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
+       "description_width": ""
       }
      },
-     "f23cfdd8a9bd4f4f881a7dba98a11ba4": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "f2c8d102cd5342b99e42685c2da1058b": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "f77c3280ee964579ae59ebbc8e39780e": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "LayoutModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LayoutModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "height": null,
-       "justify_content": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "msg_throttle": 1,
-       "order": null,
-       "overflow": null,
-       "overflow_x": null,
-       "overflow_y": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "f91ffb7111314c72b41ea6dfc617e374": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
-      "model_name": "ValidModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "ValidModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "ValidView",
-       "description": "Valid!",
-       "disabled": false,
-       "layout": "IPY_MODEL_ec8b67763ae344279d46f3717f3ce3c1",
-       "msg_throttle": 1,
-       "readout": "Invalid",
-       "value": false
-      }
-     },
-     "fa12c076ae4b4ba68aa0dbaf1f6e9c80": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "bcfce0d42db14c708259607736602179": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "ToggleButtonsModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "ToggleButtonsModel",
        "_options_labels": [
         "Slow",
         "Regular",
         "Fast"
        ],
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "ToggleButtonsView",
        "button_style": "",
        "description": "Speed:",
-       "disabled": false,
        "icons": [],
-       "layout": "IPY_MODEL_3d53699ff99a4fdc87909434e78128e4",
-       "msg_throttle": 1,
-       "tooltips": [],
-       "value": "Slow"
+       "index": 0,
+       "layout": "IPY_MODEL_7b2c8a53b2934f03b131ab2a4e94803d",
+       "style": "IPY_MODEL_f3945c9d4cbf4c1ab3b5dbc6e0e15475",
+       "tooltips": [
+        "Description of slow",
+        "Description of regular",
+        "Description of fast"
+       ]
       }
      },
-     "fd8e8ff9da1f4b028003c9afc4f9410f": {
-      "model_module": "jupyter-js-widgets",
-      "model_module_version": "*",
+     "c067bbcce1984f77a3f84947cfad1a46": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "c127f121f54c4edc93483af8793ec782": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c44c6deb729b4a4dbf951b9bbf9d0901": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c5211ce5f43d4bde800dee7cecfb526a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c692115e21264cbea36e9a71738dfead": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "BoundedIntTextModel",
+      "state": {
+       "description": "Text:",
+       "layout": "IPY_MODEL_323e892406cd4c428e9e0d3a50e934bc",
+       "max": 10,
+       "style": "IPY_MODEL_04dcbf013c294e69a7f6f09eb643caa4",
+       "value": 7
+      }
+     },
+     "c6936f7070ed48669eb5c416dc79ada8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c6fd73ecfd494cffb6e40003dbbaa2c2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntRangeSliderModel",
+      "state": {
+       "_model_name": "IntRangeSliderModel",
+       "_view_name": "IntRangeSliderView",
+       "continuous_update": false,
+       "description": "Test:",
+       "layout": "IPY_MODEL_f2bad359e4ce420db4595c12674cce10",
+       "max": 10,
+       "style": "IPY_MODEL_819aa731a0ee464c94c65d8da1924c2d",
+       "value": [
+        5,
+        7
+       ]
+      }
+     },
+     "c7bddd70abea43aabf018069af51ca53": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c83be8eed1b24f529cd630ba7849bff9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c9aab996feee474396da46870ded182e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "P2",
+       "layout": "IPY_MODEL_4b932535cf844e6ab601ab75f888c09f",
+       "style": "IPY_MODEL_134a3c21e8084b3b8fdce65629d4fcfc"
+      }
+     },
+     "ca77f11b03e342789d260d79acfcddc7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cade29a9b6f34fadbf36883d78ade0cb": {
+      "buffers": [
+       {
+        "data": "iVBORw0KGgoAAAANSUhEUgAAAGQAAABHCAIAAAB+uHWbAAAACXBIWXMAABJ0AAASdAHeZh94AAAHNUlEQVR4nO2cbVMaVxTH/6CggNIAxgxqGpLGzEQjmdHMdNKxnbaZaqbGMdYkjd8mHyWvMmOmbcjgQ9JYrXWMwVKCxEcI2ggyCqg8ycMucPuC1Ek1dtkFlkX9vXIO9+w5+/fevffs3l0RIQQnZIeYsUUymdzd3QWQSCQoiip8SsKFWSybzTYwMJBMJg0Gg8Fg4CEnwVLO2KKxsdFqtVIUlUqlRCIRAJvN5nK5Mn+zIplMEkIkEgmHROPxeGVlJZ+Om5upb75p0el0exZmsVZXVy9fvmy32/V6fcayvr7e0dFRVlbGNrzX66UoqqGhga0jAIvF0trayo8jReHpU7S0hNfWZtmJtafRh4jFYrGYeQjv49SpU+l0moMjgAsXLvDj+PffmJ7G7dugaZHV+p+fmMXKI9yGQwa1Wl1oR0Lw++8Qi9HfDwA0vb8Br2IJmUgEg4P44gt8+umhbU7EAoClJczP44cfIJX+X7PjLlY6jV9/hVqNvj7mxsdarO1tPH+OGzdQW5tV++Mr1uvXcLtx7x6yXwJxmYxLnWQSBgPKy9HdzUIpHMOetbGBsTF0deGTT1j7Hi+xXr5EJIL+frAv1YDjMwzjcfz8M06fRkcHR6WQjVivXr169OgRTdMDAwM2m41jnKKyugqjETdvorExp+Mwi3Xt2jW5XF5WVnblyhWr1QqAoiir1bq1tZVTZL4YG4PbjTt3oFCw8HK73Qd7BvM169mzZ4FAYHp6OhaL1dfXA5BKpXq9vrxc6Ne7SARGI778Ehxuc9TX11dXV8/Ozn5oZD7hW7duHTSKxWIO97P4ZHERCwu4cwec7p5BJBIdPMEjeIFPpzEygkgEfX0clToMoQ8ltuzsYGQE332H06fzf/AjJZbFgvV13L8PTncJmTkiw5Cm8fQpJBJ0dxdKKRyNnuXxYHISN29yqWBYUfJiTU0hGsXduwXsUHuUsFiJBAwGtLXh4kWeIpaqWCsrmJnB7dvI4RkIa0pPLEIwNgapFPfv8x26xMQKhzE0hPZ2LhVM7jCLZTabvV5vZ2enyWQSiUTXr1/nIa2PMj8Puz3/6/LsYZ5Crl69GovFCCGrq6srKysACCGJRCKVShU+vfek0xgeRiyG3l6elEomkwe3DDH3rOHhYY/HYzKZlEplxkLTtNPpbGhoUKlU+U/zAFtbeP4cHR2oqeEh2nt8Pp/L5dpnZBarp6dnn0UqlTY1NXHYGMKBv/7CxkYBK5jD0Gq1CoXC+t/NDsItd2gaT56gshJdXXwrdRgCnQ09HkxMoKsL/w59QSA4sQjBy5eIRt9vZREUwhIrFsPgIFpb8dlnxU7lYwhILKcTr1+jqwtyebFTOQShiPXiBeRy9PVxf6jHA8UXKxyG0Yivv0ZdXbFTYaLIYmUqmHv3IPjnakAR11mpFIaGEI+jt7c0lEKxelZRKpjcYRbr3bt3kUikubl5YmJCpVJ9dKc3K8xmbG4WoYLJHeZ81Wr18vIygFQqFY1GcwlGUTAYIJMJqIJhBXPKsVgsEonY7XaFQrG0tAQgkUhYLBa/388qktuNJ0/w7bdobuaYK5+4XK59VTQAECai0ajf79/d3Q2FQtFolBAyPDyceQsne/74g/z2G0mnWTkVmWAwODEx8aGF+Zolk8lkMhnnf1E8DoMBn3+O8+c5H0MoFHY2dDphNqO3FxUVBY3DE4USixCMjkIux48/FihCESiIWMEgRkbw1VclUMGwIv9izc3B6SzmM5jCkc/VTiqFwUFQFHp6jqBSyGPP8vnw4gU6O6HR5OuQgiM/Yv35J3y+kqxgWJHrydE0fvkFVVX4/vsjrhRy7FluNyYn0d2Nqqp85SNomDvD2tpa5iMYDocjHA5njIRgchLLy+jvZ6FUMpmkD755nB2xWIxnx4Mwi7W8vOx2uwOBwNu3b4eGhgBQFH76CQ0NuHGDXbDt7e2NjQ1uiS4sLPDseBDmYahUKlOpVCAQ2NtHr1QqaXpkYUHENo1EIpFOp7m9ALSzs8NNaM6ONE1funTpQ4uIMH24x+FwiMVihUIRCoW0Wm11dTWHwEeDsgcPHvx/C41Go1arq6qqNBrN3NyczWbT6XRTU1MrKyvns76T4PV6x8fHZTLZ4uKi3W4/d+5c9m+zPHz4UK/Xh0Kh0dFRsVic/XcaZmdn19fX6+rqHj9+LJFINFmvALe3t8fHx+PxeDgcnp6ePnPmTOaLFOxm+6WlpYqKis3NzbW1NY/Hk72jyWRqa2szm801NTXBYDASiWTvK5FICCHz8/NNTU0zMzPZO9bU1Ozs7AA4e/asw+HI3lGlUul0OkKIyWRqbm5+8+ZNxs5u6aDT6fx+v8fjqa2tZTWvtba2ZjYO+v1+xoG/j0Qi4XA45HK5zWZj9QQgGAxGo1GLxRIKhVi9luXz+YxGo1arbWlpsVqt7e3tGTvzNeuEPY76ojuvnIjFghOxWHAiFgtOxGLBP8cR6WT0GAbhAAAAAElFTkSuQmCC",
+        "encoding": "base64",
+        "path": [
+         "value"
+        ]
+       }
+      ],
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ImageModel",
+      "state": {
+       "height": "400",
+       "layout": "IPY_MODEL_d087879420fc41e3b806b06d069f1595",
+       "width": "300"
+      }
+     },
+     "cb7bcde2dd664b21b3e5af5b1c27056e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cc60cf34ded446ff87a7156be8f8680e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cc87bd8da3484961bb490f6dd9a916f4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_5d6dfecbdce94630a5b976743886caae",
+        "IPY_MODEL_396218b29fae4e49aab649f23ba9271d",
+        "IPY_MODEL_eb8a3a3920ab46d3a338b56d473dc067",
+        "IPY_MODEL_787d731d70ad4a2b86d2ef88a1344ee8"
+       ],
+       "layout": "IPY_MODEL_99105fe0a12842178af5bf34886763a8"
+      }
+     },
+     "ce0d60101a5a4762ac52b60159817270": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DatePickerModel",
+      "state": {
+       "description": "Pick a Date",
+       "disabled": false,
+       "layout": "IPY_MODEL_a8977af75efc4b5ea256e6135aa39099",
+       "style": "IPY_MODEL_674c413e5b6d4535b65ff2b11a831c35"
+      }
+     },
+     "d087879420fc41e3b806b06d069f1595": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d23acd51730f4c51b71f610e7958e7a8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d248e931f171477786aceb10021afbe0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
       "model_name": "LabelModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "jupyter-js-widgets",
-       "_model_module_version": "*",
-       "_model_name": "LabelModel",
-       "_view_module": "jupyter-js-widgets",
-       "_view_module_version": "*",
-       "_view_name": "LabelView",
-       "description": "",
-       "disabled": false,
-       "layout": "IPY_MODEL_8bceaa69a7a54522acf296c855079463",
-       "msg_throttle": 1,
-       "placeholder": "​",
+       "layout": "IPY_MODEL_aa68c9873a734057b3ae3bb3150e5b1d",
+       "style": "IPY_MODEL_c6936f7070ed48669eb5c416dc79ada8",
+       "value": "0"
+      }
+     },
+     "d34344e7870441d7b71d540d2575edcb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "SliderStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d36d2a40226b4f20ba7f82743df3fd40": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_dbf67a9f4c6b414b8dcbe6f479ed332e",
+       "style": "IPY_MODEL_66108e24c03d4e0a8496d0f7b88b9c5e",
+       "value": "1"
+      }
+     },
+     "d6af3750810346b0bd395d2727c32418": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d6afc68827cc4354bbff5a857e754f5c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d74712fbafbb462aacfa22022d962aaa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d8a5419b4d95458397d2bebb7be72320": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntSliderModel",
+      "state": {
+       "layout": "IPY_MODEL_d6af3750810346b0bd395d2727c32418",
+       "style": "IPY_MODEL_9645a3abd2394befa4880849ba14c439"
+      }
+     },
+     "db1d02c5be164481a5814edd0408df7e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dbf67a9f4c6b414b8dcbe6f479ed332e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dcf141916aef43c09cc1178957387339": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "BoundedFloatTextModel",
+      "state": {
+       "description": "Text:",
+       "layout": "IPY_MODEL_ffaf6b99f7fd4692b25883585f21ef2c",
+       "max": 10,
+       "style": "IPY_MODEL_b44fdad619a340a8912851d84be35ba5",
+       "value": 7.5
+      }
+     },
+     "dd431edda13e42b384c3fdf0da876c8e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ControllerModel",
+      "state": {
+       "layout": "IPY_MODEL_53e9cff815544fd2b7cf21f623ea3d5b"
+      }
+     },
+     "dde741b0a4064eaf8c22dc856f005050": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "de13d0355c6d4a2b9316672bc6934801": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "df4231d6e4284db2b84ffc2e28997aa3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntSliderModel",
+      "state": {
+       "layout": "IPY_MODEL_260c10d89a5943988afeefed0bbfa0df",
+       "style": "IPY_MODEL_d34344e7870441d7b71d540d2575edcb",
+       "value": 50
+      }
+     },
+     "df99f53bcb5c4406807811a16321a6b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dfb871f032ce46398953670eede31aa8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_5b71ec56890c41ea92ab28931f29b356",
+       "style": "IPY_MODEL_db1d02c5be164481a5814edd0408df7e",
+       "value": "0"
+      }
+     },
+     "e1945b3d92f748e7b2267d7e6707029f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e4b8cc72664b4af9957e48ac2caa71b7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e5c506e01fb949ebbbd882ecaa6cca11": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e6414e51a6b84b77bbca07174042f407": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "BoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_d248e931f171477786aceb10021afbe0",
+        "IPY_MODEL_d36d2a40226b4f20ba7f82743df3fd40",
+        "IPY_MODEL_2f06cb6df4ef433eb0da36bc7f592af5",
+        "IPY_MODEL_b3a24607a26d4a6db3c25ba9811e0329"
+       ],
+       "layout": "IPY_MODEL_c44c6deb729b4a4dbf951b9bbf9d0901"
+      }
+     },
+     "e6d54404c45445269ebe04c4c148597c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e6ff9a77a66d4d479e62aadcb457a502": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e7307a79e0b940fe93b22363a7acbae1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatLogSliderModel",
+      "state": {
+       "description": "Log Slider",
+       "layout": "IPY_MODEL_5eb2f6edffbd420a8c6e64671c9ffcf5",
+       "max": 10,
+       "min": -10,
+       "step": 0.2,
+       "style": "IPY_MODEL_494158494996463db0a7d963c5271a27",
+       "value": 10
+      }
+     },
+     "e756063607f74ab9b545082e7b57b1f7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e85adb3440784b0fa3fb45747a792635": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "eb8a3a3920ab46d3a338b56d473dc067": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LabelModel",
+      "state": {
+       "layout": "IPY_MODEL_0c19bce9461b4019a752a077a071d693",
+       "style": "IPY_MODEL_fd35b0fdb7734293a968f7d046ef1600",
        "value": "2"
       }
+     },
+     "ebd0457751e441e4a18c0b19c5b3ae44": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "String:",
+       "layout": "IPY_MODEL_6f10ef0d2d2242e7b04af8e0bd343724",
+       "placeholder": "Type something",
+       "style": "IPY_MODEL_a4bba5e46daf4b09bde561ead851e8ef",
+       "value": "Hello World"
+      }
+     },
+     "eca4345e6d0d4a1abcafacce461803d7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "eddc968a6e184d599b89553aa7bc7ef9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "LinkModel",
+      "state": {
+       "source": [
+        "IPY_MODEL_48b16c2cb388479c95098c6f7ab13ed0",
+        "value"
+       ],
+       "target": [
+        "IPY_MODEL_df4231d6e4284db2b84ffc2e28997aa3",
+        "value"
+       ]
+      }
+     },
+     "ef64bc2bcae54900a7b6c58618dfd4ae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "efda474ceb1944b3abf51813c9dd6806": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f0c52cce43074ccc9df9b73dba0f403d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f1d4f927cfe04ac5b8784495a911569a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f2bad359e4ce420db4595c12674cce10": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f349f3d268a64741a954b9ef9edb4c60": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f3945c9d4cbf4c1ab3b5dbc6e0e15475": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonsStyleModel",
+      "state": {
+       "button_width": "",
+       "description_width": ""
+      }
+     },
+     "f970119cba234e2e89dbe8f00a276b2b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fbd6a8d0fcfe47ca9d613460ce04c7ac": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "TextModel",
+      "state": {
+       "description": "P3",
+       "layout": "IPY_MODEL_154a6e22eb05444ab5cc3664454cd7ca",
+       "style": "IPY_MODEL_f349f3d268a64741a954b9ef9edb4c60"
+      }
+     },
+     "fd35b0fdb7734293a968f7d046ef1600": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ff697b7cefa34a4bba21a8021995bae2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Slider",
+        "1": "Text"
+       },
+       "children": [
+        "IPY_MODEL_d8a5419b4d95458397d2bebb7be72320",
+        "IPY_MODEL_3afb971b70db448f8533ccbcd79add82"
+       ],
+       "layout": "IPY_MODEL_49d605fd694c46d6a0ac936d6becbec0",
+       "selected_index": null
+      }
+     },
+     "ffaf6b99f7fd4692b25883585f21ef2c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
      }
     },
-    "version_major": 1,
+    "version_major": 2,
     "version_minor": 0
    }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
The example notebook for widgets was using old widgets APIs that are not available in 7.x anymore (which was released over two years ago).