### PR TITLE
Feature: support static widgets in Reveal.js slides

### DIFF
--- a/share/jupyter/nbconvert/templates/reveal/index.html.j2
+++ b/share/jupyter/nbconvert/templates/reveal/index.html.j2
@@ -114,6 +114,8 @@ a.anchor-link {
 {% endblock body_footer %}
 
 {% block footer %}
+{{ super() }}
+
 {% block footer_js %}
 <script>
 require(


### PR DESCRIPTION
This restores the embedding of widget state in rendered notebooks using the `SlidesExporter` with the default `reveal` template. This has been implemented by adding a call to `super()` in the footer block, which calls the `lab/base.html.j2` implementation. 

I don't know whether this is the preferred style of nbconvert. Looking at `base.html.j2` and `index.html.j2`, it seems like there is an `implementation` (base) vs `client` (index) separation. If this is the case, perhaps a more robust (although breaking) change would be to rename the `footer` block in `base.html.j2` to something like `embed_widget_state`: https://github.com/jupyter/nbconvert/blob/e49b9a8a220c9f9f87c23764ea7b48eac4707937/share/jupyter/nbconvert/templates/lab/base.html.j2#L262-L270