### PR TITLE
Fix dangling reference to get_template_paths()

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -140,8 +140,7 @@ class HTMLExporter(TemplateExporter):
                 # if that fails (for instance a binary file, png or ttf)
                 # we mimic jinja2
                 pieces = split_template_path(name)
-                searchpaths = self.get_template_paths()
-                for searchpath in searchpaths:
+                for searchpath in self.template_paths:
                     filename = os.path.join(searchpath, *pieces)
                     print(filename, os.path.exists(filename))
                     if os.path.exists(filename):


### PR DESCRIPTION
Use the existing property interface instead. Must have been missed when it got refactored.