### PR TITLE
fix: small typos/corrections on the docs for the template sytem

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -117,7 +117,7 @@ option. For example, to use the ``reveal`` template with the HTML exporter
    To produce HTML corresponding to the looks of the classic notebook, one can use the
    ``classic`` template by passing ``--template classic`` to the command line.
 
-The nbconvet template system has been completely revamped with nbconvert 6.0 to allow
+The nbconvert template system has been completely revamped with nbconvert 6.0 to allow
 for greater extensibility. Nbconvert templates can now be installed as third-party packages
 and are automatically picked up by nbconvert.
 

--- a/docs/source/customizing.rst
+++ b/docs/source/customizing.rst
@@ -20,10 +20,10 @@ Where are nbconvert templates installed?
 
 Nbconvert templates are *directories* containing resources for nbconvert template
 exporters such as jinja templates and associated assets. They are installed in the
-**data directory** of nbconvert, namely ``<installation prefix>/jupyter/nbconvert``.
+**data directory** of nbconvert, namely ``<installation prefix>/share/jupyter/nbconvert``.
 Nbconvert includes several templates already.
 
-For example, three templates are provided in nbconvert core for the HTML exporter:
+For example, three HTML templates are provided in nbconvert core for the HTML exporter:
 
  - ``lab`` (The default HTML template, which produces the same DOM structure as JupyterLab)
  - ``classic`` (The HTML template styled after the classic notebook)
@@ -83,8 +83,8 @@ template, exports text/html, and enables a preprocessor called "500-reveal".
       }
     }
 
-Inheitance
-~~~~~~~~~~~~
+Inheritance
+~~~~~~~~~~~
 
 Nbconvert walks up the inheritance structure determined by ``conf.json`` and produces an agregated
 configuration, merging the dictionaries of registered preprocessors.
@@ -126,4 +126,3 @@ from the Jupyter data directory.
 For example, in the reveal template, ``index.html.j2`` extends ``base.html.j2`` which is in the same directory, and
 ``base.html.j2`` extends ``lab/base.html.j2``. This approach allows using content that is available in other templates
 or may be overriden in the current template.
-


### PR DESCRIPTION
Nice work on the docs @SylvainCorlay, I only had a few small corrections.

I wasn't sure the `<prefix>/share/jupyter/nbconvert/` also worked on windows. But it seems it does:
```
In [3]: import jupyter_core.paths

In [4]: jupyter_core.paths.jupyter_path('nbconvert')
Out[4]:
['C:\\Users\\maartenbreddels\\AppData\\Roaming\\jupyter\\nbconvert',
 'C:\\Users\\maartenbreddels\\Anaconda3\\envs\\vaex\\share\\jupyter\\nbconvert',
 'C:\\ProgramData\\jupyter\\nbconvert']

```