### PR TITLE
Modernize latex greek math handling (partially fixes #1673)

### DIFF
--- a/share/jupyter/nbconvert/templates/latex/base.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/base.tex.j2
@@ -14,13 +14,6 @@ override this.-=))
     ((* block docclass *))\documentclass[11pt]{article}((* endblock docclass *))
 
     ((* block packages *))
-    \usepackage{iftex}
-    \ifPDFTeX
-    	\usepackage[T1]{fontenc}
-    	\usepackage{mathpazo}
-    \else
-    	\usepackage{fontspec}
-    \fi
 
     % Basic figure setup, for now with no caption control since it's done
     % automatically by Pandoc (which extracts ![](path) syntax from Markdown).
@@ -48,7 +41,21 @@ override this.-=))
     }
     \usepackage{upquote} % Upright quotes for verbatim code
     \usepackage{eurosym} % defines \euro
-    \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
+
+    \usepackage{iftex}
+    \ifPDFTeX
+        \usepackage[T1]{fontenc}
+        \IfFileExists{alphabeta.sty}{
+              \usepackage{alphabeta}
+          }{
+              \usepackage[mathletters]{ucs}
+              \usepackage[utf8x]{inputenc}
+          }
+    \else
+        \usepackage{fontspec}
+        \usepackage{unicode-math}
+    \fi
+
     \usepackage{fancyvrb} % verbatim replacement that allows latex
     \usepackage{grffile} % extends the file name processing of package graphics 
                          % to support a larger range


### PR DESCRIPTION
The current latex base template uses the ucs package with mathletters,
but as it does not also set utf8x on inputenc, the ucs package does
not work as intended, and Greek letters do not appear in math.

As utf8x and ucs are somewhat outdated and problematic, this PR uses
a few conditions to try to enable Greek letters in both math and text.

For pdflatex, if the alphabeta package (part of greek-inputenc, and
not necessarily installed) is present, this is used, as it better
supports Greek math and text, including diacritics.  It it is not,
ucs with mathletters is used, which will allow math, and some text,
though diacritics will cause an error.

For xelatex and lualatex, this instead uses unicode-math, which
handles math well but does not support pdflatex.  While this
arrangement does support text, note that by default, the fonts used
are unlikely to include support for Greek text, and the glyphs will be
omitted (both for text and for monospace text), particularly since
Latin Modern does not support Greek text.  I have an additional change
which uses Computer Modern Unicode if available, but I'd like to keep
these separate, as it's unclear to me that setting the font in this
template would be a good idea.

Mathpazo for pdflatex is removed for consistency with xelatex/lualatex
output, and the position of the conditional is moved to avoid an order
conflict with the ams packages; this more closely matches the position
of unicode-math in pandoc's template.