### PR TITLE
Handle ValueErrors raised by get_exporter

### DIFF
--- a/nbconvert/exporters/base.py
+++ b/nbconvert/exporters/base.py
@@ -141,6 +141,6 @@ def get_export_names(config=get_config()):
             e = get_exporter(exporter_name)(config=config)
             if e.enabled:
                 enabled_exporters.append(exporter_name)
-        except ExporterDisabledError:
+        except (ExporterDisabledError, ValueError):
             pass
     return enabled_exporters


### PR DESCRIPTION
Fixes  #1366

```bash
$ python -m jupyterlab.browser_check
...
[I 2020-09-10 06:05:49.817 ServerApp] Test Complete
[I 2020-09-10 06:05:49.817 ServerApp] Exiting normally
[I 2020-09-10 06:05:49.817 ServerApp] Stopping server..
```