### PR TITLE
Don't use a shell to call inkscape

### DIFF
--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -62,7 +62,7 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
             raise RuntimeError("Unable to find inkscape executable --version")
         return output.decode('utf-8').split(' ')[1]
 
-    # FIXME: Deprecate passing a list here
+    # FIXME: Deprecate passing a string here
     command = Union(
         [Unicode(), List()],
         help="""
@@ -145,7 +145,7 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
                 # For backwards compatibility with specifying strings
                 # Okay-ish, since the string is trusted
                 full_cmd = self.command.format(*template_vars)
-            subprocess.call(full_cmd, shell=isinstance(str))
+            subprocess.call(full_cmd, shell=isinstance(full_cmd, str))
 
             # Read output from drive
             # return value expects a filename

--- a/nbconvert/preprocessors/tests/test_svg2pdf.py
+++ b/nbconvert/preprocessors/tests/test_svg2pdf.py
@@ -87,8 +87,17 @@ class Testsvg2pdf(PreprocessorTestsBase):
 
     def test_inkscape_pre_v1_command(self):
         preprocessor = self.build_preprocessor(inkscape='fake-inkscape', inkscape_version='0.92.3')
-        assert preprocessor.command == 'fake-inkscape --without-gui --export-pdf="{to_filename}" "{from_filename}"'
+        assert preprocessor.command == [
+            'fake-inkscape',
+            '--without-gui',
+            '--export-filename={to_filename}',
+            '{from_filename}'
+        ]
 
     def test_inkscape_v1_command(self):
         preprocessor = self.build_preprocessor(inkscape='fake-inkscape', inkscape_version='1.0beta2')
-        assert preprocessor.command == 'fake-inkscape --export-filename="{to_filename}" "{from_filename}"'
+        assert preprocessor.command == [
+            'fake-inkscape',
+            '--export-pdf={to_filename}',
+            '{from_filename}'
+        ]


### PR DESCRIPTION
Python generally recommends against using `shell=True`
when calling
subprocesses (https://docs.python.org/3/library/subprocess.html#security-considerations).
This also causes issues with shell metacharacters (see
https://github.com/jupyter/nbconvert/pull/1469). I'm also
not entirely sure that the shell command *is* fully trustable
- I don't know where {to_filename} and {from_filename} are
from. Rest of nbconvert also prefers using lists instead
of strings to call commands.

svg2pdf also uses a command instead of a string now. We leave
the old string implementation alone for backwards compatibility,
although I'd really prefer to remove it.

We don't need the quotes set up in
https://github.com/jupyter/nbconvert/pull/1469,
since using a list automatically deals with that.