### PR TITLE
Add short wait time for fonts and rendering

### DIFF
--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -38,7 +38,9 @@ class WebPDFExporter(HTMLExporter):
         async def main():
             browser = await self._check_launch_reqs()()
             page = await browser.newPage()
+            await page.waitFor(100)
             await page.goto('data:text/html,'+html, waitUntil='networkidle0')
+            await page.waitFor(100)
 
             dimensions = await page.evaluate(
               """() => {


### PR DESCRIPTION
As described in #1408, the networkidle0 and networkidle2 are not good signals to know that widgets and all outputs have finished rendering.

We need a better system, but this wait time around the network idle practically fixes the issues that I am observing.