### PR TITLE
fix: avoid closing the script tag early by escaping a forward slash

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -64,6 +64,9 @@ default_filters = {
         'get_metadata': filters.get_metadata,
         'convert_pandoc': filters.convert_pandoc,
         'json_dumps': json.dumps,
+        # browsers will parse </script>, closing a script tag early
+        # Since JSON allows escaping forward slash, this will still be parsed by JSON
+        'escape_html_script': lambda x: x.replace('</script>', '<\\/script>'),
         'strip_trailing_newline': filters.strip_trailing_newline,
         'text_base64': filters.text_base64,
 }

--- a/share/jupyter/nbconvert/templates/classic/base.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/base.html.j2
@@ -267,7 +267,7 @@ var element = $('#{{ div_id }}');
 {% set mimetype = 'application/vnd.jupyter.widget-state+json'%} 
 {% if mimetype in nb.metadata.get("widgets",{})%}
 <script type="{{ mimetype }}">
-{{ nb.metadata.widgets[mimetype] | json_dumps }}
+{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html_script }}
 </script>
 {% endif %}
 {{ super() }}

--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -273,7 +273,7 @@ var element = document.getElementById('{{ div_id }}');
 {% set mimetype = 'application/vnd.jupyter.widget-state+json'%}
 {% if mimetype in nb.metadata.get("widgets",{})%}
 <script type="{{ mimetype }}">
-{{ nb.metadata.widgets[mimetype] | json_dumps }}
+{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html_script }}
 </script>
 {% endif %}
 {{ super() }}


### PR DESCRIPTION
Closes #1562
Closes #802
Related #804
Related https://github.com/spatialaudio/nbsphinx/issues/183

Having a widget like this:
```
import ipywidgets as widgets
widgets.Label("Let me bug you with a closing tag </script>")
```

left an invalid HTML document, since there was a closing script tag that the browser directly parses, escaping the forward slash works around this, see:
 * https://stackoverflow.com/questions/1659749/script-tag-in-javascript-string
 * https://stackoverflow.com/questions/1580647/json-why-are-forward-slashes-escaped