### PR TITLE
Apply windows work-around fix for async applications

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -13,6 +13,7 @@ import logging
 import sys
 import os
 import glob
+import asyncio
 from textwrap import fill, dedent
 from ipython_genutils.text import indent
 
@@ -285,6 +286,10 @@ class NbConvertApp(JupyterApp):
     @catch_config_error
     def initialize(self, argv=None):
         """Initialize application, notebooks, writer, and postprocessor"""
+        # See https://bugs.python.org/issue37373 :(
+        if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
         self.init_syspath()
         super().initialize(argv)
         self.init_notebooks()


### PR DESCRIPTION
Mirrors https://github.com/nteract/papermill/pull/517 for patching the entrypoint. Should fix https://github.com/jupyter/nbconvert/issues/1372 if they're using command line. If they are importing as a library they might still need to apply the same work-around because it doesn't do anything if async calls have already begun so we only protect the application launch point.

No real way to write a unittest for this one

This should be the last issue for 6.0.2 release with a few fixes added