### PR TITLE
Prevent page breaks in outputs when printing

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -41,9 +41,11 @@
     {{ resources.include_css("static/theme-light.css") }}
 {% endif %}
 <style type="text/css">
+/* Misc */
 a.anchor-link {
    display: none;
 }
+
 .highlight  {
     margin: 0.4em;
 }
@@ -57,9 +59,59 @@ a.anchor-link {
     overflow: hidden;
 }
 
+/* Output area styling: using table instead of flexbox so that we can use break-inside property */
+
+.jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-prompt {
+  min-width: calc(
+    var(--jp-cell-prompt-width) - var(--jp-private-cell-scrolling-output-offset)
+  );
+}
+
+.jp-OutputArea-child {
+  display: table;
+  width: 100%;
+}
+
+.jp-OutputPrompt {
+  display: table-cell;
+  vertical-align: top;
+  min-width: var(--jp-cell-prompt-width);
+}
+
+body[data-format='mobile'] .jp-OutputPrompt {
+  display: table-row;
+}
+
+.jp-OutputArea-output {
+  display: table-cell;
+  width: 100%;
+}
+
+body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
+  display: table-row;
+}
+
+.jp-OutputArea-output.jp-OutputArea-executeResult {
+  width: 100%;
+}
+
+/* block wrapper: using block instead of flexbox so that we can use break-inside property
+   note: in the case of JupyterLab, wrappers also include collapsers, hence the flexbox.
+ */
+
+.jp-Cell-inputWrapper, .jp-Cell-outputWrapper {
+  display: block;
+}
+
+/* Media print rules */
+
 @media print {
   body {
     margin: 0;
+  }
+
+  .jp-OutputArea-child {
+    break-inside: avoid-page;
   }
 }
 </style>


### PR DESCRIPTION
Alternative to #1676, based on the move from flexbox to table display implemented in https://github.com/jupyterlab/jupyterlab/pull/11508, which passes the visual regression tests.

I think that using `table` is cleaner than using `inline-box` which has other side effects (like adding vertical space between lines unless setting the font size to 0).

Closes #1676.