### PR TITLE
support bleach 5, add packaging and tinycss2 dependencies

### DIFF
--- a/nbconvert/preprocessors/sanitize.py
+++ b/nbconvert/preprocessors/sanitize.py
@@ -8,35 +8,34 @@ import bleach
 from bleach import ALLOWED_ATTRIBUTES, ALLOWED_TAGS, clean
 from traitlets import Any, Bool, List, Set, Unicode
 
-
 _USE_BLEACH_CSS_SANITIZER = False
 _USE_BLEACH_STYLES = False
 
 
 try:
     # bleach[css] >=5.0
-    from bleach.css_sanitizer import (
-        CSSSanitizer,
-        ALLOWED_CSS_PROPERTIES as ALLOWED_STYLES, 
-    )
+    from bleach.css_sanitizer import ALLOWED_CSS_PROPERTIES as ALLOWED_STYLES
+    from bleach.css_sanitizer import CSSSanitizer
+
     _USE_BLEACH_CSS_SANITIZER = True
     _USE_BLEACH_STYLES = False
 except ImportError:
     try:
         # bleach <5
         from bleach import ALLOWED_STYLES
+
         _USE_BLEACH_CSS_SANITIZER = False
         _USE_BLEACH_STYLES = True
         warnings.warn(
-            "Support for bleach <5 will be removed in a future version of nbconvert", 
-            DeprecationWarning
+            "Support for bleach <5 will be removed in a future version of nbconvert",
+            DeprecationWarning,
         )
 
     except ImportError:
         warnings.warn(
             "The installed bleach/tinycss2 do not provide CSS sanitization, "
             "please upgrade to bleach >=5",
-            UserWarning
+            UserWarning,
         )
 
 

--- a/nbconvert/preprocessors/sanitize.py
+++ b/nbconvert/preprocessors/sanitize.py
@@ -4,7 +4,6 @@ NBConvert Preprocessor for sanitizing HTML rendering of notebooks.
 
 import warnings
 
-import bleach
 from bleach import ALLOWED_ATTRIBUTES, ALLOWED_TAGS, clean
 from traitlets import Any, Bool, List, Set, Unicode
 

--- a/setup.py
+++ b/setup.py
@@ -237,20 +237,21 @@ setup_args = dict(
 )
 
 setup_args["install_requires"] = [
-    "mistune>=0.8.1,<2",
-    "jinja2>=2.4",
-    "pygments>=2.4.1",
-    "jupyterlab_pygments",
-    "traitlets>=5.0",
-    "jupyter_core",
-    "nbformat>=4.4",
-    "entrypoints>=0.2.2",
-    "bleach",
-    "pandocfilters>=1.4.1",
-    "defusedxml",
     "beautifulsoup4",
-    "nbclient>=0.5.0,<0.6.0",
+    "bleach",
+    "defusedxml",
+    "entrypoints>=0.2.2",
+    "jinja2>=2.4",
+    "jupyter_core",
+    "jupyterlab_pygments",
     "MarkupSafe>=2.0",
+    "mistune>=0.8.1,<2",
+    "nbclient>=0.5.0,<0.6.0",
+    "nbformat>=4.4",
+    "packaging",
+    "pandocfilters>=1.4.1",
+    "pygments>=2.4.1",
+    "traitlets>=5.0",
 ]
 
 pyppeteer_req = "pyppeteer>=1,<1.1"

--- a/setup.py
+++ b/setup.py
@@ -251,6 +251,7 @@ setup_args["install_requires"] = [
     "packaging",
     "pandocfilters>=1.4.1",
     "pygments>=2.4.1",
+    "tinycss2",  # for bleach >=5
     "traitlets>=5.0",
 ]
 


### PR DESCRIPTION
## References
- investigating #1754 

## Code Changes
- [x] add dependency on `packaging`, which was previously being provided by `bleach`
  - it's better if we _can_ support bleach 4 and 5
- [x] add dependency on `tinycss2`
  - it has a rather tight pin upstream, but is hidden behind an `[extra]`, sigh 
- [x] sort dependencies
- [x] add compatibility for `bleach` 5 with `tinycss2`
  - [x] fallback to `bleach` 4, with deprecation warning
    - [x] fallback with  to no CSS santizaton, with user warning

## Alternatives
- pin to `bleach<5` (not great, because security-related)
- pin to `bleach>=5` (not terrible)