### PR TITLE
Bugfix: drop Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ language: python
 
 matrix:
     include:
-        - python: 3.6
         - python: 3.7
         - python: 3.8
+        - python: 3.9
     allow_failures:
         - python: nightly
 env:

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup_args = dict(
     package_data    = package_data,
     data_files      = get_data_files(),
     cmdclass        = cmdclass,
-    python_requires = '>=3.6',
+    python_requires = '>=3.7',
     author          = 'Jupyter Development Team',
     author_email    = 'jupyter@googlegroups.com',
     url             = 'https://jupyter.org',


### PR DESCRIPTION
This PR supersedes https://github.com/jupyter/nbconvert/pull/1542 to remove Python 3.6 support. I decided to put all of the changes in one PR to keep things simple. Thanks for the original PR @SylvainCorlay.

@MSeal are you happy to merge this?

I have not modified the README because it's important to keep a note of when the version support was dropped for users still on `nbconvert<6.1`