### PR TITLE
Set cm-unicode font for latex if available (fixes #1673)

### DIFF
--- a/share/jupyter/nbconvert/templates/latex/base.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/base.tex.j2
@@ -54,6 +54,28 @@ override this.-=))
     \else
         \usepackage{fontspec}
         \usepackage{unicode-math}
+        % Try to load cm-unicode, using filenames
+        % to support both XeLaTeX and LuaLaTeX.
+        \IfFontExistsTF{cmunrm.otf}{
+        \setmainfont{cmun}[
+               Extension=.otf,
+               UprightFont=*rm,
+               ItalicFont=*ti,
+               BoldFont=*bx,
+               BoldItalicFont=*bi]
+        \setmonofont{cmun}[
+               Extension=.otf,
+               UprightFont=*tt,
+               ItalicFont=*it,
+               BoldFont=*tb,
+               BoldItalicFont=*tx]
+        \setsansfont{cmun}[
+               Extension=.otf,
+               UprightFont=*ss,
+               ItalicFont=*si,
+               BoldFont=*sx,
+               BoldItalicFont=*so]
+        }{}
     \fi
 
     \usepackage{fancyvrb} % verbatim replacement that allows latex

--- a/share/jupyter/nbconvert/templates/latex/base.tex.j2
+++ b/share/jupyter/nbconvert/templates/latex/base.tex.j2
@@ -14,13 +14,6 @@ override this.-=))
     ((* block docclass *))\documentclass[11pt]{article}((* endblock docclass *))
 
     ((* block packages *))
-    \usepackage{iftex}
-    \ifPDFTeX
-    	\usepackage[T1]{fontenc}
-    	\usepackage{mathpazo}
-    \else
-    	\usepackage{fontspec}
-    \fi
 
     % Basic figure setup, for now with no caption control since it's done
     % automatically by Pandoc (which extracts ![](path) syntax from Markdown).
@@ -48,7 +41,21 @@ override this.-=))
     }
     \usepackage{upquote} % Upright quotes for verbatim code
     \usepackage{eurosym} % defines \euro
-    \usepackage[mathletters]{ucs} % Extended unicode (utf-8) support
+
+    \usepackage{iftex}
+    \ifPDFTeX
+        \usepackage[T1]{fontenc}
+        \IfFileExists{alphabeta.sty}{
+              \usepackage{alphabeta}
+          }{
+              \usepackage[mathletters]{ucs}
+              \usepackage[utf8x]{inputenc}
+          }
+    \else
+        \usepackage{fontspec}
+        \usepackage{unicode-math}
+    \fi
+
     \usepackage{fancyvrb} % verbatim replacement that allows latex
     \usepackage{grffile} % extends the file name processing of package graphics 
                          % to support a larger range


### PR DESCRIPTION
This includes PR #1686 and depends on it, but makes potentially more problematic changes.

For LuaLaTeX and XeLaTeX, the default fonts usually don't support
Greek text, causing problems when Greek letters are used outside of
math mode (eg, as text or as symbols in code).  This change to the
base template uses the cm-unicode fonts, if they are available.
Fonts are left unchanged if cm-unicode is not available, in which
case Greek letters in math will still work, but text will be missing.

Loading is done here using cm-unicode's filenames, rather than the
fonts' symbolic names, because XeLaTeX cannot search for symbolic
names of fonts that are not available to the system (but may be
available to LaTeX).  LuaLaTeX does not have this limitation, but can
also load using filenames.