### PR TITLE
HTMLExporter: Respect the embed_images flag for HTML blocks

### DIFF
--- a/nbconvert/tests/files/notebook5_embed_images.ipynb
+++ b/nbconvert/tests/files/notebook5_embed_images.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e684608d",
+   "metadata": {},
+   "source": [
+    "![](./containerized_deployments.jpeg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e609fcaf",
+   "metadata": {},
+   "source": [
+    "<img src='./containerized_deployments.jpeg'></img>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0043f9e",
+   "metadata": {},
+   "source": [
+    "<div>\n",
+    "    <img src='./containerized_deployments.jpeg'></img>\n",
+    "</div>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -572,6 +572,32 @@ class TestNbConvertApp(TestsBase):
 
             assert "var widgetRendererSrc = 'https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js';" in output
 
+    def test_not_embedding_images_htmlexporter(self):
+        """Check that the HTMLExporter does not embed images by default"""
+
+        with self.create_temp_cwd(["notebook5_embed_images.ipynb",
+                                   "containerized_deployments.jpeg"]):
+            self.nbconvert('notebook5_embed_images --log-level 0 --to html')
+            assert os.path.isfile('notebook5_embed_images.html')
+            with open("notebook5_embed_images.html", 'r', encoding="utf8") as f:
+                text = f.read()
+                assert "./containerized_deployments.jpeg" in text
+                assert "src='./containerized_deployments.jpeg'" in text
+                assert text.count("data:image/jpeg;base64") == 0
+
+    def test_embedding_images_htmlexporter(self):
+        """Check that the HTMLExporter embeds images if needed"""
+
+        with self.create_temp_cwd(["notebook5_embed_images.ipynb",
+                                   "containerized_deployments.jpeg"]):
+            self.nbconvert('notebook5_embed_images --log-level 0 --to html --embed-images')
+            assert os.path.isfile('notebook5_embed_images.html')
+            with open("notebook5_embed_images.html", 'r', encoding="utf8") as f:
+                text = f.read()
+                assert "./containerized_deployments.jpeg" not in text
+                assert "src='./containerized_deployments.jpeg'" not in text
+                assert text.count("data:image/jpeg;base64") == 3
+
     def test_execute_widgets_from_nbconvert(self):
         """Check jupyter widgets render"""
         notebookName = "Unexecuted_widget"

--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ setup_args['install_requires'] = [
     'pandocfilters>=1.4.1',
     'testpath',
     'defusedxml',
+    'beautifulsoup4',
     'nbclient>=0.5.0,<0.6.0'
 ]
 


### PR DESCRIPTION
This is a follow-up of https://github.com/jupyter/nbconvert/pull/1717 which was only working for markdown images:
```
![](./my_image.jpg)
```

This PR adds support for embedding images for HTML `img` tags as well:

```
<img src='./my_image.jpg'></img>
```

It adds beautifulsoup4 as a dependency for parsing the HTML contained in Markdown cells.

---

cc. @maartenbreddels maybe you'd have an opinion on this as you've been working on embedding images in Voila?

cc. @SylvainCorlay 