### PR TITLE
small update to docs hide cell

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,5 +12,6 @@ dependencies:
 - tornado
 - entrypoints
 - ipykernel
+- pip
 - pip:
     - nbsphinx>=0.7.1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,6 +12,5 @@ dependencies:
 - tornado
 - entrypoints
 - ipykernel
-- pip
 - pip:
     - nbsphinx>=0.7.1

--- a/docs/source/nbconvert_library.ipynb
+++ b/docs/source/nbconvert_library.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "from urllib.request import urlopen\n",
     "\n",
-    "url = 'http://jakevdp.github.com/downloads/notebooks/XKCD_plots.ipynb'\n",
+    "url = 'https://jakevdp.github.io/downloads/notebooks/XKCD_plots.ipynb'\n",
     "response = urlopen(url).read().decode()\n",
     "response[0:60] + ' ...'"
    ]

--- a/docs/source/removing_cells.rst
+++ b/docs/source/removing_cells.rst
@@ -15,7 +15,7 @@ Removing pieces of cells using cell tags
 The most straightforward way to control which pieces of cells are
 removed is to use **cell tags**. These are single-string snippets of
 metadata that are stored in each cells "tag" field. The
-`TagRemovePreprocessor` can be used 
+`TagRemovePreprocessor` can be used
 to remove inputs, outputs, or entire cells.
 
 For example, here is a configuration that uses a different tag for
@@ -27,17 +27,33 @@ we demonstrate using the nbconvert Python API.
    from traitlets.config import Config
    import nbformat as nbf
    from nbconvert.exporters import HTMLExporter
+   from nbconvert.preprocessors import TagRemovePreprocessor
 
+   # Setup config
    c = Config()
 
-   # Configure our tag removal
+   # Configure tag removal - be sure to tag your cells to remove  using the
+   # words remove_cell to remove cells. You can also modify the code to use
+   # a different tag word
    c.TagRemovePreprocessor.remove_cell_tags = ("remove_cell",)
    c.TagRemovePreprocessor.remove_all_outputs_tags = ('remove_output',)
    c.TagRemovePreprocessor.remove_input_tags = ('remove_input',)
+   c.TagRemovePreprocessor.enabled = True
 
    # Configure and run out exporter
-   c.HTMLExporter.preprocessors = ["TagRemovePreprocessor"]
-   HTMLExporter(config=c).from_filename("path/to/mynotebook.ipynb")
+   c.HTMLExporter.preprocessors = ["nbconvert.preprocessors.TagRemovePreprocessor"]
+
+   exporter = HTMLExporter(config=c)
+   exporter.register_preprocessor(TagRemovePreprocessor(config=c),True)
+
+   # Configure and run out exporter - returns a tuple - first element with html,
+   # second with notebook metadata
+   output = HTMLExporter(config=c).from_filename("your-notebook-file-path.ipynb")
+
+   # Write to output html file
+   with open("your-output-file-name.html",  "w") as f:
+       f.write(output[0])
+
 
 Removing cells using Regular Expressions on cell content
 --------------------------------------------------------
@@ -63,4 +79,3 @@ an arbitrary number of whitespace characters followed by the end of the string.
 See https://regex101.com/ for an interactive guide to regular expressions
 (make sure to select the python flavor). See https://docs.python.org/library/re.html
 for the official regular expression documentation in python.
-

--- a/docs/source/removing_cells.rst
+++ b/docs/source/removing_cells.rst
@@ -46,7 +46,7 @@ we demonstrate using the nbconvert Python API.
    exporter = HTMLExporter(config=c)
    exporter.register_preprocessor(TagRemovePreprocessor(config=c),True)
 
-   # Configure and run out exporter - returns a tuple - first element with html,
+   # Configure and run our exporter - returns a tuple - first element with html,
    # second with notebook metadata
    output = HTMLExporter(config=c).from_filename("your-notebook-file-path.ipynb")
 


### PR DESCRIPTION
closes #1194 
In the documentation, the code to hide cells currently returns an error where it can't find the `TagRemoveProcessor` object. A resolution was proposed in this issue to register the processor prior to calling it. 

Further the example is missing code to export the object to a file which many users may need to  do!  This pr  simply fixes the code sample.  @yuvipanda  I'm very open to making any changes and testing the locally! I am running the most current released version of nbconvert. i built the docs locally and ran into a small issue:

```bash
(nbconvert) CIRES-EL-LM-020:docs leahwasser$ make html
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v3.5.4
loading intersphinx inventory from https://docs.python.org/3.6/objects.inv...
loading intersphinx inventory from http://jinja.pocoo.org/docs/dev/objects.inv...
loading intersphinx inventory from https://nbformat.readthedocs.io/en/latest/objects.inv...
intersphinx inventory has moved: http://jinja.pocoo.org/docs/dev/objects.inv -> https://jinja.palletsprojects.com/en/master/objects.inv
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 22 source files that are out of date
updating environment: [new config] 22 added, 0 changed, 0 removed
reading sources... [ 86%] nbconvert_library                                            
Notebook error:
NoSuchKernel in nbconvert_library.ipynb:
No such kernel named python3
```
i'm not sure if that is  related to  my  environment  install but  the docs that i modified should not actually cause any build issues. let's see what CI has to say.

UPDATE:  i was able to  fix this  by installing notebook in my nbconvert dev envt and rerunning the notebook figuring  perhaps it would then  find the right kernel and add it to the notebook  metadata. docs are now building nicely locally. i'll see  if that URL fix also  solves  the CI  issues. 
