### PR TITLE
Add --to webpdf for PDF rendering via browser

### DIFF
--- a/docs/source/api/exporters.rst
+++ b/docs/source/api/exporters.rst
@@ -63,6 +63,8 @@ inherit either directly or indirectly from
 
 .. autoclass:: PDFExporter
 
+.. autoclass:: WebPDFExporter
+
 .. autoclass:: PythonExporter
 
 .. autoclass:: RSTExporter

--- a/docs/source/external_exporters.rst
+++ b/docs/source/external_exporters.rst
@@ -18,7 +18,7 @@ format designated by the ``FORMAT`` string as explained below.
 
 Extending the built-in format exporters
 ---------------------------------------
-A few built-in formats are available by default: `html`, `pdf`,
+A few built-in formats are available by default: `html`, `pdf`, `webpdf`,
 `script`, `latex`. Each of these has its own *exporter* with many
 configuration options that can be extended. Having the option to point to a
 different *exporter* allows authors to create their own fully customized
@@ -127,7 +127,7 @@ We will use the following layout for our package to expose a custom exporter::
         └── templates
             └── test_template.tpl
 
-If you wished to create this same directory structure you could use the following commands 
+If you wished to create this same directory structure you could use the following commands
 when you are at the directory under which you wish to build your ``mypackage`` package:
 
 .. code-block:: bash
@@ -140,11 +140,11 @@ when you are at the directory under which you wish to build your ``mypackage`` p
 
 .. important::
     You should not publish this package without adding content to your ``LICENSE.md`` file.
-    For example, ``nbconvert`` follows the Jupyter Project convention of using a Modified BSD 
+    For example, ``nbconvert`` follows the Jupyter Project convention of using a Modified BSD
     License (also known as New or Revised or 3-Clause BSD).
     For a guide on picking the right license for your use case,
     please see `choose a license <http://choosealicense.com>`_.
-    If you do not specify the license, your code may be `unusable by many open source projects`_. 
+    If you do not specify the license, your code may be `unusable by many open source projects`_.
 
 .. _`unusable by many open source projects`: http://choosealicense.com/no-license/
 

--- a/docs/source/highlighting.rst
+++ b/docs/source/highlighting.rst
@@ -1,15 +1,15 @@
 Customizing Syntax Highlighting
 ===============================
 
-Under the hood, nbconvert uses pygments to highlight code. Both pdf and html exporting support 
+Under the hood, nbconvert uses pygments to highlight code. pdf, webpdf and html exporting support
 changing the highlighting style.
 
 Using Builtin styles
 --------------------
-Pygments has a number of builtin styles available. To use them, we just need to set the style setting 
+Pygments has a number of builtin styles available. To use them, we just need to set the style setting
 in the relevant preprocessor.
 
-To change the html highlighting export with:
+To change html and webpdf highlighting export with:
 
 .. code-block:: bash
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,16 +12,17 @@ Installing nbconvert
 Nbconvert is packaged for both pip and conda, so you can install it with::
 
     pip install nbconvert
+
     # OR
+
     conda install nbconvert
 
-If you're new to Python, we recommend installing `Anaconda <https://www.anaconda.com/distribution/>`_,
-a Python distribution which includes nbconvert and the other Jupyter components.
+The `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ and `Miniforge <https://github.com/conda-forge/miniforge/>`_ distributions both provide a minimal conda installation.
 
 .. important::
 
     To unlock its full capabilities, nbconvert requires Pandoc, TeX
-    (specifically, XeLaTeX) and Chromium. These must be installed separately.
+    (specifically, XeLaTeX) and Pyppeteer. These must be installed separately.
 
 Installing Pandoc
 -----------------
@@ -39,11 +40,8 @@ On other platforms, you can get pandoc from
 Installing TeX
 --------------
 
-For converting to PDF, nbconvert can either use `Puppeteer <https://pptr.dev>`_
-(with ``--to webpdf``) or the TeX document preparation ecosystem (with
-``--to pdf``). In the latter case it produces an intermediate ``.tex`` file
-which is compiled by the XeTeX engine with the LaTeX2e format (via the ``xelatex``
-command) to produce PDF output.
+For converting notebooks to PDF (with ``--to pdf``), nbconvert makes use of LaTeX
+and the XeTeX as the rendering engine.
 
 .. versionadded:: 5.0
 
@@ -72,13 +70,14 @@ notebooks to PDF.
 Installing Chromium
 -------------------
 
-When converting to PDF with ``--to webpdf``, nbconvert uses `Puppeteer <https://pptr.dev>`_, and
-more precisely its Python bindings `pyppeteer <https://github.com/pyppeteer/pyppeteer>`_. pyppeteer
-needs a special version of Chromium, and can automatically download it. Since the download size is
-quite large (around 100 MB), nbconvert prevents it by default. If pyppeteer finds a suitable
-version of Chromium on your system, it will try and use it. Otherwise, please use the
-``--allow-chromium-download`` flag to allow Chromium's download. Note that installing with
-``nbconvert[webpdf]`` we install a compatible version of pyppeteer for this usecase.
+For converting notebooks to PDF with ``--to webpdf``, nbconvert requires the
+`Pyppeteer <https://github.com/pyppeteer/pyppeteer>`_ Chromium automation library.
+
+Pyppeteer makes use of a specific version of Chromium. If it does not find a suitable
+installation of the web browser, it can automatically download it if the ``--allow-chromium-download``
+flag is passed to the command line.
+
+To install a suitable version of pyppeteer, you can pip install ``nbconvert[webpdf]``.
 
 PDF conversion on a limited TeX environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -77,7 +77,8 @@ more precisely its Python bindings `pyppeteer <https://github.com/pyppeteer/pypp
 needs a special version of Chromium, and can automatically download it. Since the download size is
 quite large (around 100 MB), nbconvert prevents it by default. If pyppeteer finds a suitable
 version of Chromium on your system, it will try and use it. Otherwise, please use the
-``--allow-chromium-download`` flag to allow Chromium's download.
+``--allow-chromium-download`` flag to allow Chromium's download. Note that installing with
+``nbconvert[webpdf]`` we install a compatible version of pyppeteer for this usecase.
 
 PDF conversion on a limited TeX environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -19,8 +19,8 @@ If you're new to Python, we recommend installing `Anaconda <https://www.anaconda
 a Python distribution which includes nbconvert and the other Jupyter components.
 
 .. important::
-    
-    To unlock nbconvert's full capabilities requires Pandoc and TeX 
+
+    To unlock nbconvert's full capabilities requires Pandoc and TeX
     (specifically, XeLaTeX). These must be installed separately.
 
 Installing Pandoc
@@ -39,22 +39,23 @@ On other platforms, you can get pandoc from
 Installing TeX
 --------------
 
-For converting to PDF, nbconvert uses the TeX document preparation 
-ecosystem. It produces an intermediate ``.tex`` file which is 
-compiled by the XeTeX engine with the LaTeX2e format (via the 
-``xelatex`` command) to produce PDF output. 
+For converting to PDF, nbconvert can either use `Puppeteer <https://pptr.dev>`_
+(with ``--to webpdf``) or the TeX document preparation ecosystem (with
+``--to pdf``). In the latter case it produces an intermediate ``.tex`` file
+which is compiled by the XeTeX engine with the LaTeX2e format (via the ``xelatex``
+command) to produce PDF output.
 
 .. versionadded:: 5.0
-    
-    We use XeTeX as the rendering engine rather than pdfTeX (as 
-    in earlier versions). XeTeX can access fonts through native 
-    operating system libraries, it has better support for OpenType 
-    formatted fonts and Unicode characters. 
 
-To install a complete TeX environment (including XeLaTeX and 
-the necessary supporting packages) by hand can be tricky. 
-Fortunately, there are packages that make this much easier. These 
-packages are specific to different operating systems: 
+    We use XeTeX as the rendering engine rather than pdfTeX (as
+    in earlier versions). XeTeX can access fonts through native
+    operating system libraries, it has better support for OpenType
+    formatted fonts and Unicode characters.
+
+To install a complete TeX environment (including XeLaTeX and
+the necessary supporting packages) by hand can be tricky.
+Fortunately, there are packages that make this much easier. These
+packages are specific to different operating systems:
 
 * Linux: `TeX Live <http://tug.org/texlive/>`_
 
@@ -63,10 +64,10 @@ packages are specific to different operating systems:
 * macOS (OS X): `MacTeX <http://tug.org/mactex/>`_.
 * Windows: `MikTex <http://www.miktex.org/>`_
 
-Because nbconvert depends on packages and fonts included in standard 
-TeX distributions, if you do not have a complete installation, you 
-may not be able to use nbconvert's standard tooling to convert 
-notebooks to PDF. 
+Because nbconvert depends on packages and fonts included in standard
+TeX distributions, if you do not have a complete installation, you
+may not be able to use nbconvert's standard tooling to convert
+notebooks to PDF.
 
 PDF conversion on a limited TeX environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,7 +77,7 @@ If you are only able to install a limited TeX environment, there are two main ro
 1. Using TeX by hand
     a. You could convert to ``.tex`` directly; this requires Pandoc.
     b. edit the file to accord with your local environment
-    c. run ``xelatex`` directly. 
+    c. run ``xelatex`` directly.
 2. Custom exporter
-    a. You could write a :ref:`custom exporter <external_exporters>` 
-       that takes your system's limitations into account. 
+    a. You could write a :ref:`custom exporter <external_exporters>`
+       that takes your system's limitations into account.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -20,8 +20,8 @@ a Python distribution which includes nbconvert and the other Jupyter components.
 
 .. important::
 
-    To unlock nbconvert's full capabilities requires Pandoc and TeX
-    (specifically, XeLaTeX). These must be installed separately.
+    To unlock its full capabilities, nbconvert requires Pandoc, TeX
+    (specifically, XeLaTeX) and Chromium. These must be installed separately.
 
 Installing Pandoc
 -----------------
@@ -68,6 +68,16 @@ Because nbconvert depends on packages and fonts included in standard
 TeX distributions, if you do not have a complete installation, you
 may not be able to use nbconvert's standard tooling to convert
 notebooks to PDF.
+
+Installing Chromium
+-------------------
+
+When converting to PDF with ``--to webpdf``, nbconvert uses `Puppeteer <https://pptr.dev>`_, and
+more precisely its Python bindings `pyppeteer <https://github.com/pyppeteer/pyppeteer>`_. pyppeteer
+needs a special version of Chromium, and can automatically download it. Since the download size is
+quite large (around 100 MB), nbconvert prevents it by default. If pyppeteer finds a suitable
+version of Chromium on your system, it will try and use it. Otherwise, please use the
+``--allow-chromium-download`` flag to allow Chromium's download.
 
 PDF conversion on a limited TeX environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -89,9 +89,11 @@ WebPDF
 ~~~~~~
 * ``--to webpdf``
 
-  Generates a PDF via puppeteer (chromium web browser). Supports the same
-  templates as ``--to html``. Requires ``pyppeteer`` to be installed via
-  ``nbconvert[webpdf]``.
+  Generates a by first rendering to HTML, rendering the HTML Chromium headless, and
+  exporting to PDF. This exporter supports the same templates as ``--to html``.
+
+  The webpdf exporter requires the ``pyppeteer`` Chromium automation library, which
+  can be installed via ``nbconvert[webpdf]``.
 
 .. _convert_revealjs:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -89,7 +89,7 @@ WebPDF
 ~~~~~~
 * ``--to webpdf``
 
-  Generates a PDF via puppeteer (chrome web browser). Supports the same
+  Generates a PDF via puppeteer (chromium web browser). Supports the same
   templates as ``--to html``.
 
 .. _convert_revealjs:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -24,6 +24,7 @@ The currently supported output formats are:
     - :ref:`HTML <convert_html>`,
     - :ref:`LaTeX <convert_latex>`,
     - :ref:`PDF <convert_pdf>`,
+    - :ref:`WebPDF <convert_webpdf>`,
     - :ref:`Reveal.js HTML slideshow <convert_revealjs>`,
     - :ref:`Markdown <convert_markdown>`,
     - :ref:`Ascii <convert_ascii>`,
@@ -58,7 +59,7 @@ LaTeX
 * ``--to latex``
 
   Latex export.  This generates ``NOTEBOOK_NAME.tex`` file,
-  ready for export. 
+  ready for export.
   Images are output as .png files in a folder.
 
   - ``--template article`` (default)
@@ -82,6 +83,15 @@ PDF
 
   Generates a PDF via latex. Supports the same templates as ``--to latex``.
 
+.. _convert_webpdf:
+
+WebPDF
+~~~~~~
+* ``--to webpdf``
+
+  Generates a PDF via puppeteer (chrome web browser). Supports the same
+  templates as ``--to html``.
+
 .. _convert_revealjs:
 
 Reveal.js HTML slideshow
@@ -89,10 +99,10 @@ Reveal.js HTML slideshow
 * ``--to slides``
 
   This generates a Reveal.js HTML slideshow.
-  
+
 Running this slideshow requires a copy of reveal.js (version 3.x).
-  
-By default, this will include a script tag in the html that will directly load 
+
+By default, this will include a script tag in the html that will directly load
 reveal.js from a public CDN.
 
 This means that if you include your slides on a webpage, they should work as
@@ -103,19 +113,19 @@ Speaker notes require a local copy of reveal.js. Then, you need to tell
 ``nbconvert`` how to find that local copy.
 
 Timers only work if you already have speaker notes, but also require a local
-https server. You can read more about this in ServePostProcessorExample_. 
+https server. You can read more about this in ServePostProcessorExample_.
 
 To make this clearer, let's look at an example of how to get speaker notes
-working with a local copy of reveal.js: SlidesWithNotesExample_. 
+working with a local copy of reveal.js: SlidesWithNotesExample_.
 
-.. note:: 
+.. note::
 
-  In order to designate a mapping from notebook cells to Reveal.js slides, 
-  from within the Jupyter notebook, select menu item 
-  View --> Cell Toolbar --> Slideshow. That will reveal a drop-down menu 
-  on the upper-right of each cell.  From it, one may choose from 
-  "Slide," "Sub-Slide", "Fragment", "Skip", and "Notes."  On conversion, 
-  cells designated as "skip" will not be included, "notes" will be included 
+  In order to designate a mapping from notebook cells to Reveal.js slides,
+  from within the Jupyter notebook, select menu item
+  View --> Cell Toolbar --> Slideshow. That will reveal a drop-down menu
+  on the upper-right of each cell.  From it, one may choose from
+  "Slide," "Sub-Slide", "Fragment", "Skip", and "Notes."  On conversion,
+  cells designated as "skip" will not be included, "notes" will be included
   only in presenter notes, etc.
 
 .. _SlidesWithNotesExample:
@@ -126,7 +136,7 @@ Example: creating slides w/ speaker notes
 Let's suppose you have a notebook ``your_talk.ipynb`` that you want to convert
 to slides. For this example, we'll assume that you are working in the same
 directory as the notebook you want to convert (i.e., when you run ``ls .``,
-``your_talk.ipynb`` shows up amongst the list of files). 
+``your_talk.ipynb`` shows up amongst the list of files).
 
 First, we need a copy of reveal.js in the same directory as your slides. One
 way to do this is to use the following commands in your terminal:
@@ -141,12 +151,12 @@ way to do this is to use the following commands in your terminal:
 Then we need to tell nbconvert to point to this local copy. To do that we use
 the ``--reveal-prefix`` command line flag to point to the local copy.
 
-.. code-block:: shell 
+.. code-block:: shell
 
   jupyter nbconvert your_talk.ipynb --to slides --reveal-prefix reveal.js
 
-This will create file ``your_talk.slides.html``, which you should be able to 
-access with ``open your_talk.slides.html``. To access the speaker notes, press 
+This will create file ``your_talk.slides.html``, which you should be able to
+access with ``open your_talk.slides.html``. To access the speaker notes, press
 ``s`` after the slides load and they should open in a new window.
 
 Note: This does not enable slides that run completely offline. While you have a
@@ -165,9 +175,9 @@ reveal.js from a local https server.
 
 Fortunately, ``nbconvert`` makes this fairly straightforward through the use of
 the ``ServePostProcessor``. To activate this server, we append the command line
-flag ``--post serve`` to our call to nbconvert. 
+flag ``--post serve`` to our call to nbconvert.
 
-.. code-block:: shell 
+.. code-block:: shell
 
   jupyter nbconvert your_talk.ipynb --to slides --reveal-prefix reveal.js --post serve
 
@@ -182,7 +192,7 @@ Markdown
 * ``--to markdown``
 
   Simple markdown output.  Markdown cells are unaffected,
-  and code cells indented 4 spaces. 
+  and code cells indented 4 spaces.
   Images are output as .png files in a folder.
 
 .. _convert_ascii:
@@ -191,7 +201,7 @@ Ascii
 ~~~~~~~~
 * ``--to asciidoc``
 
-  Ascii output. 
+  Ascii output.
   Images are output as .png files in a folder.
 
 .. _convert_rst:
@@ -201,7 +211,7 @@ reStructuredText
 * ``--to rst``
 
   Basic reStructuredText output. Useful as a starting point for embedding
-  notebooks in Sphinx docs. 
+  notebooks in Sphinx docs.
   Images are output as .png files in a folder.
 
   .. note::

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -90,7 +90,8 @@ WebPDF
 * ``--to webpdf``
 
   Generates a PDF via puppeteer (chromium web browser). Supports the same
-  templates as ``--to html``.
+  templates as ``--to html``. Requires ``pyppeteer`` to be installed via
+  ``nbconvert[webpdf]``.
 
 .. _convert_revealjs:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -89,7 +89,7 @@ WebPDF
 ~~~~~~
 * ``--to webpdf``
 
-  Generates a by first rendering to HTML, rendering the HTML Chromium headless, and
+  Generates a PDF by first rendering to HTML, rendering the HTML Chromium headless, and
   exporting to PDF. This exporter supports the same templates as ``--to html``.
 
   The webpdf exporter requires the ``pyppeteer`` Chromium automation library, which

--- a/nbconvert/exporters/__init__.py
+++ b/nbconvert/exporters/__init__.py
@@ -1,4 +1,4 @@
-from .base import (export, get_exporter, 
+from .base import (export, get_exporter,
                    ExporterNameError, get_export_names)
 from .html import HTMLExporter
 from .slides import SlidesExporter
@@ -8,6 +8,7 @@ from .markdown import MarkdownExporter
 from .asciidoc import ASCIIDocExporter
 from .notebook import NotebookExporter
 from .pdf import PDFExporter
+from .webpdf import WebPDFExporter
 from .python import PythonExporter
 from .rst import RSTExporter
 from .exporter import Exporter, FilenameExtension

--- a/nbconvert/exporters/tests/test_webpdf.py
+++ b/nbconvert/exporters/tests/test_webpdf.py
@@ -1,0 +1,44 @@
+"""Tests for the latex preprocessor"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import io
+import pytest
+
+from mock import patch
+
+from .base import ExportersTestsBase
+from ..webpdf import WebPDFExporter
+
+class TestWebPDFExporter(ExportersTestsBase):
+    """Contains test functions for webpdf.py"""
+
+    exporter_class = WebPDFExporter
+
+    def test_export(self):
+        """
+        Can a TemplateExporter export something?
+        """
+        (output, resources) = WebPDFExporter().from_filename(self._get_notebook())
+        assert len(output) > 0
+
+    @patch('pyppeteer.util.check_chromium', return_value=False)
+    def test_webpdf_without_chromium(self, mock_check_chromium):
+        """
+        Generate PDFs if chromium not present?
+        """
+        with pytest.raises(RuntimeError):
+            WebPDFExporter().from_filename(self._get_notebook())
+
+    def test_webpdf_without_pyppeteer(self):
+        """
+        Generate PDFs if chromium not present?
+        """
+        with pytest.raises(RuntimeError):
+            exporter = WebPDFExporter()
+            with io.open(self._get_notebook(), encoding='utf-8') as f:
+                nb = exporter.from_file(f, resources={})
+                # Have to do this as the very last action as traitlets do dynamic importing often
+                with patch('builtins.__import__', side_effect=ModuleNotFoundError("Fake missing")):
+                    exporter.from_notebook_node(nb)

--- a/nbconvert/exporters/tests/test_webpdf.py
+++ b/nbconvert/exporters/tests/test_webpdf.py
@@ -20,7 +20,7 @@ class TestWebPDFExporter(ExportersTestsBase):
         """
         Can a TemplateExporter export something?
         """
-        (output, resources) = WebPDFExporter().from_filename(self._get_notebook())
+        (output, resources) = WebPDFExporter(allow_chromium_download=True).from_filename(self._get_notebook())
         assert len(output) > 0
 
     @patch('pyppeteer.util.check_chromium', return_value=False)
@@ -29,7 +29,7 @@ class TestWebPDFExporter(ExportersTestsBase):
         Generate PDFs if chromium not present?
         """
         with pytest.raises(RuntimeError):
-            WebPDFExporter().from_filename(self._get_notebook())
+            WebPDFExporter(allow_chromium_download=False).from_filename(self._get_notebook())
 
     def test_webpdf_without_pyppeteer(self):
         """

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -1,0 +1,47 @@
+"""Export to PDF via puppeteer"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import asyncio
+from pyppeteer import launch
+
+from .html import HTMLExporter
+
+class WebPDFExporter(HTMLExporter):
+    """Writer designed to write to PDF files.
+
+    This inherits from :class:`HTMLExporter`. It creates the HTML using the
+    template machinery, and then runs puppeteer (through pyppeteer) to create
+    a pdf.
+    """
+    export_from_notebook="PDF via Puppeteer"
+
+    def run_puppeteer(self, html):
+        """Run puppeteer."""
+
+        async def main():
+            browser = await launch()
+            page = await browser.newPage()
+            await page.goto('data:text/html,'+html, waitUntil='networkidle0')
+            pdf_data = await page.pdf()
+            await browser.close()
+            return pdf_data
+
+        pdf_data = asyncio.get_event_loop().run_until_complete(main())
+        return pdf_data
+
+    def from_notebook_node(self, nb, resources=None, **kw):
+        html, resources = super().from_notebook_node(
+            nb, resources=resources, **kw
+        )
+
+        self.log.info("Building PDF")
+        pdf_data = self.run_puppeteer(html)
+        self.log.info('PDF successfully created')
+
+        # convert output extension to pdf
+        # the writer above required it to be html
+        resources['output_extension'] = '.pdf'
+
+        return pdf_data, resources

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -4,8 +4,10 @@
 # Distributed under the terms of the Modified BSD License.
 
 import asyncio
-from pyppeteer import launch
 
+from pyppeteer import launch
+from pyppeteer.util import check_chromium
+from traitlets import Bool
 from .html import HTMLExporter
 
 class WebPDFExporter(HTMLExporter):
@@ -16,6 +18,10 @@ class WebPDFExporter(HTMLExporter):
     a pdf.
     """
     export_from_notebook="PDF via Puppeteer"
+
+    allow_chromium_download = Bool(False,
+        help="Whether to allow downloading chromium if no suitable version is found on the system."
+    ).tag(config=True)
 
     def run_puppeteer(self, html):
         """Run puppeteer."""
@@ -32,6 +38,10 @@ class WebPDFExporter(HTMLExporter):
         return pdf_data
 
     def from_notebook_node(self, nb, resources=None, **kw):
+        if not self.allow_chromium_download and not check_chromium():
+            raise RuntimeError("No suitable chromium executable found on the system. "
+                               "Please use '--allow-chromium-download' to allow downloading one.")
+
         html, resources = super().from_notebook_node(
             nb, resources=resources, **kw
         )

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -1,4 +1,4 @@
-"""Export to PDF via puppeteer"""
+"""Export to PDF via a headless browser"""
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
@@ -12,13 +12,12 @@ class WebPDFExporter(HTMLExporter):
     """Writer designed to write to PDF files.
 
     This inherits from :class:`HTMLExporter`. It creates the HTML using the
-    template machinery, and then runs puppeteer (through pyppeteer) to create
-    a pdf.
+    template machinery, and then run pyppeteer to create a pdf.
     """
-    export_from_notebook="PDF via Puppeteer"
+    export_from_notebook = "PDF via pyppeteer"
 
     allow_chromium_download = Bool(False,
-        help="Whether to allow downloading chromium if no suitable version is found on the system."
+        help="Whether to allow downloading Chromium if no suitable version is found on the system."
     ).tag(config=True)
 
     def _check_launch_reqs(self):
@@ -33,8 +32,8 @@ class WebPDFExporter(HTMLExporter):
                                "Please use '--allow-chromium-download' to allow downloading one.")
         return launch
 
-    def run_puppeteer(self, html):
-        """Run puppeteer."""
+    def run_pyppeteer(self, html):
+        """Run pyppeteer."""
 
         async def main():
             browser = await self._check_launch_reqs()()
@@ -54,7 +53,7 @@ class WebPDFExporter(HTMLExporter):
         )
 
         self.log.info("Building PDF")
-        pdf_data = self.run_puppeteer(html)
+        pdf_data = self.run_pyppeteer(html)
         self.log.info('PDF successfully created')
 
         # convert output extension to pdf

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -126,6 +126,13 @@ nbconvert_flags.update({
         """Exclude input cells and output prompts from converted document. 
         This mode is ideal for generating code-free reports."""
         ),
+    'allow-chromium-download' : (
+        {'WebPDFExporter' : {
+            'allow_chromium_download' : True,
+            }
+        },
+        """Whether to allow downloading chromium if no suitable version is found on the system."""
+        ),
 })
 
 

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -131,6 +131,27 @@ class TestNbConvertApp(TestsBase):
             )
             assert os.path.isfile('notebook with spaces.pdf')
 
+    def test_webpdf_without_chromium(self):
+        """
+        Generate PDFs if chromium not present?
+        """
+        with self.create_temp_cwd(['notebook2.ipynb']):
+            with pytest.raises(OSError):
+                self.nbconvert('--to webpdf '
+                               '"notebook2"'
+                )
+
+    def test_webpdf_with_chromium(self):
+        """
+        Generate PDFs if chromium allowed to be downloaded?
+        """
+        with self.create_temp_cwd(['notebook2.ipynb']):
+            self.nbconvert('--to webpdf '
+                           '--allow-chromium-download '
+                           '"notebook2"'
+            )
+            assert os.path.isfile('notebook2.pdf')
+
     @onlyif_cmds_exist('pandoc', 'xelatex')
     def test_pdf(self):
         """

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -131,6 +131,7 @@ class TestNbConvertApp(TestsBase):
             )
             assert os.path.isfile('notebook with spaces.pdf')
 
+    @pytest.mark.order1
     def test_webpdf_without_chromium(self):
         """
         Generate PDFs if chromium not present?
@@ -141,6 +142,7 @@ class TestNbConvertApp(TestsBase):
                                '"notebook2"'
                 )
 
+    @pytest.mark.order2
     def test_webpdf_with_chromium(self):
         """
         Generate PDFs if chromium allowed to be downloaded?

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -131,18 +131,6 @@ class TestNbConvertApp(TestsBase):
             )
             assert os.path.isfile('notebook with spaces.pdf')
 
-    @pytest.mark.dependency()
-    def test_webpdf_without_chromium(self):
-        """
-        Generate PDFs if chromium not present?
-        """
-        with self.create_temp_cwd(['notebook2.ipynb']):
-            with pytest.raises(OSError):
-                self.nbconvert('--to webpdf '
-                               '"notebook2"'
-                )
-
-    @pytest.mark.dependency(depends=['test_webpdf_without_chromium'])
     def test_webpdf_with_chromium(self):
         """
         Generate PDFs if chromium allowed to be downloaded?

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -131,7 +131,7 @@ class TestNbConvertApp(TestsBase):
             )
             assert os.path.isfile('notebook with spaces.pdf')
 
-    @pytest.mark.order1
+    @pytest.mark.dependency()
     def test_webpdf_without_chromium(self):
         """
         Generate PDFs if chromium not present?
@@ -142,7 +142,7 @@ class TestNbConvertApp(TestsBase):
                                '"notebook2"'
                 )
 
-    @pytest.mark.order2
+    @pytest.mark.dependency(depends=['test_webpdf_without_chromium'])
     def test_webpdf_with_chromium(self):
         """
         Generate PDFs if chromium allowed to be downloaded?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[build-system]
-requires = ["setuptools >= 40.6.0", "pyppeteer"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "pyppeteer"]

--- a/setup.py
+++ b/setup.py
@@ -227,6 +227,7 @@ setup_args['install_requires'] = [
     'nbclient>=0.2.0',
 ]
 jupyter_client_req = 'jupyter_client>=5.3.1'
+pyppeteer_req = 'pyppeteer==0.2.2'
 
 extra_requirements = {
     'test': ['pytest',
@@ -235,10 +236,10 @@ extra_requirements = {
              'ipykernel',
              jupyter_client_req,
              'ipywidgets>=7',
-             'pyppeteer==0.2.2',
+             pyppeteer_req,
     ],
     'serve': ['tornado>=4.0'],
-    'webpdf': ['pyppeteer==0.2.2'],
+    'webpdf': [pyppeteer_req],
     'execute': [jupyter_client_req],
     'docs': ['sphinx>=1.5.1',
              'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,7 @@ setup_args['install_requires'] = [
 jupyter_client_req = 'jupyter_client>=5.3.1'
 
 extra_requirements = {
-    'test': ['pytest', 'pytest-cov', 'pytest-ordering', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
+    'test': ['pytest', 'pytest-cov', 'pytest-dependency', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
     'serve': ['tornado>=4.0'],
     'execute': [jupyter_client_req],
     'docs': ['sphinx>=1.5.1',

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,7 @@ setup_args['install_requires'] = [
     'testpath',
     'defusedxml',
     'nbclient>=0.2.0',
-    'pyppeteer'
+    'pyppeteer>=0.2.2'
 ]
 jupyter_client_req = 'jupyter_client>=5.3.1'
 

--- a/setup.py
+++ b/setup.py
@@ -229,10 +229,17 @@ setup_args['install_requires'] = [
 ]
 jupyter_client_req = 'jupyter_client>=5.3.1'
 
+def install_chromium():
+    from pyppeteer.util import check_chromium, download_chromium
+    if not check_chromium():
+        download_chromium()
+    return ''
+
 extra_requirements = {
     'test': ['pytest', 'pytest-cov', 'pytest-dependency', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
     'serve': ['tornado>=4.0'],
     'execute': [jupyter_client_req],
+    'chromium': [install_chromium()],
     'docs': ['sphinx>=1.5.1',
              'sphinx_rtd_theme',
              'nbsphinx>=0.2.12',

--- a/setup.py
+++ b/setup.py
@@ -225,13 +225,20 @@ setup_args['install_requires'] = [
     'testpath',
     'defusedxml',
     'nbclient>=0.2.0',
-    'pyppeteer>=0.2.2'
 ]
 jupyter_client_req = 'jupyter_client>=5.3.1'
 
 extra_requirements = {
-    'test': ['pytest', 'pytest-cov', 'pytest-dependency', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
+    'test': ['pytest',
+             'pytest-cov',
+             'pytest-dependency',
+             'ipykernel',
+             jupyter_client_req,
+             'ipywidgets>=7',
+             'pyppeteer==0.2.2',
+    ],
     'serve': ['tornado>=4.0'],
+    'webpdf': ['pyppeteer==0.2.2'],
     'execute': [jupyter_client_req],
     'docs': ['sphinx>=1.5.1',
              'sphinx_rtd_theme',
@@ -239,7 +246,7 @@ extra_requirements = {
              'sphinxcontrib_github_alt',
              'ipython',
              jupyter_client_req,
-             ],
+    ],
 }
 
 extra_requirements['all'] = sum(extra_requirements.values(), [])

--- a/setup.py
+++ b/setup.py
@@ -225,6 +225,7 @@ setup_args['install_requires'] = [
     'testpath',
     'defusedxml',
     'nbclient>=0.2.0',
+    'pyppeteer'
 ]
 jupyter_client_req = 'jupyter_client>=5.3.1'
 
@@ -254,6 +255,7 @@ setup_args['entry_points'] = {
         'slides=nbconvert.exporters:SlidesExporter',
         'latex=nbconvert.exporters:LatexExporter',
         'pdf=nbconvert.exporters:PDFExporter',
+        'webpdf=nbconvert.exporters:WebPDFExporter',
         'markdown=nbconvert.exporters:MarkdownExporter',
         'python=nbconvert.exporters:PythonExporter',
         'rst=nbconvert.exporters:RSTExporter',

--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,7 @@ setup_args['install_requires'] = [
 jupyter_client_req = 'jupyter_client>=5.3.1'
 
 extra_requirements = {
-    'test': ['pytest', 'pytest-cov', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
+    'test': ['pytest', 'pytest-cov', 'pytest-ordering', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
     'serve': ['tornado>=4.0'],
     'execute': [jupyter_client_req],
     'docs': ['sphinx>=1.5.1',

--- a/setup.py
+++ b/setup.py
@@ -229,17 +229,10 @@ setup_args['install_requires'] = [
 ]
 jupyter_client_req = 'jupyter_client>=5.3.1'
 
-def install_chromium():
-    from pyppeteer.util import check_chromium, download_chromium
-    if not check_chromium():
-        download_chromium()
-    return ''
-
 extra_requirements = {
     'test': ['pytest', 'pytest-cov', 'pytest-dependency', 'ipykernel', jupyter_client_req, 'ipywidgets>=7'],
     'serve': ['tornado>=4.0'],
     'execute': [jupyter_client_req],
-    'chromium': [install_chromium()],
     'docs': ['sphinx>=1.5.1',
              'sphinx_rtd_theme',
              'nbsphinx>=0.2.12',


### PR DESCRIPTION
Compared to `--to pdf`, this allows to have widgets in the PDF document. It also supports the same templates as `--to html`.