### PR TITLE
Set mimetype for webpdf correctly

### DIFF
--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -5,14 +5,10 @@
 
 import asyncio
 
-<<<<<<< HEAD
-from traitlets import Bool, default
-from jupyter_core.paths import jupyter_path
-=======
 import tempfile, os
 
-from traitlets import Bool
->>>>>>> fa3ba7440cae2f2a7d3b5c0b4051e683b5576e82
+from traitlets import Bool, default
+from jupyter_core.paths import jupyter_path
 import concurrent.futures
 
 from .html import HTMLExporter

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -5,7 +5,7 @@
 
 import asyncio
 
-from traitlets import Bool
+from traitlets import Bool, default
 import concurrent.futures
 
 from .html import HTMLExporter
@@ -33,6 +33,12 @@ class WebPDFExporter(HTMLExporter):
         Set to True to match behavior of LaTeX based PDF generator
         """
     ).tag(config=True)
+
+    output_mimetype = "application/pdf"
+
+    @default('file_extension')
+    def _file_extension_default(self):
+        return '.pdf'
 
     def _check_launch_reqs(self):
         try:

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -6,6 +6,7 @@
 import asyncio
 
 from traitlets import Bool, default
+from jupyter_core.paths import jupyter_path
 import concurrent.futures
 
 from .html import HTMLExporter
@@ -39,6 +40,14 @@ class WebPDFExporter(HTMLExporter):
     @default('file_extension')
     def _file_extension_default(self):
         return '.pdf'
+
+    @default('template_name')
+    def _template_name_default(self):
+        return 'webpdf'
+
+    @default('template_data_paths')
+    def _template_data_paths_default(self):
+        return jupyter_path("nbconvert", "templates", "webpdf")
 
     def _check_launch_reqs(self):
         try:

--- a/nbconvert/preprocessors/tests/test_svg2pdf.py
+++ b/nbconvert/preprocessors/tests/test_svg2pdf.py
@@ -87,8 +87,8 @@ class Testsvg2pdf(PreprocessorTestsBase):
 
     def test_inkscape_pre_v1_command(self):
         preprocessor = self.build_preprocessor(inkscape='fake-inkscape', inkscape_version='0.92.3')
-        assert preprocessor.command == 'fake-inkscape --without-gui --export-pdf="{to_filename}" "{from_filename}"'
+        assert preprocessor.command == '"fake-inkscape" --without-gui --export-pdf="{to_filename}" "{from_filename}"'
 
     def test_inkscape_v1_command(self):
         preprocessor = self.build_preprocessor(inkscape='fake-inkscape', inkscape_version='1.0beta2')
-        assert preprocessor.command == 'fake-inkscape --export-filename="{to_filename}" "{from_filename}"'
+        assert preprocessor.command == '"fake-inkscape" --export-filename="{to_filename}" "{from_filename}"'

--- a/share/jupyter/nbconvert/templates/webpdf/conf.json
+++ b/share/jupyter/nbconvert/templates/webpdf/conf.json
@@ -1,0 +1,6 @@
+{
+    "base_template": "lab",
+    "mimetypes": {
+        "application/pdf": true
+    }
+}

--- a/share/jupyter/nbconvert/templates/webpdf/index.pdf.j2
+++ b/share/jupyter/nbconvert/templates/webpdf/index.pdf.j2
@@ -1,0 +1,1 @@
+{%- extends 'lab/base.html.j2' -%}


### PR DESCRIPTION
- Browsers now detect the file as PDF and offer to
  open it in correct applications. Earlier, it was
  treated as a html file
- Fix the extension shown after the exporter in
  'Download as' menu. It was also .html before.