### PR TITLE
Fix code output indentation when running nbconvert --no-input

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -122,6 +122,7 @@ nbconvert_flags.update({
         {'TemplateExporter' : {
             'exclude_output_prompt' : True,
             'exclude_input': True,
+            'exclude_input_prompt': True,
             }
         },
         """Exclude input cells and output prompts from converted document. 


### PR DESCRIPTION
This PR adds the suggested fix for https://github.com/jupyter/nbconvert/issues/1189 in https://github.com/jupyter/nbconvert/issues/1189#issuecomment-674278616. I also verified that the original problem persists in nbconvert 6.0.3 with the provided repro before opening this PR.