### PR TITLE
Allow get_export_names to skip configuration check

### DIFF
--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -35,6 +35,10 @@ exporting to HTML.
 CLI Flags and Aliases
 ---------------------
 
+The dynamic loading of exporters can be disabled by setting the environment
+variable ``NBCONVERT_DISABLE_CONFIG_EXPORTERS``. This causes all exporters
+to be loaded regardless of the value of their ``enabled`` attribute.
+
 When using Nbconvert from the command line, a number of aliases and flags are
 defined as shortcuts to configuration options for convience.
 

--- a/nbconvert/exporters/base.py
+++ b/nbconvert/exporters/base.py
@@ -3,6 +3,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import os
 import warnings
 
 import entrypoints
@@ -135,6 +136,10 @@ def get_export_names(config=get_config()):
     them as an nbconvert.exporter entrypoint.
     """
     exporters = sorted(entrypoints.get_group_named('nbconvert.exporters'))
+    if os.environ.get("NBCONVERT_DISABLE_CONFIG_EXPORTERS"):
+        get_logger().info("Config exporter loading disabled, no additional exporters will be automatically included.")
+        return exporters
+
     enabled_exporters = []
     for exporter_name in exporters:
         try:

--- a/nbconvert/exporters/tests/test_exporter.py
+++ b/nbconvert/exporters/tests/test_exporter.py
@@ -97,7 +97,7 @@ class TestExporter(ExportersTestsBase):
             # enabled in the config
             self.assertNotEqual(export_names, ['notebook'])
 
-        # In the abscence of this variable we should revert to
+        # In the absence of this variable we should revert to
         # the normal behavior.
         del os.environ["NBCONVERT_DISABLE_CONFIG_EXPORTERS"]
         export_names = get_export_names(config=config)

--- a/nbconvert/exporters/tests/test_exporter.py
+++ b/nbconvert/exporters/tests/test_exporter.py
@@ -13,8 +13,10 @@ Module with tests for exporter.py
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-
+import os
 from traitlets.config import Config
+
+from unittest.mock import patch
 
 from .base import ExportersTestsBase
 from ...preprocessors.base import Preprocessor
@@ -71,5 +73,32 @@ class TestExporter(ExportersTestsBase):
             'Exporter': {'enabled': False}, 
             'NotebookExporter': {'enabled': True}
         })
+        export_names = get_export_names(config=config)
+        self.assertEqual(export_names, ['notebook'])
+
+    def test_get_exporter_disable_config_exporters(self):
+        """
+        Does get_export_names behave correctly with respect to
+        NBCONVERT_DISABLE_CONFIG_EXPORTERS being set in the
+        environment?
+        """
+        config = Config({
+            'Exporter': {'enabled': False},
+            'NotebookExporter': {'enabled': True}
+        })
+        os.environ["NBCONVERT_DISABLE_CONFIG_EXPORTERS"] = "1"
+        with patch("nbconvert.exporters.base.get_exporter") as exp:
+            export_names = get_export_names(config=config)
+            # get_export_names should not call get_exporter for
+            # any of the entry points because we return before then.
+            exp.assert_not_called()
+
+            # We should have all exporters, not just the ones
+            # enabled in the config
+            self.assertNotEqual(export_names, ['notebook'])
+
+        # In the abscence of this variable we should revert to
+        # the normal behavior.
+        del os.environ["NBCONVERT_DISABLE_CONFIG_EXPORTERS"]
         export_names = get_export_names(config=config)
         self.assertEqual(export_names, ['notebook'])


### PR DESCRIPTION
This introduces an environment variable named
NBCONVERT_DISABLE_CONFIG_EXPORTERS that will cause get_export_names to
return all entrypoints instead of checking the "enabled" status of
each one.

Closes: #1439