### PR TITLE
add slide numbering

### DIFF
--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -158,7 +158,7 @@ class SlidesExporter(HTMLExporter):
     reveal_number = Unicode('',
         help="""
         slide number format (e.g. 'c/t'). Choose from:
-        'c': current, 't': total, 'h': horzontal, 'v': vertical
+        'c': current, 't': total, 'h': horizontal, 'v': vertical
         """
     ).tag(config=True)
 

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -155,6 +155,13 @@ class SlidesExporter(HTMLExporter):
         """
     ).tag(config=True)
 
+    reveal_number = Unicode('',
+        help="""
+        slide number format (e.g. 'c/t'). Choose from:
+        'c': current, 't': total, 'h': horzontal, 'v': vertical
+        """
+    ).tag(config=True)
+
     font_awesome_url = Unicode(
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css",
         help="""
@@ -172,4 +179,5 @@ class SlidesExporter(HTMLExporter):
         resources['reveal']['theme'] = self.reveal_theme
         resources['reveal']['transition'] = self.reveal_transition
         resources['reveal']['scroll'] = self.reveal_scroll
+        resources['reveal']['number'] = self.reveal_number
         return resources

--- a/share/jupyter/nbconvert/templates/reveal/index.html.j2
+++ b/share/jupyter/nbconvert/templates/reveal/index.html.j2
@@ -5,6 +5,7 @@
 {% set reveal_url_prefix = resources.reveal.url_prefix | default('https://unpkg.com/reveal.js@4.0.2', true) %}
 {% set reveal_theme = resources.reveal.theme | default('white', true) %}
 {% set reveal_transition = resources.reveal.transition | default('slide', true) %}
+{% set reveal_number = resources.reveal.number | default('', true) %}
 {% set reveal_scroll = resources.reveal.scroll | default(false, true) | json_dumps %}
 
 {%- block header -%}
@@ -144,6 +145,7 @@ require(
             progress: true,
             history: true,
             transition: "{{reveal_transition}}",
+            slideNumber: "{{reveal_number}}",
             plugins: [RevealNotes]
         });
 


### PR DESCRIPTION
Add support for https://revealjs.com/slide-numbers/

Example use: `nbconvert --to=slides --SlidesExporter.reveal_number='c/t'`

Fixes #737