### PR TITLE
Adding missing div compared to JupyterLab DOM structure

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -86,11 +86,13 @@
 
 {% block markdowncell scoped %}
 <div class="jp-Cell-inputWrapper">
+<div class="jp-InputArea jp-Cell-inputArea">
 {%- if resources.global_content_filter.include_input_prompt-%}
     {{ self.empty_in_prompt() }}
 {%- endif -%}
 <div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput {{ celltags(cell) }}" data-mime-type="text/markdown">
 {{ cell.source  | markdown2html | strip_files_prefix }}
+</div>
 </div>
 </div>
 {%- endblock markdowncell %}


### PR DESCRIPTION
I came across this while comparing the DOM of the JupyterLab notebook widget and the nbconvert lab template.

Will be self-merging this as it is a trivial fix.