### PR TITLE
Solved svg2pdf conversion error if Inkscape is installed into the default path on a windows machine

### DIFF
--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -74,9 +74,9 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
 
     @default('command')
     def _command_default(self):
-        major_verison = self.inkscape_version.split('.')[0]
-        export_option = ' --export-filename' if int(major_verison) > 0 else ' --export-pdf'
-        gui_option = '' if int(major_verison) > 0 else ' --without-gui'
+        major_version = self.inkscape_version.split('.')[0]
+        export_option = ' --export-filename' if int(major_version) > 0 else ' --export-pdf'
+        gui_option = '' if int(major_version) > 0 else ' --without-gui'
 
         return '{inkscape}{gui_option}{export_option}='.format(
             inkscape=self.inkscape, export_option=export_option, gui_option=gui_option

--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -74,12 +74,13 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
 
     @default('command')
     def _command_default(self):
+        inkscape_path_string = f'\"{self.inkscape}\"'
         major_version = self.inkscape_version.split('.')[0]
         export_option = ' --export-filename' if int(major_version) > 0 else ' --export-pdf'
         gui_option = '' if int(major_version) > 0 else ' --without-gui'
 
         return '{inkscape}{gui_option}{export_option}='.format(
-            inkscape=self.inkscape, export_option=export_option, gui_option=gui_option
+            inkscape=inkscape_path_string, export_option=export_option, gui_option=gui_option
         ) + '"{to_filename}" "{from_filename}"'
 
     inkscape = Unicode(help="The path to Inkscape, if necessary").tag(config=True)


### PR DESCRIPTION
The " " in "Program Files" in the default path for Inkscape on a windows machine makes the conversion fail. I updated the file to enclose the command string into double quotes. This allows the system to run properly on windows.

I'm not able to test on a Mac or Linux/Unix machine, so I'm unsure if my solution will create problems for users on different operating systems.