### PR TITLE
Fix Deprecation warning for jinja2 contextfilter

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -11,7 +11,7 @@ import base64
 from traitlets import default, Unicode, Bool
 from traitlets.config import Config
 from jupyter_core.paths import jupyter_path
-from jinja2 import contextfilter
+from jinja2 import pass_context
 from jinja2.loaders import split_template_path
 import jinja2
 
@@ -106,7 +106,7 @@ class HTMLExporter(TemplateExporter):
         c.merge(super().default_config)
         return c
 
-    @contextfilter
+    @pass_context
     def markdown2html(self, context, source):
         """Markdown to HTML filter respecting the anchor_link_text setting"""
         cell = context.get('cell', {})


### PR DESCRIPTION
Resolves https://github.com/jupyter/nbconvert/issues/1568.

As noted in the Jinja docs here https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.contextfilter and in the Changelog here https://jinja.palletsprojects.com/en/3.0.x/changes/#version-3-0-0, the `contextfilter` decorator has been replaced with `pass_context`, which provides the same functionality. `contextfilter` will be removed in Jinja 3.1.

Side note: I'm not really familiar with the internals of the html exporter and the markdown filter, so I wasn't sure how to test this (and didn't know whether existing coverage would ensure this still works). 