### PR TITLE
switch from entrypoints to importlib-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docs/source/*.j2
 docs/source/example.html
 docs/source/mytemplate/*
 docs/source/config_options.rst
+.venv
 
 # Eclipse pollutes the filesystem
 .project

--- a/nbconvert/exporters/script.py
+++ b/nbconvert/exporters/script.py
@@ -3,7 +3,10 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import entrypoints
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
 from traitlets import Dict, default
 
 from .base import get_exporter
@@ -32,8 +35,9 @@ class ScriptExporter(TemplateExporter):
         """
         if lang_name not in self._lang_exporters:
             try:
-                Exporter = entrypoints.get_single("nbconvert.exporters.script", lang_name).load()
-            except entrypoints.NoSuchEntryPoint:
+                exporters = importlib_metadata.entry_points()["nbconvert.exporters.script"]
+                Exporter = [e for e in exporters if e.name == lang_name][0].load()
+            except (KeyError, IndexError):
                 self._lang_exporters[lang_name] = None
             else:
                 # TODO: passing config is wrong, but changing this revealed more complicated issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "beautifulsoup4",
     "bleach",
     "defusedxml",
-    "entrypoints>=0.2.2",
+    "importlib-metadata;python_version<3.8",
     "jinja2>=3.0",
     "jupyter_core>=4.7",
     "jupyterlab_pygments",


### PR DESCRIPTION
entrypoints is deprecated and recommends switching to importlib-metadata. I've implemented this because I'm using a custom import mechanism that works with the documented importlib.metadata interface but not with entrypoints' custom logic