### PR TITLE
Always hide the collapser element

### DIFF
--- a/share/jupyter/nbconvert/templates/lab/index.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/index.html.j2
@@ -102,11 +102,12 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
   width: 100%;
 }
 
-@media print {
-  .jp-Collapser {
-    display: none;
-  }
+/* Hiding the collapser by default */
+.jp-Collapser {
+  display: none;
+}
 
+@media print {
   .jp-Cell-inputWrapper,
   .jp-Cell-outputWrapper {
     display: block;


### PR DESCRIPTION
This element is unlikely to be used in nbconvert anyway?

We could probably use it to allow collapsing cells just like in JupyterLab. But this is not implemented yet, so it's probably best to not show it for now.

# Before this PR:

![collapser](https://user-images.githubusercontent.com/21197331/151394260-874b75ea-5371-4fa1-aa29-710cef63fa9c.png)

# After this PR:

![nocollapser](https://user-images.githubusercontent.com/21197331/151394328-843bb5ff-0978-44c1-b90e-7a254dd13f74.png)
