### PR TITLE
CodeMirror style bleed fix

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -61,6 +61,7 @@ a.anchor-link {
 
 .CodeMirror pre {
   margin: 0;
+  padding: 0;
 }
 
 /* Using table instead of flexbox so that we can use break-inside property */


### PR DESCRIPTION
The jupyterlab CSS sets some padding for `pre` tags in CodeMirror cells. In nbconvert, we use a `pre` tag at the top level for the pygments-rendered input cell, which inherits this rule.