### PR TITLE
Include output of stdout stream in lab template

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -273,6 +273,10 @@ class TemplateExporter(Exporter):
         help = "This allows you to exclude output prompts from all templates if set to True."
         ).tag(config=True)
 
+    exclude_output_stdin = Bool(True,
+        help = "This allows you to exclude output of stdin stream from lab template if set to True."
+        ).tag(config=True)
+
     exclude_code_cell = Bool(False,
         help = "This allows you to exclude code cells from all templates if set to True."
         ).tag(config=True)
@@ -375,6 +379,7 @@ class TemplateExporter(Exporter):
                 'include_unknown': not self.exclude_unknown,
                 'include_input': not self.exclude_input,
                 'include_output': not self.exclude_output,
+                'include_output_stdin': not self.exclude_output_stdin,
                 'include_input_prompt': not self.exclude_input_prompt,
                 'include_output_prompt': not self.exclude_output_prompt,
                 'no_prompt': self.exclude_input_prompt and self.exclude_output_prompt,

--- a/nbconvert/exporters/tests/files/notebook3.ipynb
+++ b/nbconvert/exporters/tests/files/notebook3.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "test input: input value\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'input value'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "input(\"test input:\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbconvert/exporters/tests/test_templateexporter.py
+++ b/nbconvert/exporters/tests/test_templateexporter.py
@@ -483,6 +483,7 @@ class TestExporter(ExportersTestsBase):
                 "exclude_output_prompt": False,
                 "exclude_markdown": False,
                 "exclude_code_cell": False,
+                "exclude_output_stdin": True,
             }
         }
         c_no_io = Config(no_io)
@@ -501,6 +502,7 @@ class TestExporter(ExportersTestsBase):
                 "exclude_output_prompt": False,
                 "exclude_markdown": False,
                 "exclude_code_cell": True,
+                "exclude_output_stdin": True,
             }
         }
         c_no_code = Config(no_code)
@@ -521,6 +523,7 @@ class TestExporter(ExportersTestsBase):
                 "exclude_output_prompt": False,
                 "exclude_markdown": False,
                 "exclude_code_cell": False,
+                "exclude_output_stdin": True,
             }
         }
         c_no_input_prompt = Config(no_input_prompt)
@@ -540,6 +543,7 @@ class TestExporter(ExportersTestsBase):
                 "exclude_output_prompt": False,
                 "exclude_markdown": True,
                 "exclude_code_cell": False,
+                "exclude_output_stdin": True,
             }
         }
 
@@ -560,6 +564,7 @@ class TestExporter(ExportersTestsBase):
                 "exclude_output_prompt": True,
                 "exclude_markdown": False,
                 "exclude_code_cell": False,
+                "exclude_output_stdin": True,
             }
         }
         c_no_output_prompt = Config(no_output_prompt)
@@ -568,6 +573,48 @@ class TestExporter(ExportersTestsBase):
 
         assert not resources_no_output_prompt['global_content_filter']['include_output_prompt']
         assert "Out[1]" not in nb_no_output_prompt
+
+    def test_exclude_output_stdin(self):
+        no_output_stdin = {
+            "TemplateExporter":{
+                "exclude_output": False,
+                "exclude_input": False,
+                "exclude_input_prompt": False,
+                "exclude_output_prompt": True,
+                "exclude_markdown": False,
+                "exclude_code_cell": False,
+                "exclude_output_stdin": True,
+            }
+        }
+        c_no_output_stdin = Config(no_output_stdin)
+        exporter_no_output_prompt  = HTMLExporter(config=c_no_output_stdin)
+
+        nb_no_output_stdin, resources_no_output_stdin = exporter_no_output_prompt.from_filename(
+            self._get_notebook('notebook3.ipynb'))
+
+        assert not resources_no_output_stdin['global_content_filter']['include_output_stdin']
+        assert "test input: input value" not in nb_no_output_stdin
+
+    def test_include_output_stdin(self):
+        output_stdin = {
+            "TemplateExporter":{
+                "exclude_output": False,
+                "exclude_input": False,
+                "exclude_input_prompt": False,
+                "exclude_output_prompt": True,
+                "exclude_markdown": False,
+                "exclude_code_cell": False,
+                "exclude_output_stdin": False,
+            }
+        }
+        c_output_stdin = Config(output_stdin)
+        exporter_output_stdin= HTMLExporter(config=c_output_stdin)
+
+        nb_output_stdin, resources_output_stdin = exporter_output_stdin.from_filename(
+            self._get_notebook('notebook3.ipynb'))
+
+        assert resources_output_stdin['global_content_filter']['include_output_stdin']
+        assert "test input: input value" in nb_output_stdin
 
     def test_remove_elements_with_tags(self):
 

--- a/share/jupyter/nbconvert/templates/base/null.j2
+++ b/share/jupyter/nbconvert/templates/base/null.j2
@@ -58,6 +58,9 @@ consider calling super even if it is a leaf block, we might insert more blocks l
                                                     {%- elif output.name == 'stderr' -%}
                                                         {%- block stream_stderr scoped -%}
                                                         {%- endblock stream_stderr -%}
+                                                    {%- elif output.name == 'stdin' -%}
+                                                        {%- block stream_stdin scoped -%}
+                                                        {%- endblock stream_stdin -%}
                                                     {%- endif -%}
                                                 {%- endblock stream -%}
                                             {%- elif output.output_type == 'display_data' -%}

--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -123,6 +123,16 @@ unknown type  {{ cell.type }}
 </div>
 {%- endblock stream_stderr %}
 
+{% block stream_stdin -%}
+{%- if resources.global_content_filter.include_output_stdin -%}
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stdin">
+<pre>
+{{- output.text | ansi2html -}}
+</pre>
+</div>
+{%- endif %}
+{%- endblock stream_stdin %}
+
 {% block data_svg scoped -%}
 <div class="jp-RenderedSVG jp-OutputArea-output {{ extra_class }}" data-mime-type="image/svg+xml">
 {%- if output.svg_filename %}


### PR DESCRIPTION
The lab template does not include stdin stream generated by `input()`. I propose to add new config `exclude_output_stdin` to exclude the stdin stream in lab template.  The default value of `exclude_output_stdin` should be `True` for compatibility.

The CSS in this PR renders stdin stream as follows.

![image](https://user-images.githubusercontent.com/1088786/96347252-61d28180-10db-11eb-812a-8c739558bbaa.png)

