### PR TITLE
Fixed template assignments with old basic and full names with tpl extension

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -57,6 +57,10 @@ HTML
 
     Simplified HTML, using the classic jupyter look and feel.
 
+  - ``--template basic``
+
+    Base HTML, rendering with minimal structure and styles.
+
 .. _convert_latex:
 
 LaTeX

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -565,18 +565,37 @@ class TemplateExporter(Exporter):
                 template_dir = os.path.join(base_dir, base_template)
                 if os.path.exists(template_dir):
                     found_at_least_one = True
-                conf_file = os.path.join(template_dir, 'conf.json')
-                if os.path.exists(conf_file):
-                    with open(conf_file) as f:
-                        conf = recursive_update(json.load(f), conf)
-            for root_dir in root_dirs:
-                template_dir = os.path.join(root_dir, 'nbconvert', 'templates', base_template)
-                if os.path.exists(template_dir):
-                    found_at_least_one = True
-                conf_file = os.path.join(template_dir, 'conf.json')
-                if os.path.exists(conf_file):
-                    with open(conf_file) as f:
-                        conf = recursive_update(json.load(f), conf)
+                    conf_file = os.path.join(template_dir, 'conf.json')
+                    if os.path.exists(conf_file):
+                        with open(conf_file) as f:
+                            conf = recursive_update(json.load(f), conf)
+                    break
+            if not found_at_least_one:
+                for root_dir in root_dirs:
+                    template_dir = os.path.join(root_dir, 'nbconvert', 'templates', base_template)
+                    if os.path.exists(template_dir):
+                        found_at_least_one = True
+                        conf_file = os.path.join(template_dir, 'conf.json')
+                        if os.path.exists(conf_file):
+                            with open(conf_file) as f:
+                                conf = recursive_update(json.load(f), conf)
+                        break
+            if not found_at_least_one:
+                for root_dir in root_dirs:
+                    compatibility_name = base_template + '.tpl'
+                    compatibility_path = os.path.join(root_dir, 'nbconvert', 'templates', 'compatibility', compatibility_name)
+                    if os.path.exists(compatibility_path):
+                        found_at_least_one = True
+                        warnings.warn(
+                            f"5.x template name passed '{self.template_name}'. Use 'lab' or 'classic' for new template usage.",
+                            DeprecationWarning)
+                        self.template_file = compatibility_name
+                        # Without these added the templates can't find their transitive extensions
+                        if base_template == 'basic':
+                            template_names.extend(['classic', 'base'])
+                        if base_template == 'full':
+                            template_names.extend(['lab', 'base'])
+                        break
             if not found_at_least_one:
                 paths = "\n\t".join(root_dirs)
                 raise ValueError('No template sub-directory with name %r found in the following paths:\n\t%s' % (base_template, paths))

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -590,11 +590,6 @@ class TemplateExporter(Exporter):
                             f"5.x template name passed '{self.template_name}'. Use 'lab' or 'classic' for new template usage.",
                             DeprecationWarning)
                         self.template_file = compatibility_name
-                        # Without these added the templates can't find their transitive extensions
-                        if base_template == 'basic':
-                            template_names.extend(['classic', 'base'])
-                        if base_template == 'full':
-                            template_names.extend(['lab', 'base'])
                         break
             if not found_at_least_one:
                 paths = "\n\t".join(root_dirs)

--- a/nbconvert/exporters/tests/test_html.py
+++ b/nbconvert/exporters/tests/test_html.py
@@ -140,9 +140,9 @@ class TestHTMLExporter(ExportersTestsBase):
         (output, resources) = HTMLExporter(template_name='classic', filters=filters).from_notebook_node(nb)
         self.assertTrue("ADDED_TEXT" in output)
 
-    def test_basic_compatibility_name(self):
+    def test_basic_name(self):
         """
-        Can a HTMLExporter export using the 'basic' compatibility template?
+        Can a HTMLExporter export using the 'basic' template?
         """
         (output, resources) = HTMLExporter(template_name='basic').from_filename(self._get_notebook())
         assert len(output) > 0

--- a/nbconvert/exporters/tests/test_html.py
+++ b/nbconvert/exporters/tests/test_html.py
@@ -140,3 +140,9 @@ class TestHTMLExporter(ExportersTestsBase):
         (output, resources) = HTMLExporter(template_name='classic', filters=filters).from_notebook_node(nb)
         self.assertTrue("ADDED_TEXT" in output)
 
+    def test_basic_compatibility_name(self):
+        """
+        Can a HTMLExporter export using the 'basic' compatibility template?
+        """
+        (output, resources) = HTMLExporter(template_name='basic').from_filename(self._get_notebook())
+        assert len(output) > 0

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -200,6 +200,28 @@ class TestExporter(ExportersTestsBase):
             assert os.path.dirname(template) in exporter.template_paths
 
     # Can't use @pytest.mark.parametrize without removing all self.assert calls in all tests... repeating some here
+    def absolute_template_name_5x_compatibility_test(self, template):
+        config = Config()
+        # We're setting the template_name instead of the template_file
+        config.TemplateExporter.template_name = template
+        with pytest.warns(DeprecationWarning):
+            exporter = self._make_exporter(config=config)
+        template_dir, template_file = os.path.split(exporter.template.filename)
+        _, compat_dir = os.path.split(template_dir)
+        assert compat_dir == 'compatibility'
+        assert template_file == template + '.tpl'
+        assert template_dir in exporter.template_paths
+
+    def test_absolute_template_name_5x_compatibility_basic(self):
+        self.absolute_template_name_5x_compatibility_test('basic')
+
+    def test_absolute_template_name_5x_compatibility_full(self):
+        self.absolute_template_name_5x_compatibility_test('full')
+
+    def test_absolute_template_name_5x_compatibility_display_priority(self):
+        self.absolute_template_name_5x_compatibility_test('display_priority')
+
+    # Can't use @pytest.mark.parametrize without removing all self.assert calls in all tests... repeating some here
     def relative_template_test(self, template):
         with tempdir.TemporaryWorkingDirectory() as td:
             with patch('os.getcwd', return_value=os.path.abspath(td)):

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -212,9 +212,6 @@ class TestExporter(ExportersTestsBase):
         assert template_file == template + '.tpl'
         assert template_dir in exporter.template_paths
 
-    def test_absolute_template_name_5x_compatibility_basic(self):
-        self.absolute_template_name_5x_compatibility_test('basic')
-
     def test_absolute_template_name_5x_compatibility_full(self):
         self.absolute_template_name_5x_compatibility_test('full')
 

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -194,8 +194,8 @@ class NbConvertApp(JupyterApp):
         > jupyter nbconvert --to latex mynotebook.ipynb
 
         Both HTML and LaTeX support multiple output templates. LaTeX includes
-        'base', 'article' and 'report'.  HTML includes 'basic' and 'full'. You
-        can specify the flavor of the format used.
+        'base', 'article' and 'report'.  HTML includes 'basic', 'classic' and 'lab'.
+        You can specify the flavor of the format used.
 
         > jupyter nbconvert --to html --template lab mynotebook.ipynb
         

--- a/share/jupyter/nbconvert/templates/asciidoc/index.asciidoc.j2
+++ b/share/jupyter/nbconvert/templates/asciidoc/index.asciidoc.j2
@@ -1,4 +1,4 @@
-{% extends 'display_priority.j2' %}
+{% extends 'base/display_priority.j2' %}
 
 
 {% block input %}

--- a/share/jupyter/nbconvert/templates/basic/conf.json
+++ b/share/jupyter/nbconvert/templates/basic/conf.json
@@ -1,0 +1,13 @@
+{
+    "base_template": "base",
+    "mimetypes": {
+        "text/html": true
+    },
+    "preprocessors": {
+        "100-pygments": {
+            "type": "nbconvert.preprocessors.CSSHTMLHeaderPreprocessor",
+            "enabled": true,
+            "style": "default"
+        }
+    }
+}

--- a/share/jupyter/nbconvert/templates/basic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/basic/index.html.j2
@@ -1,0 +1,1 @@
+{%- extends 'classic/base.html.j2' -%}

--- a/share/jupyter/nbconvert/templates/classic/base.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/base.html.j2
@@ -1,5 +1,5 @@
-{%- extends 'display_priority.j2' -%}
-{% from 'celltags.j2' import celltags %}
+{%- extends 'base/display_priority.j2' -%}
+{% from 'base/celltags.j2' import celltags %}
 
 {% block codecell %}
 <div class="cell border-box-sizing code_cell rendered{{ celltags(cell) }}">

--- a/share/jupyter/nbconvert/templates/classic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/index.html.j2
@@ -1,6 +1,6 @@
-{%- extends 'base.html.j2' -%}
-{% from 'mathjax.html.j2' import mathjax %}
-{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+{%- extends 'classic/base.html.j2' -%}
+{% from 'base/mathjax.html.j2' import mathjax %}
+{% from 'base/jupyter_widgets.html.j2' import jupyter_widgets %}
 
 {%- block header -%}
 <!DOCTYPE html>
@@ -34,7 +34,7 @@
 {% endfor %}
 
 {% block notebook_css %}
-{{ resources.include_css("static/style.css") }}
+{{ resources.include_css("classic/static/style.css") }}
 <style type="text/css">
 /* Overrides of notebook CSS for static HTML export */
 body {

--- a/share/jupyter/nbconvert/templates/compatibility/basic.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/basic.tpl
@@ -1,2 +1,0 @@
-{{ resources.deprecated("This template is deprecated, please use classic/index.html.j2") }}
-{%- extends 'classic/index.html.j2' -%}

--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -1,5 +1,5 @@
-{%- extends 'display_priority.j2' -%}
-{% from 'celltags.j2' import celltags %}
+{%- extends 'base/display_priority.j2' -%}
+{% from 'base/celltags.j2' import celltags %}
 
 {% block codecell %}
 {%- if not cell.outputs -%}

--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -1,6 +1,6 @@
-{%- extends 'base.html.j2' -%}
-{% from 'mathjax.html.j2' import mathjax %}
-{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+{%- extends 'lab/base.html.j2' -%}
+{% from 'base/mathjax.html.j2' import mathjax %}
+{% from 'base/jupyter_widgets.html.j2' import jupyter_widgets %}
 
 {%- block header -%}
 <!DOCTYPE html>
@@ -34,11 +34,11 @@
 {% endfor %}
 
 {% block notebook_css %}
-{{ resources.include_css("static/index.css") }}
+{{ resources.include_css("lab/static/index.css") }}
 {% if resources.theme == 'dark' %}
-    {{ resources.include_css("static/theme-dark.css") }}
+    {{ resources.include_css("lab/static/theme-dark.css") }}
 {% else %}
-    {{ resources.include_css("static/theme-light.css") }}
+    {{ resources.include_css("lab/static/theme-light.css") }}
 {% endif %}
 <style type="text/css">
 a.anchor-link {

--- a/share/jupyter/nbconvert/templates/latex/base.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/base.tex.j2
@@ -4,7 +4,7 @@ functions. Figures, data_text,
 This template defines defines a default docclass, the inheriting class should
 override this.-=))
 
-((*- extends 'document_contents.tex.j2' -*))
+((*- extends 'latex/document_contents.tex.j2' -*))
 
 %===============================================================================
 % Abstract overrides

--- a/share/jupyter/nbconvert/templates/latex/display_priority.j2
+++ b/share/jupyter/nbconvert/templates/latex/display_priority.j2
@@ -2,7 +2,7 @@
     To edit this file, please refer to ../../skeleton/README.md =))
 
 
-((*- extends 'null.j2' -*))
+((*- extends 'latex/null.j2' -*))
 
 ((=display data priority=))
 

--- a/share/jupyter/nbconvert/templates/latex/document_contents.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/document_contents.tex.j2
@@ -1,4 +1,4 @@
-((*- extends 'display_priority.j2' -*))
+((*- extends 'latex/display_priority.j2' -*))
 
 %===============================================================================
 % Support blocks

--- a/share/jupyter/nbconvert/templates/latex/index.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/index.tex.j2
@@ -1,7 +1,7 @@
 
 ((=- Default to the notebook output style -=))
 ((*- if not cell_style is defined -*))
-    ((* set cell_style = 'style_jupyter.tex.j2' *))
+    ((* set cell_style = 'latex/style_jupyter.tex.j2' *))
 ((*- endif -*))
 
 ((=- Inherit from the specified cell style. -=))

--- a/share/jupyter/nbconvert/templates/latex/report.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/report.tex.j2
@@ -1,7 +1,7 @@
 
 % Default to the notebook output style
 ((* if not cell_style is defined *))
-    ((* set cell_style = 'style_ipython.tex.j2' *))
+    ((* set cell_style = 'latex/style_ipython.tex.j2' *))
 ((* endif *))
 
 % Inherit from the specified cell style.

--- a/share/jupyter/nbconvert/templates/latex/style_bw_ipython.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/style_bw_ipython.tex.j2
@@ -1,6 +1,6 @@
 ((= Black&white ipython input/output style =))
 
-((*- extends 'base.tex.j2' -*))
+((*- extends 'latex/base.tex.j2' -*))
 
 %===============================================================================
 % Input

--- a/share/jupyter/nbconvert/templates/latex/style_bw_python.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/style_bw_python.tex.j2
@@ -1,6 +1,6 @@
 ((= Black&white Python input/output style =))
 
-((*- extends 'base.tex.j2' -*))
+((*- extends 'latex/base.tex.j2' -*))
 
 %===============================================================================
 % Input

--- a/share/jupyter/nbconvert/templates/latex/style_ipython.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/style_ipython.tex.j2
@@ -1,6 +1,6 @@
 ((= IPython input/output style =))
 
-((*- extends 'base.tex.j2' -*))
+((*- extends 'latex/base.tex.j2' -*))
 
 % Custom definitions
 ((* block definitions *))

--- a/share/jupyter/nbconvert/templates/latex/style_jupyter.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/style_jupyter.tex.j2
@@ -1,5 +1,5 @@
 ((=- IPython input/output style -=))
-((*- extends 'base.tex.j2' -*))
+((*- extends 'latex/base.tex.j2' -*))
 
 ((*- block packages -*))
     \usepackage[breakable]{tcolorbox}

--- a/share/jupyter/nbconvert/templates/latex/style_python.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/style_python.tex.j2
@@ -1,6 +1,6 @@
 ((= Python input/output style =))
 
-((*- extends 'base.tex.j2' -*))
+((*- extends 'latex/base.tex.j2' -*))
 
 % Custom definitions
 ((* block definitions *))

--- a/share/jupyter/nbconvert/templates/python/index.py.j2
+++ b/share/jupyter/nbconvert/templates/python/index.py.j2
@@ -1,4 +1,4 @@
-{%- extends 'null.j2' -%}
+{%- extends 'base/null.j2' -%}
 
 {%- block header -%}
 #!/usr/bin/env python

--- a/share/jupyter/nbconvert/templates/reveal/index.html.j2
+++ b/share/jupyter/nbconvert/templates/reveal/index.html.j2
@@ -90,7 +90,7 @@ a.anchor-link {
 }
 </style>
 
-{{ resources.include_css("lab/static/custom_reveal.css") }}
+{{ resources.include_css("reveal/static/custom_reveal.css") }}
 
 {% endblock notebook_css %}
 {%- endblock html_head -%}

--- a/share/jupyter/nbconvert/templates/reveal/index.html.j2
+++ b/share/jupyter/nbconvert/templates/reveal/index.html.j2
@@ -1,6 +1,6 @@
-{%- extends 'base.html.j2' -%}
-{% from 'mathjax.html.j2' import mathjax %}
-{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+{%- extends 'reveal/base.html.j2' -%}
+{% from 'base/mathjax.html.j2' import mathjax %}
+{% from 'base/jupyter_widgets.html.j2' import jupyter_widgets %}
 
 {% set reveal_url_prefix = resources.reveal.url_prefix | default('https://unpkg.com/reveal.js@4.0.2', true) %}
 {% set reveal_theme = resources.reveal.theme | default('white', true) %}
@@ -61,11 +61,11 @@ if( window.location.search.match( /print-pdf/gi ) ) {
 {% endfor %}
 
 {% block notebook_css %}
-{{ resources.include_css("static/index.css") }}
+{{ resources.include_css("lab/static/index.css") }}
 {% if resources.theme == 'dark' %}
-    {{ resources.include_css("static/theme-dark.css") }}
+    {{ resources.include_css("lab/static/theme-dark.css") }}
 {% else %}
-    {{ resources.include_css("static/theme-light.css") }}
+    {{ resources.include_css("lab/static/theme-light.css") }}
 {% endif %}
 <style type="text/css">
 a.anchor-link {
@@ -90,7 +90,7 @@ a.anchor-link {
 }
 </style>
 
-{{ resources.include_css("static/custom_reveal.css") }}
+{{ resources.include_css("lab/static/custom_reveal.css") }}
 
 {% endblock notebook_css %}
 {%- endblock html_head -%}

--- a/share/jupyter/nbconvert/templates/rst/index.rst.j2
+++ b/share/jupyter/nbconvert/templates/rst/index.rst.j2
@@ -1,4 +1,4 @@
-{%- extends 'display_priority.j2' -%}
+{%- extends 'base/display_priority.j2' -%}
 
 
 {% block in_prompt %}

--- a/share/jupyter/nbconvert/templates/script/script.j2
+++ b/share/jupyter/nbconvert/templates/script/script.j2
@@ -1,4 +1,4 @@
-{%- extends 'null.j2' -%}
+{%- extends 'base/null.j2' -%}
 
 {% block input %}
 {{ cell.source }}


### PR DESCRIPTION
In the refactor that simplified the template_name fetching we broke using `template=basic` despite the path to the compatibility templates being added to the search paths. This fixes this by searching the compatibility directory last.

Second half of resolving https://github.com/jupyter/nbconvert/issues/1384