### PR TITLE
Correct file paths for xelatex so pdf export does not fail on Windows

### DIFF
--- a/nbconvert/writers/files.py
+++ b/nbconvert/writers/files.py
@@ -7,6 +7,7 @@ import io
 import os
 import glob
 
+from pathlib import Path
 from traitlets import Unicode, observe
 from ipython_genutils.path import link_or_copy, ensure_dir_exists
 from ipython_genutils.py3compat import unicode_type
@@ -118,7 +119,7 @@ class FilesWriter(WriterBase):
                 dest = notebook_name + output_extension
             else:
                 dest = notebook_name
-            dest = os.path.join(build_directory, dest)
+            dest = Path(build_directory) / dest
 
             # Write conversion results.
             self.log.info("Writing %i bytes to %s", len(output), dest)


### PR DESCRIPTION
Close #974 . Mentioning @t-makaro and @MSeal since you were involved in that issue's discussion.

On a newly installed windows machine, `nbconvert 5.6.1` cannot create PDFs, but fails with the error 

```
! Undefined control sequence.

<*> .\notebook
```

as described in #974, https://github.com/jupyter/jupyter_core/issues/144, and https://discourse.jupyter.org/t/convert-notebook-to-pdf/1227/3.

In my testing, this is because `xelatex` does not seem to recognize backslashes as windows file path separators (tested in powershell, cmd, and gitbash/mintty), which are created when using `os.path.join`. As a resolution to this, I suggest using `pathlib` semantics instead of `os.path.join` to create the filename path for `xelatex`.

`pathlib` is available since Python 3.4 and I noticed that nbconvert already require >= 3.6, so this should not be a compatibility issue. I have kept the change minimal in this PR, if you want to replace more of the `os.path` occurrences, let me know.

I tested this on Windows 10 19041.388 and Arch 5.7.9-arch1-1 with `nbconvert 5.6.1` on both machines. On the windows machine, I installed Tex via TinyTex (which provides `xelatex 3.14159265-2.6-0.999992`).


