### PR TITLE
Fixed erroneous markdown counts for execute preprocessor breaking nbformat rules

### DIFF
--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -121,7 +121,8 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         # Copied and intercepted to allow for custom preprocess_cell contracts to be fullfilled
         self.store_history = store_history
         cell, resources = self.preprocess_cell(cell, self.resources, cell_index)
-        if execution_count:
+        # Apply rules from nbclient for where to apply execution counts
+        if execution_count and cell.cell_type == 'code' and cell.source.strip():
             cell['execution_count'] = execution_count
         return cell, resources
 

--- a/nbconvert/preprocessors/tests/files/MixedMarkdown.ipynb
+++ b/nbconvert/preprocessors/tests/files/MixedMarkdown.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "this is a code cell\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('this is a code cell')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# This is a markdown cell"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbconvert/preprocessors/tests/test_execute.py
+++ b/nbconvert/preprocessors/tests/test_execute.py
@@ -64,6 +64,15 @@ def test_basic_execution():
     assert_notebooks_equal(input_nb, output_nb)
 
 
+def test_mixed_markdown_execution():
+    preprocessor = ExecutePreprocessor()
+    fname = os.path.join(os.path.dirname(__file__), 'files', 'MixedMarkdown.ipynb')
+    with open(fname) as f:
+        input_nb = nbformat.read(f, 4)
+        output_nb, _ = preprocessor.preprocess(deepcopy(input_nb))
+    assert_notebooks_equal(input_nb, output_nb)
+
+
 def test_executenb():
     fname = os.path.join(os.path.dirname(__file__), 'files', 'HelloWorld.ipynb')
     with open(fname) as f:


### PR DESCRIPTION
Resolves https://github.com/jupyter/nbconvert/issues/1392. This was an issue in nbclient at one point as well and I forgot to guard against it in making the work-around to enable the preprocess cell calls in nbconvert.

This warrants a patch release when it's fixed,