### PR TITLE
Allow exporters to be enabled or disabled via config

### DIFF
--- a/nbconvert/exporters/base.py
+++ b/nbconvert/exporters/base.py
@@ -7,6 +7,7 @@ import warnings
 
 import entrypoints
 
+from traitlets.config import get_config
 from traitlets.log import get_logger
 from traitlets.utils.importstring import import_item
 
@@ -119,4 +120,6 @@ def get_export_names():
     Exporters can be found in external packages by registering
     them as an nbconvert.exporter entrypoint.
     """
-    return sorted(entrypoints.get_group_named('nbconvert.exporters'))
+    c = get_config()
+    names = sorted(entrypoints.get_group_named('nbconvert.exporters'))
+    return [e for e in names if get_exporter(e)(config=c).enabled]

--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -52,7 +52,9 @@ class Exporter(LoggingConfigurable):
     accompanying resources dict.
     """
 
-    enabled = Bool(True).tag(config=True)
+    enabled = Bool(True,
+        help = "Disable this exporter (and any exporters inherited from it)."
+    ).tag(config=True)
 
     file_extension = FilenameExtension(
         help="Extension of the file that should be written to disk"

--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -17,7 +17,7 @@ import nbformat
 
 from traitlets.config.configurable import LoggingConfigurable
 from traitlets.config import Config
-from traitlets import HasTraits, Unicode, List, TraitError
+from traitlets import Bool, HasTraits, Unicode, List, TraitError
 from traitlets.utils.importstring import import_item
 from ipython_genutils import text, py3compat
 
@@ -51,6 +51,8 @@ class Exporter(LoggingConfigurable):
     NotebookNode object and then return the modified NotebookNode object and
     accompanying resources dict.
     """
+
+    enabled = Bool(True).tag(config=True)
 
     file_extension = FilenameExtension(
         help="Extension of the file that should be written to disk"

--- a/nbconvert/exporters/tests/test_export.py
+++ b/nbconvert/exporters/tests/test_export.py
@@ -10,9 +10,12 @@ import sys
 
 import nbformat
 import nbconvert.tests
+import pytest
+
+from traitlets.config import Config
 
 from .base import ExportersTestsBase
-from ..base import get_exporter, export, ExporterNameError, get_export_names
+from ..base import get_exporter, export, ExporterNameError, ExporterDisabledError, get_export_names
 from ..exporter import Exporter
 from ..python import PythonExporter
 
@@ -30,6 +33,15 @@ class TestExport(ExportersTestsBase):
             export(exporter, self._get_notebook())
         except ExporterNameError as e:
             pass
+
+
+    def test_export_disabled(self):
+        """
+        Trying to use a disabled exporter should raise ExporterDisbledError
+        """
+        config = Config({'NotebookExporter': {'enabled': False}})
+        with pytest.raises(ExporterDisabledError):
+            get_exporter('notebook', config=config)
 
 
     def test_export_filename(self):

--- a/nbconvert/exporters/tests/test_exporter.py
+++ b/nbconvert/exporters/tests/test_exporter.py
@@ -19,6 +19,7 @@ from traitlets.config import Config
 from .base import ExportersTestsBase
 from ...preprocessors.base import Preprocessor
 from ..exporter import Exporter
+from ..base import get_export_names, ExporterDisabledError
 
 
 #-----------------------------------------------------------------------------
@@ -57,3 +58,18 @@ class TestExporter(ExportersTestsBase):
         exporter = Exporter(config=config)
         (notebook, resources) = exporter.from_filename(self._get_notebook())
         self.assertEqual(notebook['pizza'], 'cheese')
+
+    def test_get_export_names_disable(self):
+        """Can we disable a specific importer?"""
+        config = Config({'Exporter': {'enabled': False}})
+        export_names = get_export_names()
+        self.assertFalse('Exporter' in export_names)
+
+    def test_get_export_names_disable(self):
+        """Can we disable all exporters then enable a single one"""
+        config = Config({
+            'Exporter': {'enabled': False}, 
+            'NotebookExporter': {'enabled': True}
+        })
+        export_names = get_export_names(config=config)
+        self.assertEqual(export_names, ['notebook'])


### PR DESCRIPTION
This change allows people to configure which Exporters are enabled by adding a `.enabled` attribute/traitlet to the `Exporter` class. It allows users to control functionality such as the "Download as" entry in the notebook and addresses issues like #1065 or [this discourse post](https://discourse.jupyter.org/t/remove-download-as-options-in-jupyter-notebook/4374).

To disable a single exporter, configuration looks like
```python
c.ASCIIDocExporter.enabled = False
```
Or, since everything inherits from `Exporter`, you could disable all but one with
```python
c.Exporter.enabled = True
c.NotebookExporter.enabled = True
```

People wanting to tweak the notebook "Download as" options those could go in their `jupyter_notebook_config.py` but to get complete control over those entries you also need a change to the notebook (e.g.  [this hack](https://github.com/ianabc/notebook/commit/bd0715cb281954a3ff045112e63794cbc6d9446e)). In principal you could do everything there, but I felt that the disable/enable functionality was more general than just the notebook so I thought I'd ask for feedback here first.
