### PR TITLE
Added warning to template_file applications with .tpl extension

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -188,7 +188,7 @@ class TemplateExporter(Exporter):
         template_name = change['value']
         if template_name and template_name.endswith('.tpl'):
             warnings.warn(
-                f"5.x style template name passed '{self.template_name}'. Use --template-file or new template directory structures in the future.",
+                f"5.x style template name passed '{self.template_name}'. Use --template-name for the template directory with a index.<ext>.j2 file and/or --template-file to denote a different template.",
                 DeprecationWarning)
             directory, self.template_file = os.path.split(self.template_name)
             if directory:
@@ -209,6 +209,11 @@ class TemplateExporter(Exporter):
         full_path = os.path.abspath(new)
         if os.path.isfile(full_path):
             directory, self.template_file = os.path.split(self.template_file)
+            # While not strictly an invalid template file name, the extension hints that there isn't a template directory involved
+            if self.template_file.endswith('.tpl'):
+                warnings.warn(
+                    f"5.x style template file passed '{new}'. Use --template-name for the template directory with a index.<ext>.j2 file and/or --template-file to denote a different template.",
+                    DeprecationWarning)
             if directory:
                 directory, self.template_name = os.path.split(directory)
             if directory:

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -132,7 +132,36 @@ class TestExporter(ExportersTestsBase):
                 assert os.path.abspath(exporter.template.filename) == template_abs
                 assert os.path.dirname(template_abs) in [os.path.abspath(d) for d in exporter.template_paths]
 
-    def test_absolute_template_file_tpl_compatibility(self):
+    def test_absolute_template_file_compatibility(self):
+        with tempdir.TemporaryDirectory() as td:
+            template = os.path.join(td, 'abstemplate.tpl')
+            test_output = 'absolute!'
+            with open(template, 'w') as f:
+                f.write(test_output)
+            config = Config()
+            config.TemplateExporter.template_file = template
+            with pytest.warns(DeprecationWarning):
+                exporter = self._make_exporter(config=config)
+            assert exporter.template.filename == template
+            assert os.path.dirname(template) in exporter.template_paths
+
+    def test_relative_template_file_compatibility(self):
+        with tempdir.TemporaryWorkingDirectory() as td:
+            with patch('os.getcwd', return_value=os.path.abspath(td)):
+                template = os.path.join('relative', 'relative_template.tpl')
+                template_abs = os.path.abspath(os.path.join(td, template))
+                os.mkdir(os.path.dirname(template_abs))
+                test_output = 'relative!'
+                with open(template_abs, 'w') as f:
+                    f.write(test_output)
+                config = Config()
+                config.TemplateExporter.template_file = template
+                with pytest.warns(DeprecationWarning):
+                    exporter = self._make_exporter(config=config)
+                assert os.path.abspath(exporter.template.filename) == template_abs
+                assert os.path.dirname(template_abs) in [os.path.abspath(d) for d in exporter.template_paths]
+
+    def test_absolute_template_name_tpl_compatibility(self):
         with tempdir.TemporaryDirectory() as td:
             template = os.path.join(td, 'abstemplate.tpl')
             test_output = 'absolute!'
@@ -146,7 +175,7 @@ class TestExporter(ExportersTestsBase):
             assert exporter.template.filename == template
             assert os.path.dirname(template) in exporter.template_paths
 
-    def test_relative_template_file_tpl_compatibility(self):
+    def test_relative_template_name_tpl_compatibility(self):
         with tempdir.TemporaryWorkingDirectory() as td:
             with patch('os.getcwd', return_value=os.path.abspath(td)):
                 template = os.path.join('relative', 'relative_template.tpl')


### PR DESCRIPTION
Follow up to https://github.com/jupyter/nbconvert/pull/1292

I'm not 100% sure we need this warning addition with the other in place, but I am guessing we should give heads up to users that they are using the old naming convention and thus likely the old single-file pattern as well.