### PR TITLE
Prevent overflow in input areas

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -47,6 +47,16 @@ a.anchor-link {
 .highlight  {
     margin: 0.4em;
 }
+
+/* Input area styling */
+.jp-InputArea {
+    overflow: hidden;
+}
+
+.jp-InputArea-editor {
+    overflow: hidden;
+}
+
 @media print {
   body {
     margin: 0;


### PR DESCRIPTION
In the notebook lab plugin, these properties are inherited from Lumino / Phosphor.

We should be able to remove these when we can use a version of lab's CSS that includes https://github.com/jupyterlab/jupyterlab/pull/9058.