### PR TITLE
Update to Mistune 2.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "jupyter_core>=4.7",
     "jupyterlab_pygments",
     "MarkupSafe>=2.0",
-    "mistune>=2.02",
+    "mistune>=2.0.2",
     "nbclient>=0.5.0",
     "nbformat>=5.1",
     "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "jupyter_core>=4.7",
     "jupyterlab_pygments",
     "MarkupSafe>=2.0",
-    "mistune>=0.8.1,<2",
+    "mistune>=2.02",
     "nbclient>=0.5.0",
     "nbformat>=5.1",
     "packaging",


### PR DESCRIPTION
[Mistune 2.0](https://github.com/lepture/mistune/tree/799cd118cc5e664b72e98410ce1b68645f1a38c0) was major overhaul, requiring a lot of changes on the `markdown2html_mistune` filter. I understand that the update may noy be desirable (see #1685), but I'm leaving this here as an option. Still, some more testing seems needed.

## Possible problems

- [ ] I'm using mistune 2.0.2 since 2.0.0 seems to have [some XSS vulnerability](https://github.com/jupyter/nbconvert/issues/1685#issuecomment-1090180891), but is it safe?
- [ ] The new `BlockParser` [doesn't consider `#TITLE` without space](https://github.com/lepture/mistune/blob/799cd118cc5e664b72e98410ce1b68645f1a38c0/mistune/block_parser.py#L54) a valid header. I've fixed it with a custom `AXT_HEADING` regex, but there may be other problems hidden in those regexes.
- [ ] Mistune now uses the [undocumented](https://github.com/python/cpython/issues/84440#issuecomment-1101758660) [`re.Scanner`](https://github.com/lepture/mistune/blob/799cd118cc5e664b72e98410ce1b68645f1a38c0/mistune/scanner.py#L3), but I couldn't make it remove the `$$` suffix in block math and had to strip the text manually. Can we trust `re.Scanner`? It seems to have other [unexpected shortcomings](https://www.reddit.com/r/Python/comments/3edk1g/rescanner_undocumented_class_perfect_for_a/ctec8kl/?utm_source=share&utm_medium=web2x&context=3) too.
- [ ] Mistune also [considers `javascript:...` links harmful](https://github.com/lepture/mistune/blob/799cd118cc5e664b72e98410ce1b68645f1a38c0/mistune/renderers.py#L105) and removes them. I've bypassed that, but maybe it should be adopted too.
- [x] I've used f-strings, is that okay? 