### PR TITLE
Import Markup and escape directly from MarkupsSafe

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -14,6 +14,7 @@ from traitlets import default, Unicode, Bool
 from traitlets.config import Config
 from jupyter_core.paths import jupyter_path
 import jinja2
+import markupsafe
 
 if tuple(int(x) for x in jinja2.__version__.split(".")[:3]) < (3, 0, 0):
     from jinja2 import contextfilter
@@ -213,7 +214,7 @@ class HTMLExporter(TemplateExporter):
         def resources_include_css(name):
             env = self.environment
             code = """<style type="text/css">\n%s</style>""" % (env.loader.get_source(env, name)[0])
-            return jinja2.Markup(code)
+            return markupsafe.Markup(code)
 
         def resources_include_lab_theme(name):
             # Try to find the theme with the given name, looking through the labextensions
@@ -237,12 +238,12 @@ class HTMLExporter(TemplateExporter):
                         data = data.replace(local_url, 'url(data:{};base64,{})'.format(mime_type, base64_data))
 
             code = """<style type="text/css">\n%s</style>""" % data
-            return jinja2.Markup(code)
+            return markupsafe.Markup(code)
 
         def resources_include_js(name):
             env = self.environment
             code = """<script>\n%s</script>""" % (env.loader.get_source(env, name)[0])
-            return jinja2.Markup(code)
+            return markupsafe.Markup(code)
 
         def resources_include_url(name):
             env = self.environment
@@ -266,7 +267,7 @@ class HTMLExporter(TemplateExporter):
             data = base64.b64encode(data)
             data = data.replace(b'\n', b'').decode('ascii')
             src = 'data:{mime_type};base64,{data}'.format(mime_type=mime_type, data=data)
-            return jinja2.Markup(src)
+            return markupsafe.Markup(src)
 
         resources = super()._init_resources(resources)
         resources['theme'] = self.theme

--- a/nbconvert/filters/ansi.py
+++ b/nbconvert/filters/ansi.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import re
-import jinja2
+import markupsafe
 
 __all__ = [
     'strip_ansi',
@@ -57,7 +57,7 @@ def ansi2html(text):
         Text containing ANSI colors to convert to HTML
 
     """
-    text = jinja2.utils.escape(text)
+    text = markupsafe.escape(text)
     return _ansi2anything(text, _htmlconverter)
 
 

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,8 @@ setup_args['install_requires'] = [
     'testpath',
     'defusedxml',
     'beautifulsoup4',
-    'nbclient>=0.5.0,<0.6.0'
+    'nbclient>=0.5.0,<0.6.0',
+    'MarkupSafe>=2.0'
 ]
 
 pyppeteer_req = 'pyppeteer>=1,<1.1'

--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ setup_args = dict(
 
 setup_args['install_requires'] = [
     'mistune>=0.8.1,<2',
-    'jinja2>=2.4',
+    'jinja2>=2.4,<3.1',
     'pygments>=2.4.1',
     'jupyterlab_pygments',
     'traitlets>=5.0',

--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ setup_args = dict(
 
 setup_args['install_requires'] = [
     'mistune>=0.8.1,<2',
-    'jinja2>=2.4,<3.1',
+    'jinja2>=2.4',
     'pygments>=2.4.1',
     'jupyterlab_pygments',
     'traitlets>=5.0',


### PR DESCRIPTION
Fixes #1736

Jinja 3.1.0 removed `jinja.Markup` and `jinja.escape` and suggested importing them from MarkupSafe 