### PR TITLE
Update JupyterLab CSS to the latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,13 @@ package_data = {
 notebook_css_version = '5.4.0'
 notebook_css_url = "https://cdn.jupyter.org/notebook/%s/style/style.min.css" % notebook_css_version
 
-jupyterlab_css_version = '3.0.7'
+jupyterlab_css_version = '3.1.11'
 jupyterlab_css_url = "https://unpkg.com/@jupyterlab/nbconvert-css@%s/style/index.css" % jupyterlab_css_version
 
-jupyterlab_theme_light_version = '3.0.7'
+jupyterlab_theme_light_version = '3.1.11'
 jupyterlab_theme_light_url = "https://unpkg.com/@jupyterlab/theme-light-extension@%s/style/variables.css" % jupyterlab_theme_light_version
 
-jupyterlab_theme_dark_version = '3.0.7'
+jupyterlab_theme_dark_version = '3.1.11'
 jupyterlab_theme_dark_url = "https://unpkg.com/@jupyterlab/theme-dark-extension@%s/style/variables.css" % jupyterlab_theme_dark_version
 
 template_css_urls = {


### PR DESCRIPTION
This is the usual bump, like https://github.com/jupyter/nbconvert/pull/1539.

Changes seem to mainly be:

* light theme: some colors tweaked for better contrast
* nbconvert-css: some mobile-specific tweaks added for notebooks