### PR TITLE
Added proper support for backwards compatibility templates

### DIFF
--- a/nbconvert/exporters/tests/test_rst.py
+++ b/nbconvert/exporters/tests/test_rst.py
@@ -37,15 +37,6 @@ class TestRSTExporter(ExportersTestsBase):
         assert len(output) > 0
 
     @onlyif_cmds_exist('pandoc')
-    def test_export_nbformat_template_v5_name(self):
-        """
-        We support the nbconvert v5 filename, but with a deprecation warning.
-        """
-        with pytest.warns(DeprecationWarning):
-            (output, resources) = RSTExporter(template_file='rst.tpl').from_filename(self._get_notebook())
-        assert len(output) > 0
-
-    @onlyif_cmds_exist('pandoc')
     def test_empty_code_cell(self):
         """No empty code cells in rst"""
         nbname = self._get_notebook()

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -43,8 +43,6 @@ class SampleExporter(TemplateExporter):
     def _template_name_default(self):
         return 'python'
 
-    output_mimetype = 'text/x-python'
-
 class TestExporter(ExportersTestsBase):
     """Contains test functions for exporter.py"""
 
@@ -198,6 +196,25 @@ class TestExporter(ExportersTestsBase):
                 exporter = self._make_exporter(config=config)
             assert exporter.template.filename == template
             assert os.path.dirname(template) in exporter.template_paths
+    
+    # Can't use @pytest.mark.parametrize without removing all self.assert calls in all tests... repeating some here
+    def absolute_template_name_5x_compatibility_test(self, template, mimetype=None):
+        config = Config()
+        # We're setting the template_name instead of the template_file
+        config.TemplateExporter.template_name = template
+        with pytest.warns(DeprecationWarning):
+            exporter = self._make_exporter(config=config)
+        template_dir, template_file = os.path.split(exporter.template.filename)
+        _, compat_dir = os.path.split(template_dir)
+        assert compat_dir == 'compatibility'
+        assert template_file == template + '.tpl'
+        assert template_dir in exporter.template_paths
+
+    def test_absolute_template_name_5x_compatibility_full(self):
+        self.absolute_template_name_5x_compatibility_test('full', 'text/html')
+
+    def test_absolute_template_name_5x_compatibility_display_priority(self):
+        self.absolute_template_name_5x_compatibility_test('display_priority')
 
     # Can't use @pytest.mark.parametrize without removing all self.assert calls in all tests... repeating some here
     def relative_template_test(self, template):

--- a/share/jupyter/nbconvert/templates/compatibility/display_priority.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/display_priority.tpl
@@ -1,2 +1,2 @@
 {{ resources.deprecated("This template is deprecated, please use base/display_priority.j2") }}
-{%- extends 'base/display_priority.j2' -%}
+{%- extends 'display_priority.j2' -%}

--- a/share/jupyter/nbconvert/templates/compatibility/full.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/full.tpl
@@ -1,2 +1,2 @@
-{{ resources.deprecated("This template is deprecated, please use lab/index.html.j2") }}
-{%- extends 'classic/index.html.j2' -%}
+{{ resources.deprecated("This template is deprecated, please use classic/index.html.j2") }}
+{%- extends 'index.html.j2' -%}

--- a/share/jupyter/nbconvert/templates/compatibility/python.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/python.tpl
@@ -1,2 +1,0 @@
-{{ resources.deprecated("This template is deprecated, please use python/index.html.j2") }}
-{%- extends 'python/index.html.j2' -%}

--- a/share/jupyter/nbconvert/templates/compatibility/rst.tpl
+++ b/share/jupyter/nbconvert/templates/compatibility/rst.tpl
@@ -1,2 +1,0 @@
-{{ resources.deprecated("This template is deprecated, please use rst/index.rst.j2") }}
-{%- extends 'rst/index.rst.j2' -%}


### PR DESCRIPTION
Added last remaining feature from https://github.com/jupyter/nbconvert/pull/1387 to support the two templates from 5.x that didn't have an equivalent pattern in 6.x