### PR TITLE
Make pagination configurable in webpdf

### DIFF
--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -24,7 +24,7 @@ class WebPDFExporter(HTMLExporter):
     ).tag(config=True)
 
     paginate = Bool(
-        False,
+        True,
         help="""
         Split generated notebook into multiple pages.
 


### PR DESCRIPTION
- Add option to paginate PDF generated via webpdf
- Default to pagination, to be a drop-in for the LaTeX
  PDF generator as much as possible.

Ref #1464