### PR TITLE
Add an invalid notebook error

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -160,7 +160,10 @@ class IPythonRenderer(mistune.Renderer):
         attachment_prefix = 'attachment:'
         if src.startswith(attachment_prefix):
             name = src[len(attachment_prefix):]
-            assert name in attachments, "missing attachment: {}".format(name)
+            
+            if not name in attachments:
+                nbconvert.InvalidNotebook.new("missing attachment: {}".format(name))
+            
             attachment = attachments[name]
             # we choose vector over raster, and lossless over lossy
             preferred_mime_types = ['image/svg+xml', 'image/png', 'image/jpeg']

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -162,7 +162,7 @@ class IPythonRenderer(mistune.Renderer):
             name = src[len(attachment_prefix):]
             
             if not name in attachments:
-                nbconvert.InvalidNotebook.new("missing attachment: {}".format(name))
+                raise InvalidNotebook("missing attachment: {}".format(name))
             
             attachment = attachments[name]
             # we choose vector over raster, and lossless over lossy

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -595,6 +595,9 @@ class DejavuApp(NbConvertApp):
     def default_export_format(self):
         return 'html'
 
+class InvalidNotebook(Exception):
+    pass
+
 #-----------------------------------------------------------------------------
 # Main entry point
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Motivation:
  - Our new service is serving a significant amount of notebooks a day. In this we are
    seeing a number of errors from Notebook rendering that really stem
    from notebooks not being properly formatted. These show up in a number
    of errors such as the error handled in this pr, an assertion error,
    we have also seen key errors and others. This pr is a bit of a proposal
    to instead introduced a common exception that indicates the notebook
    is missing some required data that is needed to render itself.