### PR TITLE
Handle needs_background cell metadata

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -176,9 +176,17 @@ width={{ width }}
 {%- if height is not none %}
 height={{ height }}
 {%- endif %}
+class="
 {%- if output | get_metadata('unconfined', 'image/png') %}
-class="unconfined"
+unconfined
 {%- endif %}
+{%- if output | get_metadata('needs_background', 'image/png') == 'light' %}
+jp-needs-light-background
+{%- endif %}
+{%- if output | get_metadata('needs_background', 'image/png') == 'dark' %}
+jp-needs-dark-background
+{%- endif %}
+"
 >
 </div>
 {%- endblock data_png %}
@@ -198,9 +206,17 @@ width={{ width }}
 {%- if height is not none %}
 height={{ height }}
 {%- endif %}
+class="
 {%- if output | get_metadata('unconfined', 'image/jpeg') %}
-class="unconfined"
+unconfined
 {%- endif %}
+{%- if output | get_metadata('needs_background', 'image/jpeg') == 'light' %}
+jp-needs-light-background
+{%- endif %}
+{%- if output | get_metadata('needs_background', 'image/jpeg') == 'dark' %}
+jp-needs-dark-background
+{%- endif %}
+"
 >
 </div>
 {%- endblock data_jpg %}


### PR DESCRIPTION
This fixes issues when rendering Matplotlib figures with the HTMLExporter, lab template and dark theme.

Reproduce
---------

```python
import matplotlib.pyplot as plt
plt.plot([1, 2, 3, 4])
plt.ylabel('some numbers')
plt.show()
```

```bash
jupyter nbconvert --to html --HTMLExporter.theme=dark --HTMLExporter.template_name=lab Untitled.ipynb
```

Before
------

![before](https://user-images.githubusercontent.com/21197331/149121295-de76d6a2-4579-4422-8aa9-28e31c7ff513.png)

After
-----

![after](https://user-images.githubusercontent.com/21197331/149121322-eaa093c1-24bc-4f61-aad7-64f783939412.png)
