### PR TITLE
Fixing extension from html to pdf in dropdown

### DIFF
--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -7,7 +7,7 @@ import asyncio
 
 import tempfile, os
 
-from traitlets import Bool
+from traitlets import Bool, default
 import concurrent.futures
 
 from .html import HTMLExporter
@@ -51,6 +51,10 @@ class WebPDFExporter(HTMLExporter):
         This is required for webpdf to work inside most container environments.
         """
     ).tag(config=True)
+
+    @default('file_extension')
+    def _file_extension_default(self):
+        return '.pdf'
 
     def _check_launch_reqs(self):
         try:


### PR DESCRIPTION
I'm having troubles converting my notebooks to pdfs (the latex converter misses to include the mpl generated figures, while the webpdf is not working at all), and while I'm at it I fixed this small inconsistency.

Was:
<img width="251" alt="Screen Shot 2021-03-18 at 15 44 52" src="https://user-images.githubusercontent.com/6788290/111707596-9325b980-8801-11eb-843d-4852fa8d51e1.png">

Now:

<img width="261" alt="Screen Shot 2021-03-18 at 15 47 01" src="https://user-images.githubusercontent.com/6788290/111707599-9456e680-8801-11eb-8144-07d9e96cdf15.png">