### PR TITLE
Feature: make preprocessor in conf.json a dict

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -485,6 +485,11 @@ class TemplateExporter(Exporter):
         return conf
 
 
+    @observe('template_name')
+    def _on_template_name_change(self, change):
+        # since the default template paths depend on the template name, we reset it
+        self.template_paths = self._template_paths()
+
     @default('template_paths')
     def _template_paths(self, prune=True, root_dirs=None):
         paths = []

--- a/share/jupyter/nbconvert/templates/reveal/conf.json
+++ b/share/jupyter/nbconvert/templates/reveal/conf.json
@@ -3,7 +3,10 @@
     "mimetypes": {
         "text/html": true
     },
-    "preprocessors": [
-        "nbconvert.exporters.slides._RevealMetadataPreprocessor"
-    ]
+    "preprocessors": {
+        "500-reveal": {
+            "type": "nbconvert.exporters.slides._RevealMetadataPreprocessor",
+            "enabled": true
+        }
+    }
 }


### PR DESCRIPTION
Needs rebase after #1310  (only last commit matters)

This makes it easier for an inheriting template, or voila to add preprocessors.

We could also move the `CSSHTMLHeaderPreprocessor` in the HTML exporter also to the conf.json

