### PR TITLE
Fix order of template paths

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -546,7 +546,7 @@ class TemplateExporter(Exporter):
             except OSError:
                 pass
 
-        return self.extra_template_paths + additional_paths + paths
+        return paths + self.extra_template_paths + additional_paths
 
     @classmethod
     def get_compatibility_base_template_conf(cls, name):


### PR DESCRIPTION
Fixes https://github.com/jupyter/nbconvert/issues/1495.

I just played around and found this fix. I hope other devs can check this with more insight, so that nothing breaks by this patch.

Thanks!

P.S. After this patch, the repro steps described in https://github.com/jupyter/nbconvert/issues/1495 gives:
```
mostafa🐌phi ~ 
$ $VENV/jupyter nbconvert --debug --to=latex --template=my-latex-template my-notebook.ipynb
[NbConvertApp] Searching ['/repro/user-home', '/repro/user-home/.jupyter', '/repro/venv/etc/jupyter', '/usr/local/etc/jupyter', '/etc/jupyter'] for config files
[NbConvertApp] Looking for jupyter_config in /etc/jupyter
[NbConvertApp] Looking for jupyter_config in /usr/local/etc/jupyter
[NbConvertApp] Looking for jupyter_config in /repro/venv/etc/jupyter
[NbConvertApp] Looking for jupyter_config in /repro/user-home/.jupyter
[NbConvertApp] Looking for jupyter_config in /repro/user-home
[NbConvertApp] Looking for jupyter_nbconvert_config in /etc/jupyter
[NbConvertApp] Looking for jupyter_nbconvert_config in /usr/local/etc/jupyter
[NbConvertApp] Looking for jupyter_nbconvert_config in /repro/venv/etc/jupyter
[NbConvertApp] Looking for jupyter_nbconvert_config in /repro/user-home/.jupyter
[NbConvertApp] Looking for jupyter_nbconvert_config in /repro/user-home
[NbConvertApp] Converting notebook my-notebook.ipynb to latex
[NbConvertApp] Notebook name is 'my-notebook'
[NbConvertApp] Template paths:
	/repro/user-home/.local/share/jupyter/nbconvert/templates/my-latex-template 👈 Good.
	/repro/user-home/.local/share/jupyter
	/repro/user-home/.local/share/jupyter/nbconvert/templates
	/repro/user-home/.local/share/jupyter/nbconvert/templates/compatibility
	/repro/venv/share/jupyter
	/repro/venv/share/jupyter/nbconvert/templates
	/repro/venv/share/jupyter/nbconvert/templates/compatibility
	/usr/local/share/jupyter
	/usr/local/share/jupyter/nbconvert/templates
	/usr/local/share/jupyter/nbconvert/templates/compatibility
	/usr/share/jupyter
	/usr/share/jupyter/nbconvert/templates
	/usr/share/jupyter/nbconvert/templates/compatibility
	/repro/user-home/.local/share/jupyter/nbconvert/templates/latex
	/repro/venv/share/jupyter/nbconvert/templates/latex
	/usr/local/share/jupyter/nbconvert/templates/latex
	/usr/share/jupyter/nbconvert/templates/latex
[NbConvertApp] Applying preprocessor: TagRemovePreprocessor
[NbConvertApp] Applying preprocessor: RegexRemovePreprocessor
[NbConvertApp] Applying preprocessor: coalesce_streams
[NbConvertApp] Applying preprocessor: SVG2PDFPreprocessor
[NbConvertApp] Applying preprocessor: LatexPreprocessor
[NbConvertApp] Applying preprocessor: HighlightMagicsPreprocessor
[NbConvertApp] Applying preprocessor: ExtractOutputPreprocessor
[NbConvertApp] Attempting to load template index.tex.j2
[NbConvertApp]     template_paths: /repro/user-home/.local/share/jupyter/nbconvert/templates/my-latex-template:/repro/user-home/.local/share/jupyter:/repro/user-home/.local/share/jupyter/nbconvert/templates:/repro/user-home/.local/share/jupyter/nbconvert/templates/compatibility:/repro/venv/share/jupyter:/repro/venv/share/jupyter/nbconvert/templates:/repro/venv/share/jupyter/nbconvert/templates/compatibility:/usr/local/share/jupyter:/usr/local/share/jupyter/nbconvert/templates:/usr/local/share/jupyter/nbconvert/templates/compatibility:/usr/share/jupyter:/usr/share/jupyter/nbconvert/templates:/usr/share/jupyter/nbconvert/templates/compatibility:/repro/user-home/.local/share/jupyter/nbconvert/templates/latex:/repro/venv/share/jupyter/nbconvert/templates/latex:/usr/local/share/jupyter/nbconvert/templates/latex:/usr/share/jupyter/nbconvert/templates/latex
[NbConvertApp] Support files will be in my-notebook_files/
[NbConvertApp] Making directory my-notebook_files
[NbConvertApp] Writing 13500 bytes to support file my-notebook_files/my-notebook_12_1.png
[NbConvertApp] Making directory my-notebook_files
[NbConvertApp] Writing 13678 bytes to support file my-notebook_files/my-notebook_45_0.png
[NbConvertApp] Making directory my-notebook_files
[NbConvertApp] Writing 12328 bytes to support file my-notebook_files/my-notebook_58_0.png
[NbConvertApp] Making directory my-notebook_files
[NbConvertApp] Writing 13652 bytes to support file my-notebook_files/my-notebook_62_1.png
[NbConvertApp] Writing 4 bytes to my-notebook.tex

mostafa🐌phi ~ 
$ cat my-notebook.tex 
Test

```