### PR TITLE
DOC: rogue space is bad numpydoc formatting.

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -90,7 +90,7 @@ class PDFExporter(LatexExporter):
             The name of the file to convert.
         count : int
             How many times to run the command.
-         raise_on_failure: Exception class (default None)
+        raise_on_failure: Exception class (default None)
             If provided, will raise the given exception for if an instead of
             returning False on command failure.
 


### PR DESCRIPTION
This space made numpydoc _think_ the parameter is part of the
description of `count`.