### PR TITLE
Add correct output mimetype to WebPDF exporter

### DIFF
--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -52,6 +52,8 @@ class WebPDFExporter(HTMLExporter):
         """
     ).tag(config=True)
 
+    output_mimetype = "application/pdf"
+
     def _check_launch_reqs(self):
         try:
             from pyppeteer import launch


### PR DESCRIPTION
Similar to #970/#972 but for WebPDF, which currently inherits an HTML mimetype.