### PR TITLE
Updated PythonExporter to denote shebang decision from early nbconvert

### DIFF
--- a/nbconvert/exporters/python.py
+++ b/nbconvert/exporters/python.py
@@ -11,6 +11,8 @@ from .templateexporter import TemplateExporter
 class PythonExporter(TemplateExporter):
     """
     Exports a Python code file.
+    Note that the file produced will have a shebang of '#!/usr/bin/env python'
+    regardless of the actual python version used in the notebook.
     """
     @default('file_extension')
     def _file_extension_default(self):


### PR DESCRIPTION
Resolves https://github.com/jupyter/nbconvert/issues/1390 by adding the project opinion to the readthedocs page for clarity. Deeper clarify as to why can be found in the linked issue.