### PR TITLE
The custom reveal font-awesome rule conflicts with recent font awesome rules

### DIFF
--- a/share/jupyter/nbconvert/templates/reveal/static/custom_reveal.css
+++ b/share/jupyter/nbconvert/templates/reveal/static/custom_reveal.css
@@ -17,11 +17,6 @@
   border: 0px solid black;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0);
 }
-.reveal i {
-  font-style: normal;
-  font-family: FontAwesome;
-  font-size: 2em;
-}
 .reveal .slides {
   text-align: left;
 }


### PR DESCRIPTION
The proper font family is ` Font Awesome 5 Free` which is set by FontAwesome CSS.

Overriding it in our custom CSS breaks Jupyter content making use of font awesome like Jupyter widgets.