### PR TITLE
Fix error when pickling HTMLExporter

### DIFF
--- a/nbconvert/exporters/tests/test_html.py
+++ b/nbconvert/exporters/tests/test_html.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import re
+from concurrent.futures import ProcessPoolExecutor
 
 from .base import ExportersTestsBase
 from ..html import HTMLExporter
@@ -145,4 +146,13 @@ class TestHTMLExporter(ExportersTestsBase):
         Can a HTMLExporter export using the 'basic' template?
         """
         (output, resources) = HTMLExporter(template_name='basic').from_filename(self._get_notebook())
+        assert len(output) > 0
+        
+    def test_pickle(self):
+        """
+        Can HTML exporters be pickled & called across processes?
+        """
+        exporter = HTMLExporter()
+        executor = ProcessPoolExecutor()
+        (output, resources) = executor.submit(exporter.from_filename, self._get_notebook()).result()
         assert len(output) > 0


### PR DESCRIPTION
Argh. Turns out the HTML exporter had a similar issue to the TemplateExporter (in #1398) which causes it to fail to pickle. This PR fixes the HTML exporter as well.

I checked the other exporters manually and none appeared to have nested functions, but I didn't write tests for all of them.