### PR TITLE
DOC: use pygments_style provided by HTML theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,7 +115,7 @@ default_role = 'any'
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+#pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
The sickly-green background for code blocks is quite ugly, and it will become even more so when https://github.com/spatialaudio/nbsphinx/pull/463 will be merged, which will use the same background color for notebook code cells.

I guess the current setting is a remnant from using `sphinx-quickstart`, which added the `'sphinx'` style up to some time ago, when this was removed. Now the default is to not change the `pygment_style`.