### PR TITLE
Removed inheritance breaking clear-output option

### DIFF
--- a/nbconvert/preprocessors/clearoutput.py
+++ b/nbconvert/preprocessors/clearoutput.py
@@ -6,6 +6,7 @@
 from traitlets import Set
 from .base import Preprocessor
 
+
 class ClearOutputPreprocessor(Preprocessor):
     """
     Removes the output from all code cells in a notebook.

--- a/nbconvert/preprocessors/tagremove.py
+++ b/nbconvert/preprocessors/tagremove.py
@@ -7,10 +7,10 @@ one or more regular expression.
 # Distributed under the terms of the Modified BSD License.
 
 from traitlets import Set, Unicode
-from . import ClearOutputPreprocessor
+from .base import Preprocessor
 
 
-class TagRemovePreprocessor(ClearOutputPreprocessor):
+class TagRemovePreprocessor(Preprocessor):
     """
     Removes inputs, outputs, or cells from a notebook that
     have tags that designate they are to be removed prior to exporting
@@ -44,7 +44,9 @@ class TagRemovePreprocessor(ClearOutputPreprocessor):
     remove_input_tags = Set(Unicode(), default_value=[],
             help=("Tags indicating cells for which input is to be removed,"
                   "matches tags in `cell.metadata.tags`.")).tag(config=True)
-
+    remove_metadata_fields = Set(
+        {'collapsed', 'scrolled'}
+    ).tag(config=True)
 
     def check_cell_conditions(self, cell, resources, index):
         """

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -6,6 +6,7 @@
 
 import os
 import io
+import nbformat
 
 from .base import TestsBase
 from ..postprocessors import PostProcessorBase
@@ -89,6 +90,20 @@ class TestNbConvertApp(TestsBase):
             self.nbconvert('--log-level 0 --to python notebook2')
             assert not os.path.isfile('notebook1.py')
             assert os.path.isfile('notebook2.py')
+
+    def test_clear_output(self):
+        """
+        Can we clear outputs?
+        """
+        with self.create_temp_cwd(['notebook*.ipynb']) as td:
+            self.nbconvert('--clear-output notebook1')
+            assert os.path.isfile('notebook1.ipynb')
+            with open('notebook1.ipynb', encoding='utf8') as f:
+                nb = nbformat.read(f, 4)
+                for cell in nb.cells:
+                    # Skip markdown cells
+                    if 'outputs' in cell:
+                        assert cell.outputs == []
 
     def test_absolute_template_file(self):
         """--template-file '/path/to/template.tpl'"""


### PR DESCRIPTION
Fixes https://github.com/jupyter/nbconvert/issues/822 -- the issue is caused by the Jupyter application class upstream matching the `TagRemovePreprocessor` subclass of `ClearOutputPreprocessor` as the valid config when set to `ClearOutputPreprocessor`. There wasn't a good reason for the inheritance there anyway. I added a test to confirm behavior outside of manual testing.