### PR TITLE
Pin mistune for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jupyter_core>=4.7",
     "jupyterlab_pygments",
     "MarkupSafe>=2.0",
-    "mistune>=2.0.2",
+    "mistune>=2.0.2,<3",
     "nbclient>=0.5.0",
     "nbformat>=5.1",
     "packaging",


### PR DESCRIPTION
Mistune 3.0 is changing more of the APIs for the renderers, so we need to pin for now while they are in flux.