### PR TITLE
fix broken jupyter contribution workflow link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 We follow the
-[Jupyter Contribution Workflow](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html)
+[Jupyter Contribution Workflow](https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html)
 and the [IPython Contributing Guide](https://github.com/ipython/ipython/blob/master/CONTRIBUTING.md).
 
 # Testing


### PR DESCRIPTION
The link to the Jupyter Contribution Workflow in `CONTRIBUTING.md` goes to an error page. I updated it to the correct link!
