### PR TITLE
Adding styling to prevent page brake inside output area

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -57,9 +57,24 @@ a.anchor-link {
     overflow: hidden;
 }
 
+/* Output area styling */
+div.jp-OutputArea.jp-Cell-outputArea {
+    width: fit-content;
+    overflow: unset;
+}
+div.jp-OutputArea-child {
+    width: fit-content;
+    display: -webkit-inline-box;
+}
+
 @media print {
   body {
     margin: 0;
+  }
+
+  div.jp-OutputArea-child {
+    page-break-inside: avoid !important;
+    break-inside: avoid !important;
   }
 }
 </style>


### PR DESCRIPTION
Currently when a PDF is created the output content (including widgets) can be split in half across two pages. This causes the PDF report to look rather awkward. With this change the output area will be pushed to a new page whenever the split is avoidable.

cc: @SylvainCorlay 