### PR TITLE
Changed documentation of external_exporters

### DIFF
--- a/docs/source/external_exporters.rst
+++ b/docs/source/external_exporters.rst
@@ -188,16 +188,14 @@ We are going to write an exporter that:
             return '.test_ext'
 
         @property
-        def template_paths(self):
+        def extra_template_basedirs(self):
             """
             We want to inherit from HTML template, and have template under
             ``./templates/`` so append it to the search path. (see next section)
-
-            Note: nbconvert 6.0 changed ``template_path`` to ``template_paths``
             """
-            return super().template_paths+[os.path.join(os.path.dirname(__file__), "templates")]
+            return super()._default_extra_template_basedirs() + [os.path.join(os.path.dirname(__file__), "templates")]
 
-        def _template_file_default(self):
+        def _template_name_default(self):
             """
             We want to use the new template we ship with our library.
             """

--- a/docs/source/external_exporters.rst
+++ b/docs/source/external_exporters.rst
@@ -193,7 +193,8 @@ We are going to write an exporter that:
             We want to inherit from HTML template, and have template under
             ``./templates/`` so append it to the search path. (see next section)
             """
-            return super()._default_extra_template_basedirs() + [os.path.join(os.path.dirname(__file__), "templates")]
+            return super()._default_extra_template_basedirs() +
+                   [os.path.join(os.path.dirname(__file__), "templates")]
 
         def _template_name_default(self):
             """


### PR DESCRIPTION
The example provided in the documentation required the user to append his/her path to templates to `super().template_paths`, while `super().template_paths` is looking for the user provided template name. 

Changed documentation such that user updates `extra_template_basedirs`. 

I believe this PR can close Issue #1581