### PR TITLE
add meta-viewport tag to classic and lab template for mobile

### DIFF
--- a/share/jupyter/nbconvert/templates/classic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/index.html.j2
@@ -8,6 +8,7 @@
 <head>
 {%- block html_head -%}
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 {% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>{{nb_title}}</title>
 

--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -8,6 +8,7 @@
 <head>
 {%- block html_head -%}
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 {% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 <title>{{nb_title}}</title>
 


### PR DESCRIPTION
This is an upstreaming of https://github.com/voila-dashboards/voila/pull/579 originally by @mariobuikhuizen

Also used by Jupyter notebook and lab as found out by @jtpio  https://github.com/voila-dashboards/voila/pull/579#issuecomment-658149186

TLDR version is: "ask mobile screen not to lie about their screensize to allow responsive pages"


Before:
![image](https://user-images.githubusercontent.com/1765949/87436334-324c3e80-c5ed-11ea-9aeb-184f8c7e103b.png)

After:
![image](https://user-images.githubusercontent.com/1765949/87436230-0a5cdb00-c5ed-11ea-9553-23fce4113a10.png)
