### PR TITLE
Drop Python 3.6 and test with Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ language: python
 
 matrix:
     include:
-        - python: 3.6
         - python: 3.7
         - python: 3.8
+        - python: 3.9
     allow_failures:
         - python: nightly
 env:


### PR DESCRIPTION
Dropping Python 3.6

(Fixes #1540.)