### PR TITLE
Updating to MathJax 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docs/source/*.j2
 docs/source/example.html
 docs/source/mytemplate/*
 docs/source/config_options.rst
+.venv/
 
 # Eclipse pollutes the filesystem
 .project

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -52,7 +52,7 @@ class HTMLExporter(TemplateExporter):
     ).tag(config=True)
 
     mathjax_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML-full,Safe",
+        "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js",
         help="""
         URL to load Mathjax from.
 

--- a/share/jupyter/nbconvert/templates/base/mathjax3.html.j2
+++ b/share/jupyter/nbconvert/templates/base/mathjax3.html.j2
@@ -1,0 +1,34 @@
+{%- macro mathjax(url="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js") -%}
+<!-- Load mathjax -->
+<!-- MathJax configuration -->
+<script> 
+    window.MathJax = {
+	tex: {
+	    tags: "ams",
+	    useLabelIds: true,
+	    inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+	    displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+	    processEscapes: true,
+	    processEnvironments: true,
+	    autoload: {
+	    color: [],
+	    colorv2: ['color']
+	    },
+	    packages: {'[+]': ['noerrors'], '[-]': ['textmacros']}
+	},
+	chtml: {
+	    displayAlign: 'center'
+	},
+	options: {
+	    ignoreHtmlClass: 'tex2jax_ignore',
+	    processHtmlClass: 'tex2jax_process'
+	},
+	loader: {
+	    load: ['[tex]/noerrors', '[tex]/textmacros', 'ui/safe']
+	}
+    };
+</script>
+<script src="{{url}}" id="MathJax-script"> </script>
+
+<!-- End of mathjax configuration -->
+{%- endmacro %}

--- a/share/jupyter/nbconvert/templates/classic/index.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/index.html.j2
@@ -1,5 +1,5 @@
 {%- extends 'base.html.j2' -%}
-{% from 'mathjax.html.j2' import mathjax %}
+{% from 'mathjax3.html.j2' import mathjax %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
 {%- block header -%}

--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -1,5 +1,5 @@
 {%- extends 'base.html.j2' -%}
-{% from 'mathjax.html.j2' import mathjax %}
+{% from 'mathjax3.html.j2' import mathjax %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
 {%- block header -%}


### PR DESCRIPTION
Motivation:
  - This pr starts to update the nbconvert app to use MathJax 3.
    MathJax 3 does not use inline script execution to pull in its
    libraries which improves the security story for using this library.

Notes:

This needs some solid testing, I have yet to build a bunch of notebooks with it, although the config is based on the MathJax setup we are using at GitHub for Notebook viewing. We hope to upstream this so it can be tweaked and owned by the community and not us.