### PR TITLE
[DOC] Change texlive-generic-recommended to texlive-plain-generic.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -71,7 +71,7 @@ packages are specific to different operating systems:
 
   * E.g. on Debian or Ubuntu::
 
-        sudo apt-get install texlive-xetex texlive-fonts-recommended texlive-generic-recommended
+        sudo apt-get install texlive-xetex texlive-fonts-recommended texlive-plain-generic
 
 * macOS (OS X): `MacTeX <http://tug.org/mactex/>`_.
 * Windows: `MikTex <https://miktex.org/>`_


### PR DESCRIPTION
I was following the suggested packages to install for PDF output support. I didn't have a XeTeX distribution installed, so I following the suggestion:

```bash
sudo apt-get install texlive-xetex texlive-fonts-recommended texlive-generic-recommended
```

I had an installation failure on Ubuntu 20.04 and thus needed to change the last package name to `texlive-plain-generic`.

See below for details -- I think this package name has been transitioning for a while, so this fix should work for both new and LTS versions of Ubuntu/Debian.
- https://packages.debian.org/sid/texlive-generic-recommended
- https://packages.ubuntu.com/bionic/tex/texlive-generic-recommended