### PR TITLE
Update nbconvert_library.ipynb

### DIFF
--- a/docs/source/nbconvert_library.ipynb
+++ b/docs/source/nbconvert_library.ipynb
@@ -101,8 +101,7 @@
     "\n",
     "# 2. Instantiate the exporter. We use the `classic` template for now; we'll get into more details\n",
     "# later about how to customize the exporter further.\n",
-    "html_exporter = HTMLExporter()\n",
-    "html_exporter.template_name = 'classic'\n",
+    "html_exporter = HTMLExporter(template_name = 'classic')\n",
     "\n",
     "# 3. Process the notebook we loaded earlier\n",
     "(body, resources) = html_exporter.from_notebook_node(jake_notebook)"


### PR DESCRIPTION
The generated html file was not following the 'classic' template, but instead 'lab', when I ran the code according to documentaion. But when I passed the template_name as a keyword arguement to HTMLExporter it worked. So I made necessary changes to the code, in a way which worked for me. Please do a review of the code and accept the changes