### PR TITLE
Execute preprocess cells

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -64,7 +64,7 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
             Additional resources used in the conversion process.
         """
         # Although this solution may look wrong, it considers that preprocess acts like an init on execution state.
-        # we need to capture it here again to properly reset (traitlet assignments are
+        # Therefore, we need to capture it here again to properly reset because traitlet assignments are
         # not passed). The risk is if traitlets apply any side effects for dual init,
         # The risk should be manageable, and this approach minimizes side-effects
         # relative to other alternatives. One alternative but rejected implementation would be to copy the client's init internals

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -44,6 +44,17 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
 
         The input argument *nb* is modified in-place.
 
+        Note that this function recalls NotebookClient.__init__, which may look wrong.
+        However since the preprocess call acts line an init on exeuction state it's expected.
+        Therefore, we need to capture it here again to properly reset because traitlet 
+        assignments are not passed. There is a risk if traitlets apply any side effects for
+        dual init.
+        The risk should be manageable, and this approach minimizes side-effects relative
+        to other alternatives.
+
+        One alternative but rejected implementation would be to copy the client's init internals
+        which has already gotten out of sync with nbclient 0.5 release before nbcovnert 6.0 released.
+
         Parameters
         ----------
         nb : NotebookNode
@@ -63,12 +74,6 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         resources : dictionary
             Additional resources used in the conversion process.
         """
-        # Although this solution may look wrong, it considers that preprocess acts like an init on execution state.
-        # Therefore, we need to capture it here again to properly reset because traitlet assignments are
-        # not passed. There is a risk if traitlets apply any side effects for dual init.
-        # The risk should be manageable, and this approach minimizes side-effects
-        # relative to other alternatives. One alternative but rejected implementation would be to copy the client's init internals
-        # which has already gotten out of sync with nbclient 0.5 release.
         NotebookClient.__init__(self, nb, km)
         self._check_assign_resources(resources)
         self.execute()
@@ -83,7 +88,7 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         """
         Executes a single code cell.
 
-        To execute all cells see :meth:`execute`.
+        Overwrites NotebookClient's version of this method to allow for preprocess_cell calls.
 
         Parameters
         ----------
@@ -136,5 +141,6 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
             Index of the cell being processed
         """
         self._check_assign_resources(resources)
+        # Because nbclient is an async library, we need to wrap the parent async call to generate a syncronous version.
         cell = run_sync(NotebookClient.async_execute_cell)(self, cell, index, store_history=self.store_history)
         return cell, self.resources

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -63,7 +63,7 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         resources : dictionary
             Additional resources used in the conversion process.
         """
-        # This may look wrong, but preprocess acts like an init on execution state and
+        # Although this solution may look wrong, it considers that preprocess acts like an init on execution state.
         # we need to capture it here again to properly reset (traitlet assignments are
         # not passed). The risk is if traitlets apply any side effects for dual init,
         # The risk should be manageable, and this approach minimizes side-effects

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -65,7 +65,7 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         """
         # Although this solution may look wrong, it considers that preprocess acts like an init on execution state.
         # Therefore, we need to capture it here again to properly reset because traitlet assignments are
-        not passed. There is a risk if traitlets apply any side effects for dual init.
+        # not passed. There is a risk if traitlets apply any side effects for dual init.
         # The risk should be manageable, and this approach minimizes side-effects
         # relative to other alternatives. One alternative but rejected implementation would be to copy the client's init internals
         # which has already gotten out of sync with nbclient 0.5 release.

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -66,7 +66,8 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         # This may look wrong, but preprocess acts like an init on execution state and
         # we need to capture it here again to properly reset (traitlet assignments are
         # not passed). The risk is if traitlets apply any side effects for dual init,
-        # but it should be ok. The alternative is to copy the client's init internals
+        # The risk should be manageable, and this approach minimizes side-effects
+        # relative to other alternatives. One alternative but rejected implementation would be to copy the client's init internals
         # which has already gotten out of sync with nbclient 0.5 release.
         NotebookClient.__init__(self, nb, km)
         self._check_assign_resources(resources)

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -65,7 +65,7 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         """
         # Although this solution may look wrong, it considers that preprocess acts like an init on execution state.
         # Therefore, we need to capture it here again to properly reset because traitlet assignments are
-        # not passed). The risk is if traitlets apply any side effects for dual init,
+        not passed. There is a risk if traitlets apply any side effects for dual init.
         # The risk should be manageable, and this approach minimizes side-effects
         # relative to other alternatives. One alternative but rejected implementation would be to copy the client's init internals
         # which has already gotten out of sync with nbclient 0.5 release.

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -85,7 +85,7 @@ def test_preprocess_cell():
     class CellReplacer(ExecutePreprocessor):
         def preprocess_cell(self, cell, resources, index, **kwargs):
             cell.source = "print('Ignored')"
-            super().preprocess_cell(cell, resources, index, **kwargs)
+            return super().preprocess_cell(cell, resources, index, **kwargs)
 
     preprocessor = CellReplacer()
     fname = os.path.join(os.path.dirname(__file__), 'files', 'HelloWorld.ipynb')


### PR DESCRIPTION
Fixes inheritance models where subclasses are used to implement preprocess_cells on the execute preprocessor.

There's one hack in this process, but the alternatives are all worse for maintenance pov (including some ones I didn't mention like not dual inheriting classes) so it is what it is to maintain backwards and forward compatibility.