### PR TITLE
Fix recent pandoc latex tables by adding calc and array (#1536, #1566)

### DIFF
--- a/share/jupyter/nbconvert/templates/latex/base.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/base.tex.j2
@@ -77,6 +77,8 @@ override this.-=))
     \usepackage{titling}
     \usepackage{longtable} % longtable support required by pandoc >1.10
     \usepackage{booktabs}  % table support for pandoc > 1.12.2
+    \usepackage{array}     % table support for pandoc >= 2.11.3
+    \usepackage{calc}      % table minipage width calculation for pandoc >= 2.11.1
     \usepackage[inline]{enumitem} % IRkernel/repr support (it uses the enumerate* environment)
     \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
                                 % normalem makes italics be italics, not underlines


### PR DESCRIPTION
Pandoc >= 2.11.1 requires the calc package, and pandoc >= 2.11.3
requires the array package, for larger tables (taken from git blame
for pandoc's templates).  This commits adds the two packages in
an order similar to that in pandoc's templates.

This should fix both #1536 and #1566.