### PR TITLE
Fix lab template output alignment

### DIFF
--- a/share/templates/lab/base.html.j2
+++ b/share/templates/lab/base.html.j2
@@ -80,7 +80,11 @@
 {% endblock output_area_prompt %}
 
 {% block output %}
+{%- if output.output_type == 'execute_result' -%}
+<div class="jp-OutputArea-child jp-OutputArea-executeResult">
+{%- else -%}
 <div class="jp-OutputArea-child">
+{%- endif -%}
 {% if resources.global_content_filter.include_output_prompt %}
     {{ self.output_area_prompt() }}
 {% endif %}


### PR DESCRIPTION
This uses an if/else block to add the class. Note that it does not remove the `{%- set extra_class=... -%}` directive on the `execute_result` block.

Fixes #1794