### PR TITLE
Linkcheck ignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,10 @@ jobs:
           path: build/sphinx/latex/nbconvert.pdf
           destination: nbconvert.pdf
 
-      # TODO: Re-enable once linkcheck stops causing 429's from github
-      # - run:
-      #     name: Checking for broken links
-      #     command: |
-      #       python3 setup.py build_sphinx -b linkcheck
+      - run:
+          name: Checking for broken links
+          command: |
+            python3 setup.py build_sphinx -b linkcheck
 
 workflows:
   version: 2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,6 +66,10 @@ author = 'Jupyter Development Team'
 # ghissue config
 github_project_url = "https://github.com/jupyter/nbconvert"
 
+linkcheck_ignore = [
+    'https://github.com/jupyter/nbconvert/pull/',
+]
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.


### PR DESCRIPTION
With a bit of luck, this might avoid the 429 responses from Github.

It is successful here: https://app.circleci.com/pipelines/github/mgeier/nbconvert/40/workflows/b6755824-c233-4463-bdda-7c0dacb3ed16/jobs/40/

... but that's of course no guarantee that it will succeed in the future.