### PR TITLE
fix issue 1507: broken command line option --CSSHTMLHeaderPreprocessor.style=

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -499,6 +499,8 @@ class TemplateExporter(Exporter):
                 kwargs = preprocessor.copy()
                 preprocessor_cls = kwargs.pop('type')
                 preprocessor_cls = import_item(preprocessor_cls)
+                if preprocessor_cls.__name__ in self.config:
+                    kwargs.update(self.config[preprocessor_cls.__name__])
                 preprocessor = preprocessor_cls(**kwargs)
                 self.register_preprocessor(preprocessor)
 


### PR DESCRIPTION
With the upgrade to version 6.x the pygment related command line option --CSSHTMLHeaderPreprocessor.style= is broken as reported by this open issue https://github.com/jupyter/nbconvert/issues/1507

I'm testing simply converting a notebook to html. For examples
```
jupyter nbconvert --HTMLExporter.theme=dark --to html notebook.ipynb --CSSHTMLHeaderPreprocessor.style=monokai
```

Looks like that exporters' config are not propagated to the preprocessors (?)
The function I'm changing does not appear in version 5.x so I assume there are design decisions underneath

The fix is simple, but there might be implications that I miss

