### PR TITLE
Remove custom CSS block

### DIFF
--- a/share/jupyter/nbconvert/templates/classic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/index.html.j2
@@ -26,13 +26,10 @@
   {%- endif -%}
 {% endblock jupyter_widgets %}
 
-{% block extra_css %}
-{% endblock extra_css %}
-
 {% for css in resources.inlining.css -%}
-    <style type="text/css">
-    {{ css }}
-    </style>
+  <style type="text/css">
+  {{ css }}
+  </style>
 {% endfor %}
 
 {% block notebook_css %}
@@ -71,11 +68,6 @@ div#notebook-container{
 }
 </style>
 {% endblock notebook_css %}
-
-<!-- Custom stylesheet, it must be in the same directory as the html file -->
-{% block custom_css %}
-<link rel="stylesheet" href="custom.css">
-{% endblock custom_css %}
 
 {{ mathjax() }}
 


### PR DESCRIPTION
- Removing the `custom_css` block from the classic template.

  Now that we have a more pluggable template system, the dedicated way to customize the results is to create a custom template - especially as there is not a good way to place custom.css in a served directory.

- Removing the unused `extra_css` block.