### PR TITLE
WIP - Move theme css to base template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,6 @@ docs/source/config_options.rst
 
 # Downloaded theme files
 share/jupyter/nbconvert/templates/lab/static/index.css
-share/jupyter/nbconvert/templates/lab/static/theme-dark.css
-share/jupyter/nbconvert/templates/lab/static/theme-light.css
+share/jupyter/nbconvert/templates/base/static/theme-dark.css
+share/jupyter/nbconvert/templates/base/static/theme-light.css
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ jupyterlab_theme_dark_version = '2.1.2'
 jupyterlab_theme_dark_url = "https://unpkg.com/@jupyterlab/theme-dark-extension@%s/style/variables.css" % jupyterlab_theme_dark_version
 
 template_css_urls = {
-    'lab': [(jupyterlab_css_url, 'index.css'), (jupyterlab_theme_light_url, 'theme-light.css'), (jupyterlab_theme_dark_url, 'theme-dark.css')],
+    'base': [(jupyterlab_theme_light_url, 'theme-light.css'), (jupyterlab_theme_dark_url, 'theme-dark.css')],
+    'lab': [(jupyterlab_css_url, 'index.css')],
     'classic': [(notebook_css_url, 'style.css')]
 }
 

--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -23,9 +23,6 @@
   {%- endif -%}
 {% endblock jupyter_widgets %}
 
-{% block extra_css %}
-{% endblock extra_css %}
-
 {% for css in resources.inlining.css -%}
     <style type="text/css">
     {{ css }}


### PR DESCRIPTION
The widgets use the theme CSS variables, even in the classic theme.
