### PR TITLE
Ensure generated URL fragments are valid

### DIFF
--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -83,7 +83,10 @@ def _convert_header_id(header_contents):
 
     For use on markdown headings.
     """
-    return header_contents.replace(' ', '-')
+    # Valid IDs need to be non-empty and contain no space characters, but are otherwise arbitrary.
+    # However, these IDs are also used in URL fragments, which are more restrictive, so we URL
+    # encode any characters that are not valid in URL fragments.
+    return quote(header_contents.replace(' ', '-'), safe="?/:@!$&'()*+,;=")
 
 
 def add_anchor(html, anchor_link_text=u'¶'):

--- a/nbconvert/filters/tests/test_strings.py
+++ b/nbconvert/filters/tests/test_strings.py
@@ -15,6 +15,7 @@ Module with tests for Strings
 # Imports
 #-----------------------------------------------------------------------------
 import os
+import re
 
 from ...tests.base import TestsBase
 from ..strings import (wrap_text, html2text, add_anchor, strip_dollars, 
@@ -66,6 +67,20 @@ class TestStrings(TestsBase):
         html = '<h1>Hello <br>World!</h1>'
         results = add_anchor(html)
         self.assertEqual(html, results)
+
+    def test_add_anchor_valid_url_fragment(self):
+        """add_anchor creates a valid URL fragment"""
+        results = add_anchor(r'<h1>$\pi$ with #s and unicode 中</h1>')
+        match = re.search(r'href="#(.*?)"', results)
+        assert match
+        assert len(match.groups()) == 1
+        href = match.groups()[0]
+
+        assert len(href) > 0
+        # No invalid characters should be present
+        assert '\\' not in href
+        assert '#' not in href
+        assert '中' not in href
 
     def test_strip_dollars(self):
         """strip_dollars test"""


### PR DESCRIPTION
Approach we take is to replace spaces with dashes (same as what was done
before), and then URL encode any remaining characters that aren't
allowed in URL fragments.

This shouldn't break any existing links, because any links that get changed by
this were invalid already.

Fixes https://github.com/jupyter/nbconvert/issues/1580.