### PR TITLE
Allow child templates to override mathjax

### DIFF
--- a/share/jupyter/nbconvert/templates/classic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/index.html.j2
@@ -73,7 +73,9 @@ div#notebook-container{
 </style>
 {% endblock notebook_css %}
 
+{%- block html_head_js_mathjax -%}
 {{ mathjax() }}
+{%- endblock html_head_js_mathjax -%}
 
 {%- block html_head_css -%}
 {%- endblock html_head_css -%}

--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -66,7 +66,9 @@ a.anchor-link {
 
 {% endblock notebook_css %}
 
+{%- block html_head_js_mathjax -%}
 {{ mathjax() }}
+{%- endblock html_head_js_mathjax -%}
 
 {%- block html_head_css -%}
 {%- endblock html_head_css -%}


### PR DESCRIPTION
Right now, mathjax is loaded synchronously in <head>, causing
render to block before moving forward. This is problematic,
especially since most notebooks don't actually have any
math to render.

This PR allows mathjax to be customized by child templates
that inherit from lab or classic. They can make it empty,
and load mathjax how they want - in the footer, only if
there is any math to be rendered, etc.

This should cause no difference in structure for the
default templates themselves.