### PR TITLE
Update the pyppeteer dependency to resolve security issues.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ setup_args['install_requires'] = [
     'nbclient>=0.5.0,<0.6.0'
 ]
 
-pyppeteer_req = 'pyppeteer==0.2.2'
+pyppeteer_req = 'pyppeteer==0.2.6'
 
 extra_requirements = {
     'test': [


### PR DESCRIPTION
pyppeteer 0.2.6 includes a fix for https://github.com/advisories/GHSA-8ch4-58qp-g3mp by upgrading its dependency on the websocket library. See 	https://github.com/pyppeteer/pyppeteer/pull/252 and https://github.com/pyppeteer/pyppeteer/issues/275

CC @mnowacki-b