### PR TITLE
Escape HTML characters in latex output strings

### DIFF
--- a/share/jupyter/nbconvert/templates/classic/base.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/base.html.j2
@@ -191,7 +191,7 @@ alt="{{ alttext }}"
 
 {% block data_latex scoped %}
 <div class="output_latex output_subarea {{ extra_class }}">
-{{ output.data['text/latex'] | e}}
+{{ output.data['text/latex'] | e }}
 </div>
 {%- endblock data_latex %}
 

--- a/share/jupyter/nbconvert/templates/classic/base.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/base.html.j2
@@ -191,7 +191,7 @@ alt="{{ alttext }}"
 
 {% block data_latex scoped %}
 <div class="output_latex output_subarea {{ extra_class }}">
-{{ output.data['text/latex'] }}
+{{ output.data['text/latex'] | e}}
 </div>
 {%- endblock data_latex %}
 

--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -191,7 +191,7 @@ class="unconfined"
 
 {% block data_latex scoped %}
 <div class="jp-RenderedLatex jp-OutputArea-output {{ extra_class }}" data-mime-type="text/latex">
-{{ output.data['text/latex'] }}
+{{ output.data['text/latex'] | e }}
 </div>
 {%- endblock data_latex %}
 


### PR DESCRIPTION
Without this change, latex like `\left<content\right>` renders as a `<content\right>` html tag, which mathjax can't handle.

See https://nbviewer.jupyter.org/urls/galgebra--417.org.readthedocs.build/en/417/tutorials/algebra.ipynb#More-examples for an example of this failing.

This is like #514, but for cell outputs.