### PR TITLE
Remove CSS preprocessor from default

### DIFF
--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -84,7 +84,6 @@ class Exporter(LoggingConfigurable):
                                   'nbconvert.preprocessors.ExecutePreprocessor',
                                   'nbconvert.preprocessors.coalesce_streams',
                                   'nbconvert.preprocessors.SVG2PDFPreprocessor',
-                                  'nbconvert.preprocessors.CSSHTMLHeaderPreprocessor',
                                   'nbconvert.preprocessors.LatexPreprocessor',
                                   'nbconvert.preprocessors.HighlightMagicsPreprocessor',
                                   'nbconvert.preprocessors.ExtractOutputPreprocessor',

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -89,9 +89,6 @@ class HTMLExporter(TemplateExporter):
                                            'text/plain'
                                           ]
                 },
-            'CSSHTMLHeaderPreprocessor':{
-                'enabled':True
-                },
             'HighlightMagicsPreprocessor': {
                 'enabled':True
                 }

--- a/share/jupyter/nbconvert/templates/classic/conf.json
+++ b/share/jupyter/nbconvert/templates/classic/conf.json
@@ -2,5 +2,12 @@
     "base_template": "base",
     "mimetypes": {
         "text/html": true
+    },
+    "preprocessors": {
+        "100-pygments": {
+            "type": "nbconvert.preprocessors.CSSHTMLHeaderPreprocessor",
+            "enabled": true,
+            "style": "default"
+        }
     }
 }

--- a/share/jupyter/nbconvert/templates/lab/conf.json
+++ b/share/jupyter/nbconvert/templates/lab/conf.json
@@ -2,5 +2,11 @@
     "base_template": "base",
     "mimetypes": {
         "text/html": true
+    },
+    "preprocessors": {
+        "100-pygments": {
+            "type": "nbconvert.preprocessors.CSSHTMLHeaderPreprocessor",
+            "enabled": true
+        }
     }
 }

--- a/share/jupyter/nbconvert/templates/reveal/conf.json
+++ b/share/jupyter/nbconvert/templates/reveal/conf.json
@@ -4,6 +4,10 @@
         "text/html": true
     },
     "preprocessors": {
+        "100-pygments": {
+            "type": "nbconvert.preprocessors.CSSHTMLHeaderPreprocessor",
+            "enabled": true
+        },
         "500-reveal": {
             "type": "nbconvert.exporters.slides._RevealMetadataPreprocessor",
             "enabled": true


### PR DESCRIPTION
This allows the preprocessor to be configured at a template level.