### PR TITLE
#1428 add docstring

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -303,6 +303,9 @@ class TemplateExporter(Exporter):
         help="""formats of raw cells to be included in this Exporter's output."""
     ).tag(config=True)
 
+    extra_template_basedirs = List(
+        help="Specify extra directories to search for templates").tag()
+
     @default('raw_mimetypes')
     def _raw_mimetypes_default(self):
         return [self.output_mimetype, '']


### PR DESCRIPTION
Add a docstring for `TemplateExporter.extra_template_basedirs` in response to issue #1428 

I'm unsure how to handle the `.tag()` method -- this probably requires attention from someone more knowledgeable. 