### PR TITLE
Get TemporaryDirectory from stdlib tempfile, not from testpath.

### DIFF
--- a/nbconvert/exporters/tests/test_latex.py
+++ b/nbconvert/exporters/tests/test_latex.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os.path
+from tempfile import TemporaryDirectory
 import textwrap
 import re
 
@@ -14,7 +15,6 @@ from ...tests.utils import onlyif_cmds_exist
 from traitlets.config import Config
 from nbformat import write
 from nbformat import v4
-from testpath.tempdir import TemporaryDirectory
 
 from jinja2 import DictLoader
 

--- a/nbconvert/exporters/tests/test_pdf.py
+++ b/nbconvert/exporters/tests/test_pdf.py
@@ -6,8 +6,7 @@
 import logging
 import os
 import shutil
-
-from testpath import tempdir
+from tempfile import TemporaryDirectory
 
 from .base import ExportersTestsBase
 from ..pdf import PDFExporter
@@ -31,7 +30,7 @@ class TestPDF(ExportersTestsBase):
     @onlyif_cmds_exist('xelatex', 'pandoc')
     def test_export(self):
         """Smoke test PDFExporter"""
-        with tempdir.TemporaryDirectory() as td:
+        with TemporaryDirectory() as td:
             file_name = os.path.basename(self._get_notebook())
             newpath = os.path.join(td, file_name)
             shutil.copy(self._get_notebook(), newpath)

--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -10,8 +10,8 @@ import io
 import os
 import sys
 import subprocess
+from tempfile import TemporaryDirectory
 
-from testpath.tempdir import TemporaryDirectory
 from traitlets import Unicode, default, Union, List
 
 from .convertfigures import ConvertFiguresPreprocessor

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -7,6 +7,7 @@
 import os
 import io
 import nbformat
+from tempfile import TemporaryDirectory
 
 from .base import TestsBase
 from ..postprocessors import PostProcessorBase
@@ -15,7 +16,6 @@ from nbconvert import nbconvertapp
 from nbconvert.exporters import Exporter, HTMLExporter
 
 from traitlets.tests.utils import check_help_all_output
-from testpath import tempdir
 import pytest
 
 #-----------------------------------------------------------------------------
@@ -107,7 +107,7 @@ class TestNbConvertApp(TestsBase):
 
     def test_absolute_template_file(self):
         """--template-file '/path/to/template.tpl'"""
-        with self.create_temp_cwd(['notebook*.ipynb']), tempdir.TemporaryDirectory() as td:
+        with self.create_temp_cwd(['notebook*.ipynb']), TemporaryDirectory() as td:
             template = os.path.join(td, 'mytemplate.tpl')
             test_output = 'success!'
             with open(template, 'w') as f:
@@ -527,7 +527,7 @@ class TestNbConvertApp(TestsBase):
         # check absolute path
         with self.create_temp_cwd(['notebook4_jpeg.ipynb',
                                    'containerized_deployments.jpeg']):
-            output_dir = tempdir.TemporaryDirectory()
+            output_dir = TemporaryDirectory()
             path = os.path.join(output_dir.name, 'files')
             self.nbconvert(
                 '--log-level 0 notebook4_jpeg.ipynb --to rst '


### PR DESCRIPTION
They are aliases of one another on all supported Python versions.

I would like to get rid of the testpath dependency, but in any case,
this specific change should hopefully be uncontroversial.