### PR TITLE
Make the reveal template more similar to lab

### DIFF
--- a/share/jupyter/nbconvert/templates/reveal/index.html.j2
+++ b/share/jupyter/nbconvert/templates/reveal/index.html.j2
@@ -51,9 +51,6 @@ if( window.location.search.match( /print-pdf/gi ) ) {
 }
 </script>
 
-<!-- Loading the mathjax macro -->
-{{ mathjax() }}
-
 {% for css in resources.inlining.css -%}
   <style type="text/css">
     {{ css }}
@@ -93,6 +90,14 @@ a.anchor-link {
 {{ resources.include_css("static/custom_reveal.css") }}
 
 {% endblock notebook_css %}
+
+{%- block html_head_js_mathjax -%}
+{{ mathjax() }}
+{%- endblock html_head_js_mathjax -%}
+
+{%- block html_head_css -%}
+{%- endblock html_head_css -%}
+
 {%- endblock html_head -%}
 </head>
 {% endblock header%}


### PR DESCRIPTION
Lab and classic both have an `html_head_css`  block (empty in nbconvert, overridden in Voilà) and wrap the mathjax macro call in a block.

This makes it easier to make reveal and lab voilà template converge.