### PR TITLE
Do not attempt to create additional template paths.

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -18,7 +18,6 @@ from traitlets import HasTraits, Unicode, List, Dict, Bool, default, observe, va
 from traitlets.config import Config
 from traitlets.utils.importstring import import_item
 from jupyter_core.paths import jupyter_path
-from jupyter_core.utils import ensure_dir_exists
 from jinja2 import (
     TemplateNotFound, Environment, ChoiceLoader, FileSystemLoader, BaseLoader,
     DictLoader
@@ -547,14 +546,7 @@ class TemplateExporter(Exporter):
             compatibility_dir = os.path.join(root_dir, 'nbconvert', 'templates', 'compatibility')
             paths.append(compatibility_dir)
 
-        additional_paths = self.template_data_paths
-        for path in additional_paths:
-            try:
-                ensure_dir_exists(path, mode=0o700)
-            except OSError:
-                pass
-
-        return paths + self.extra_template_paths + additional_paths
+        return paths + self.extra_template_paths + self.template_data_paths
 
     @classmethod
     def get_compatibility_base_template_conf(cls, name):

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -546,7 +546,13 @@ class TemplateExporter(Exporter):
             compatibility_dir = os.path.join(root_dir, 'nbconvert', 'templates', 'compatibility')
             paths.append(compatibility_dir)
 
-        return paths + self.extra_template_paths + self.template_data_paths
+        additional_paths = []
+        for path in self.template_data_paths:
+            if not prune or os.path.exists(path):
+                additional_paths.append(path)
+
+
+        return paths + self.extra_template_paths + additional_paths
 
     @classmethod
     def get_compatibility_base_template_conf(cls, name):


### PR DESCRIPTION
Fixes #1430

Many users are reporting that nbconvert 6.x has permission errors when queried or converting files. These seem to arise when nbconvert is installed as root, then used as a user. We hypothesize that the code removed in this commit, which attempts to create template directories throughout the jupyter path hierarchy, succeeds in creating template directories when running as root. Note that it creates the template directories with permission 700. Those permissions as root mean that regular users won’t be able to read these directories, and those are the sort of permission errors we are seeing reported.

This directory creation was originally introduced in #1028, where I think it was limited to a single user configuration directory (based on the PR discussion). In #1056, this code appears to have been copied over and applied to the entire Jupyter directory hierarchy.

CC @SylvainCorlay @maartenbreddels @MSeal