### PR TITLE
* update docs: Tex Live package on Ubuntu

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -71,7 +71,7 @@ packages are specific to different operating systems:
 
   * E.g. on Debian or Ubuntu::
 
-        sudo apt-get install texlive-xetex texlive-fonts-recommended texlive-generic-recommended
+        sudo apt-get install texlive-xetex texlive-fonts-recommended texlive-latex-recommended
 
 * macOS (OS X): `MacTeX <http://tug.org/mactex/>`_.
 * Windows: `MikTex <https://miktex.org/>`_


### PR DESCRIPTION
@SylvainCorlay
change `texlive-generic-recommended to` `texlive-latex-recommended`
* The `texlive-generic-recommended package` was presented in Ubuntu 18.04 LTS (bionic) but didn't exist for the latest ubuntu

https://packages.ubuntu.com/focal/tex/