### PR TITLE
fix: allow custom template files outside of the template system

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -213,16 +213,12 @@ class TemplateExporter(Exporter):
         full_path = os.path.abspath(new)
         if os.path.isfile(full_path):
             directory, self.template_file = os.path.split(full_path)
+            self.extra_template_paths = [directory] + self.extra_template_paths
             # While not strictly an invalid template file name, the extension hints that there isn't a template directory involved
             if self.template_file.endswith('.tpl'):
                 warnings.warn(
                     f"5.x style template file passed '{new}'. Use --template-name for the template directory with a index.<ext>.j2 file and/or --template-file to denote a different template.",
                     DeprecationWarning)
-            if directory:
-                directory, self.template_name = os.path.split(directory)
-            if directory:
-                if os.path.isabs(directory):
-                    self.extra_template_basedirs = [directory]
 
     @default('template_file')
     def _template_file_default(self):
@@ -237,6 +233,7 @@ class TemplateExporter(Exporter):
 
     template_paths = List(['.']).tag(config=True, affects_environment=True)
     extra_template_basedirs = List().tag(config=True, affects_environment=True)
+    extra_template_paths = List([]).tag(config=True, affects_environment=True)
 
     @default('extra_template_basedirs')
     def _default_extra_template_basedirs(self):
@@ -549,7 +546,7 @@ class TemplateExporter(Exporter):
             except OSError:
                 pass
 
-        return additional_paths + paths
+        return self.extra_template_paths + additional_paths + paths
 
     def get_template_names(self):
         # finds a list of template names where each successive template name is the base template

--- a/nbconvert/exporters/tests/files/lablike.html.j2
+++ b/nbconvert/exporters/tests/files/lablike.html.j2
@@ -1,0 +1,4 @@
+{%- extends 'lab/index.html.j2' -%}
+{%- block body_footer -%}
+UNIQUE
+{%- endblock body_footer -%}

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -272,6 +272,15 @@ class TestExporter(ExportersTestsBase):
                 assert exporter.template_name == template
                 assert os.path.join(td, template) in exporter.template_paths
 
+    def test_local_template_file_extending_lab(self):
+        template_file = os.path.join(self._get_files_path(), 'lablike.html.j2')
+        exporter = HTMLExporter(template_file=template_file, template_name='lab')
+        nb = v4.new_notebook()
+        nb.cells.append(v4.new_code_cell("some_text"))
+        output, resources = exporter.from_notebook_node(nb)
+        assert "UNIQUE" in output
+
+
     def test_raw_template_attr(self):
         """
         Verify that you can assign a in memory template string by overwriting


### PR DESCRIPTION
As discussed over a videocall with @Mseal and @SylvainCorlay, this PR:
 * Fixes #1394 
 * is an alternative to a part of #1387 
 * and is a followup of #1292

In #1292, we kind of 'tricked' the template system, by replacing the template_name by the parent directory name of the template_file. That caused an override of the template name. If we don't do that, but simply add that directory to the template search path, the whole template system machinery works with us. This allows .e.g:
```
$ python -m nbconvert --to html --execute --template material --TemplateExporter.template_file=nbconvert/exporters/tests/files/lablike.html.j2 ~/src/QuantStack/voila/notebooks/basics.ipynb
```

So we use a particular template (material in this case, but could be labl) but override the template_file.