### PR TITLE
Fix DOM structure of markdown cells in lab template

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -89,13 +89,17 @@
 {% endblock output %}
 
 {% block markdowncell scoped %}
+<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
 <div class="jp-InputArea jp-Cell-inputArea">
 {%- if resources.global_content_filter.include_input_prompt-%}
     {{ self.empty_in_prompt() }}
 {%- endif -%}
 <div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput {{ celltags(cell) }}" data-mime-type="text/markdown">
 {{ cell.source  | markdown2html | strip_files_prefix }}
+</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Markdown cells did not quite match the DOM structure of JupyterLab. This fixes some alignment issue in rendered markdown.