### PR TITLE
HTMLExporter: Add basic support for federated labextensions themes

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -6,7 +6,9 @@
 
 import os
 import mimetypes
+import json
 import base64
+from pathlib import Path
 
 from traitlets import default, Unicode, Bool
 from traitlets.config import Config
@@ -25,6 +27,58 @@ from nbconvert.filters.widgetsdatatypefilter import WidgetsDataTypeFilter
 from nbconvert.filters.markdown_mistune import IPythonRenderer, MarkdownWithMath
 
 from .templateexporter import TemplateExporter
+
+
+def find_lab_theme(theme_name):
+    """
+    Find a JupyterLab theme location by name.
+
+    Parameters
+    ----------
+    theme_name : str
+        The name of the labextension theme you want to find.
+
+    Raises
+    ------
+    ValueError
+        If the theme was not found, or if it was not specific enough.
+
+    Returns
+    -------
+    theme_name: str
+        Full theme name (with scope, if any)
+    labextension_path : Path
+        The path to the found labextension on the system.
+    """
+    paths = jupyter_path('labextensions')
+
+    matching_themes = []
+    theme_path = None
+    for path in paths:
+        for (dirpath, dirnames, filenames) in os.walk(path):
+            # If it's a federated labextension that contains themes
+            if 'package.json' in filenames and 'themes' in dirnames:
+                # TODO Find the theme name in the JS code instead?
+                # TODO Find if it's a light or dark theme?
+                with open(Path(dirpath) / 'package.json', 'r', encoding="utf-8") as fobj:
+                    labext_name = json.loads(fobj.read())['name']
+
+                if labext_name == theme_name or theme_name in labext_name.split('/'):
+                    matching_themes.append(labext_name)
+
+                    full_theme_name = labext_name
+                    theme_path = Path(dirpath) / 'themes' / labext_name
+
+    if len(matching_themes) == 0:
+        raise ValueError(f'Could not find lab theme "{theme_name}"')
+
+    if len(matching_themes) > 1:
+        raise ValueError(
+            f'Found multiple themes matching "{theme_name}": {matching_themes}. '
+            'Please be more specific about which theme you want to use.'
+        )
+
+    return full_theme_name, theme_path
 
 
 class HTMLExporter(TemplateExporter):
@@ -89,8 +143,9 @@ class HTMLExporter(TemplateExporter):
     def _template_name_default(self):
         return 'lab'
 
-    theme = Unicode('light',
-                    help='Template specific theme(e.g. the JupyterLab CSS theme for the lab template)'
+    theme = Unicode(
+        'light',
+        help="Template specific theme(e.g. the name of a JupyterLab CSS theme distributed as prebuilt extension for the lab template)"
     ).tag(config=True)
 
     output_mimetype = 'text/html'
@@ -150,6 +205,30 @@ class HTMLExporter(TemplateExporter):
             code = """<style type="text/css">\n%s</style>""" % (env.loader.get_source(env, name)[0])
             return jinja2.Markup(code)
 
+        def resources_include_lab_theme(name):
+            # Try to find the theme with the given name, looking through the labextensions
+            _, theme_path = find_lab_theme(name)
+
+            with open(theme_path / 'index.css', 'r') as file:
+                data = file.read()
+
+            # Embed assets (fonts, images...)
+            for asset in os.listdir(theme_path):
+                local_url = "url({})".format(Path(asset).as_posix())
+
+                if local_url in data:
+                    mime_type = mimetypes.guess_type(asset)[0]
+
+                    # Replace asset url by a base64 dataurl
+                    with open(theme_path / asset, 'rb') as assetfile:
+                        base64_data = base64.b64encode(assetfile.read())
+                        base64_data = base64_data.replace(b'\n', b'').decode('ascii')
+
+                        data = data.replace(local_url, 'url(data:{};base64,{})'.format(mime_type, base64_data))
+
+            code = """<style type="text/css">\n%s</style>""" % data
+            return jinja2.Markup(code)
+
         def resources_include_js(name):
             env = self.environment
             code = """<script>\n%s</script>""" % (env.loader.get_source(env, name)[0])
@@ -178,9 +257,11 @@ class HTMLExporter(TemplateExporter):
             data = data.replace(b'\n', b'').decode('ascii')
             src = 'data:{mime_type};base64,{data}'.format(mime_type=mime_type, data=data)
             return jinja2.Markup(src)
+
         resources = super()._init_resources(resources)
         resources['theme'] = self.theme
         resources['include_css'] = resources_include_css
+        resources['include_lab_theme'] = resources_include_lab_theme
         resources['include_js'] = resources_include_js
         resources['include_url'] = resources_include_url
         resources['require_js_url'] = self.require_js_url

--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -37,8 +37,10 @@
 {{ resources.include_css("static/index.css") }}
 {% if resources.theme == 'dark' %}
     {{ resources.include_css("static/theme-dark.css") }}
-{% else %}
+{% elif resources.theme == 'light'  %}
     {{ resources.include_css("static/theme-light.css") }}
+{% else %}
+    {{ resources.include_lab_theme(resources.theme) }}
 {% endif %}
 <style type="text/css">
 /* Misc */


### PR DESCRIPTION
Allow to use labextension themes when using the lab template.

The API is the following:

```bash
jupyter nbconvert --to html --HTMLExporter.template_name=lab --HTMLExporter.theme=@oriolmirosa/jupyterlab_materialdarker Notebook.ipynb
```

The following also works (omitting npm package namespace):

```bash
jupyter nbconvert --to html --HTMLExporter.template_name=lab --HTMLExporter.theme=jupyterlab_materialdarker Notebook.ipynb
```

It will fail with a `ValueError` if the theme is not found:
```
ValueError: Could not find lab theme unknown_theme
```

References:
-----------

Fix https://github.com/jupyter/nbconvert/issues/1216

Examples:
---------

https://github.com/AllanChain/jupyterlab-theme-solarized-dark

![solarized](https://user-images.githubusercontent.com/21197331/148920255-2969b601-efb0-4acf-83e3-9a42ca9a4fea.png)

https://github.com/oriolmirosa/jupyterlab_materialdarker

![material](https://user-images.githubusercontent.com/21197331/148920325-fbb519f6-9cc8-4917-8b40-dfdcc9bd994b.png)

https://github.com/timkpaine/jupyterlab_miami_nights

![miami](https://user-images.githubusercontent.com/21197331/148920418-c0d97728-eb71-4ad5-9a3a-2d3c739cb109.png)
