### PR TITLE
Fix template precedence when using a custom template (#1558)

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -545,8 +545,8 @@ class TemplateExporter(Exporter):
                 ensure_dir_exists(path, mode=0o700)
             except OSError:
                 pass
-
-        return self.extra_template_paths + additional_paths + paths
+        
+        return paths + additional_paths + self.extra_template_paths 
 
     @classmethod
     def get_compatibility_base_template_conf(cls, name):


### PR DESCRIPTION
The order of the template_paths matters. The additional and extra paths currently shadow the `index.*` template. This means custom templates are never called if these paths are set by the exporter (e.g. LatexExporter does) or by a configuration file.

This fixes #1558 but if there is a better way to do it, I'm happy to listen.
