### PR TITLE
Restored basic template from 5.x

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -57,6 +57,10 @@ HTML
 
     Simplified HTML, using the classic jupyter look and feel.
 
+  - ``--template basic``
+
+    Base HTML, rendering with minimal structure and styles.
+
 .. _convert_latex:
 
 LaTeX

--- a/nbconvert/exporters/tests/test_html.py
+++ b/nbconvert/exporters/tests/test_html.py
@@ -140,3 +140,9 @@ class TestHTMLExporter(ExportersTestsBase):
         (output, resources) = HTMLExporter(template_name='classic', filters=filters).from_notebook_node(nb)
         self.assertTrue("ADDED_TEXT" in output)
 
+    def test_basic_name(self):
+        """
+        Can a HTMLExporter export using the 'basic' template?
+        """
+        (output, resources) = HTMLExporter(template_name='basic').from_filename(self._get_notebook())
+        assert len(output) > 0

--- a/share/jupyter/nbconvert/templates/basic/conf.json
+++ b/share/jupyter/nbconvert/templates/basic/conf.json
@@ -1,0 +1,6 @@
+{
+    "base_template": "classic",
+    "mimetypes": {
+        "text/html": true
+    }
+}

--- a/share/jupyter/nbconvert/templates/basic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/basic/index.html.j2
@@ -1,0 +1,1 @@
+{%- extends 'classic/base.html.j2' -%}

--- a/share/jupyter/nbconvert/templates/compatibility/basic.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/basic.tpl
@@ -1,2 +1,0 @@
-{{ resources.deprecated("This template is deprecated, please use classic/index.html.j2") }}
-{%- extends 'classic/index.html.j2' -%}

--- a/share/jupyter/nbconvert/templates/compatibility/full.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/full.tpl
@@ -1,2 +1,2 @@
 {{ resources.deprecated("This template is deprecated, please use lab/index.html.j2") }}
-{%- extends 'lab/index.html.j2' -%}
+{%- extends 'classic/index.html.j2' -%}


### PR DESCRIPTION
Extracted the basic template addition from https://github.com/jupyter/nbconvert/pull/1387 into an isolated PR. The full.tpl was mapped back to `classic` instead of `lab` because it was incorrectly pointing to the newer template in lieu of basic pointing to `classic` before this.