### PR TITLE
WebPDFExporter: Emulate media print

### DIFF
--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -89,7 +89,7 @@ class WebPDFExporter(HTMLExporter):
                 handleSIGINT=False, handleSIGTERM=False, handleSIGHUP=False, args=args
             )
             page = await browser.newPage()
-            await page.emulateMedia("screen")
+            await page.emulateMedia("print")
             await page.waitFor(100)
             await page.goto(f"file://{temp_file.name}", waitUntil="networkidle0")
             await page.waitFor(100)


### PR DESCRIPTION
This PR reverts a change I made in https://github.com/jupyter/nbconvert/pull/1718 where I wrongly thought that we needed to emulate the "screen" media in order for the background to properly be colored when using a custom theme, but it does not seem to be the case, only the "printBackground" pyppeteer option and the "webkit-print-color-adjust" CSS rules are needed.

The "print" media emulation is needed so that the following CSS rules are properly applied (fixing issues with page breaks on the PDF output): https://github.com/jupyter/nbconvert/blob/main/share/templates/lab/index.html.j2#L117

cc. @mnowacki-b