### PR TITLE
Scale up fonts in presentation mode

### DIFF
--- a/share/jupyter/nbconvert/templates/reveal/index.html.j2
+++ b/share/jupyter/nbconvert/templates/reveal/index.html.j2
@@ -77,6 +77,12 @@ a.anchor-link {
 .jp-Notebook {
     padding: 0;
 }
+:root {
+    --jp-ui-font-size1: 20px;       /* instead of 14px */
+    --jp-content-font-size1: 20px;  /* instead of 14px */
+    --jp-code-font-size: 19px;      /* instead of 13px */
+    --jp-cell-prompt-width: 110px;  /* instead of 64px */
+}
 </style>
 
 {{ resources.include_css("static/custom_reveal.css") }}


### PR DESCRIPTION
Overall, the 6.x version of the reveal template is *very* different from 5.x.
 - uses reveal 4.0.
 - based on the lab template for cell rendering.
This change makes it slightly closer to the original in terms of sizes.