### PR TITLE
add  pip to docs  envt

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,5 +12,6 @@ dependencies:
 - tornado
 - entrypoints
 - ipykernel
+- pip
 - pip:
     - nbsphinx>=0.7.1


### PR DESCRIPTION
This  should  address the issue  where  CI  hangs when building docs due to not being able to find pip  correctly - note that the this builds upon issues discovered in #1567 