### PR TITLE
Update to Mistune v3

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -217,7 +217,8 @@ class HTMLExporter(TemplateExporter):
             anchor_link_text=self.anchor_link_text,
             exclude_anchor_links=self.exclude_anchor_links,
         )
-        return MarkdownWithMath(renderer=renderer).render(source)
+        md = MarkdownWithMath(renderer=renderer)
+        return md(source)
 
     def default_filters(self):
         """Get the default filters."""

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -217,8 +217,7 @@ class HTMLExporter(TemplateExporter):
             anchor_link_text=self.anchor_link_text,
             exclude_anchor_links=self.exclude_anchor_links,
         )
-        md = MarkdownWithMath(renderer=renderer)
-        return md(source)
+        return MarkdownWithMath(renderer=renderer).render(source)
 
     def default_filters(self):
         """Get the default filters."""

--- a/nbconvert/filters/markdown.py
+++ b/nbconvert/filters/markdown.py
@@ -11,13 +11,14 @@ import re
 
 try:
     from .markdown_mistune import markdown2html_mistune
+
 except ImportError as e:
-    # store in variable for Python 3
     _mistune_import_error = e
 
-    def markdown2html_mistune(source):
+    def markdown2html_mistune(source: str) -> str:
         """mistune is unavailable, raise ImportError"""
-        raise ImportError("markdown2html requires mistune: %s" % _mistune_import_error)
+        msg = f"markdown2html requires mistune: {_mistune_import_error}"
+        raise ImportError(msg)
 
 
 from .pandoc import convert_pandoc

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -49,6 +49,8 @@ class MathBlockParser(BlockParser):
     is ignored here.
     """
 
+    AXT_HEADING_WITHOUT_LEADING_SPACES = r"^ {0,3}(?P<axt_1>#{1,6})(?!#+)(?P<axt_2>[ \t]*(.*?)?)$"
+
     MULTILINE_MATH = _dotall(
         # Display math mode, old TeX delimiter: $$ \sqrt{2} $$
         r"(?<!\\)[$]{2}.*?(?<!\\)[$]{2}"
@@ -62,6 +64,7 @@ class MathBlockParser(BlockParser):
 
     SPECIFICATION = {
         **BlockParser.SPECIFICATION,
+        "axt_heading": AXT_HEADING_WITHOUT_LEADING_SPACES,
         "multiline_math": MULTILINE_MATH,
     }
 

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -14,7 +14,15 @@ from html import escape
 from typing import LiteralString, Match
 
 import bs4
-from mistune import BlockParser, BlockState, HTMLRenderer, InlineParser, Markdown, import_plugin
+from mistune import (
+    BlockParser,
+    BlockState,
+    HTMLRenderer,
+    InlineParser,
+    InlineState,
+    Markdown,
+    import_plugin,
+)
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_lexer_by_name
@@ -86,48 +94,70 @@ class MathInlineParser(InlineParser):
     delimiters from all these varieties, and extracts the type of environment
     in the last case (``foo`` in this example).
     """
-    BLOCK_MATH_TEX = _dotall(r"(?<!\\)\$\$(.*?)(?<!\\)\$\$")
-    BLOCK_MATH_LATEX = _dotall(r"(?<!\\)\\\\\[(.*?)(?<!\\)\\\\\]")
-    INLINE_MATH_TEX = _dotall(r"(?<![$\\])\$(.+?)(?<![$\\])\$")
-    INLINE_MATH_LATEX = _dotall(r"(?<!\\)\\\\\((.*?)(?<!\\)\\\\\)")
-    LATEX_ENVIRONMENT = _dotall(r"\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}")
 
-    # The order is important here
-    RULE_NAMES = (
+    # Display math mode, using older TeX delimiter: $$ \pi $$
+    BLOCK_MATH_TEX = _dotall(r"(?<!\\)\$\$(?P<math_block_tex>.*?)(?<!\\)\$\$")
+    # Display math mode, using newer LaTeX delimiter: \[ \pi \]
+    BLOCK_MATH_LATEX = _dotall(r"(?<!\\)\\\\\[(?P<math_block_latex>.*?)(?<!\\)\\\\\]")
+    # Inline math mode, using older TeX delimiter: $ \pi $  (cannot be empty!)
+    INLINE_MATH_TEX = _dotall(r"(?<![$\\])\$(?P<math_inline_tex>.+?)(?<![$\\])\$")
+    # Inline math mode, using newer LaTeX delimiter: \( \pi \)
+    INLINE_MATH_LATEX = _dotall(r"(?<!\\)\\\\\((?P<math_inline_latex>.*?)(?<!\\)\\\\\)")
+    # LaTeX math environment: \begin{equation} \pi \end{equation}
+    LATEX_ENVIRONMENT = _dotall(
+        r"\\begin\{(?P<math_env_name>[a-z]*\*?)\}"
+        r"(?P<math_env_body>.*?)"
+        r"\\end\{(?P=math_env_name)\}"
+    )
+
+    SPECIFICATION = {
+        **InlineParser.SPECIFICATION,
+        "block_math_tex": BLOCK_MATH_TEX,
+        "block_math_latex": BLOCK_MATH_LATEX,
+        "inline_math_tex": INLINE_MATH_TEX,
+        "inline_math_latex": INLINE_MATH_LATEX,
+        "latex_environment": LATEX_ENVIRONMENT,
+    }
+
+    # Block math must be matched first, and all math must come before text
+    DEFAULT_RULES = (
         "block_math_tex",
         "block_math_latex",
         "inline_math_tex",
         "inline_math_latex",
         "latex_environment",
-        *InlineParser.RULE_NAMES,
+        *InlineParser.DEFAULT_RULES,  # type: ignore
     )
 
-    def parse_block_math_tex(self, m, state):
-        """Parse block text math."""
-        # sometimes the Scanner keeps the final '$$', so we use the
-        # full matched string and remove the math markers
-        text = m.group(0)[2:-2]
-        return "block_math", text
+    def parse_block_math_tex(self, m: Match[str], state: InlineState) -> int:
+        """Parse older TeX-style display math."""
+        body = m.group("math_block_tex")
+        state.append_token({"type": "block_math", "raw": body})
+        return m.end()
 
-    def parse_block_math_latex(self, m, state):
-        """Parse block latex math ."""
-        text = m.group(1)
-        return "block_math", text
+    def parse_block_math_latex(self, m: Match[str], state: InlineState) -> int:
+        """Parse newer LaTeX-style display math."""
+        body = m.group("math_block_latex")
+        state.append_token({"type": "block_math", "raw": body})
+        return m.end()
 
-    def parse_inline_math_tex(self, m, state):
-        """Parse inline tex math."""
-        text = m.group(1)
-        return "inline_math", text
+    def parse_inline_math_tex(self, m: Match[str], state: InlineState) -> int:
+        """Parse older TeX-style inline math."""
+        body = m.group("math_inline_tex")
+        state.append_token({"type": "inline_math", "raw": body})
+        return m.end()
 
-    def parse_inline_math_latex(self, m, state):
-        """Parse inline latex math."""
-        text = m.group(1)
-        return "inline_math", text
+    def parse_inline_math_latex(self, m: Match[str], state: InlineState) -> int:
+        """Parse newer LaTeX-style inline math."""
+        body = m.group("math_inline_latex")
+        state.append_token({"type": "inline_math", "raw": body})
+        return m.end()
 
-    def parse_latex_environment(self, m, state):
+    def parse_latex_environment(self, m: Match[str], state: InlineState) -> int:
         """Parse a latex environment."""
-        name, text = m.group(1), m.group(2)
-        return "latex_environment", name, text
+        attrs = {"name": m.group("math_env_name"), "body": m.group("math_env_body")}
+        state.append_token({"type": "latex_environment", "attrs": attrs})
+        return m.end()
 
 
 class IPythonRenderer(HTMLRenderer):

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -10,7 +10,7 @@ import base64
 import mimetypes
 import os
 from html import escape
-from typing import Any, Callable, Iterable, LiteralString, Match, Optional
+from typing import Any, Callable, Dict, Iterable, Match, Optional
 
 import bs4
 from mistune import (
@@ -37,7 +37,7 @@ class InvalidNotebook(Exception):  # noqa
     pass
 
 
-def _dotall(pattern: LiteralString) -> LiteralString:
+def _dotall(pattern: str) -> str:
     """Makes the '.' special character match any character inside the pattern, including a newline.
 
     This is implemented with the inline flag `(?s:...)` and is equivalent to using `re.DOTALL`.
@@ -169,7 +169,7 @@ class IPythonRenderer(HTMLRenderer):
         exclude_anchor_links: bool = False,
         anchor_link_text: str = "¶",
         path: str = "",
-        attachments: Optional[dict[str, dict[str, str]]] = None,
+        attachments: Optional[Dict[str, Dict[str, str]]] = None,
     ):
         """Initialize the renderer."""
         super().__init__(escape, allow_harmful_protocols)
@@ -226,7 +226,7 @@ class IPythonRenderer(HTMLRenderer):
 
         return super().inline_html(html)
 
-    def heading(self, text: str, level: int, **attrs: dict[str, Any]) -> str:
+    def heading(self, text: str, level: int, **attrs: Dict[str, Any]) -> str:
         """Handle a heading."""
         html = super().heading(text, level, **attrs)
         if self.exclude_anchor_links:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jupyter_core>=4.7",
     "jupyterlab_pygments",
     "MarkupSafe>=2.0",
-    "mistune>=3.0,<4",
+    "mistune>=2.0.3,<4",
     "nbclient>=0.5.0",
     "nbformat>=5.7",
     "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jupyter_core>=4.7",
     "jupyterlab_pygments",
     "MarkupSafe>=2.0",
-    "mistune>=2.0.3,<3",
+    "mistune>=3.0,<4",
     "nbclient>=0.5.0",
     "nbformat>=5.7",
     "packaging",


### PR DESCRIPTION
[Mistune v3](/lepture/mistune/tree/v3) is already in [Pre-Release on PyPi](https://pypi.org/project/mistune/#history), with a few incompatibilities. Not a lot of changes on our side, besides moving regexes to new variables and updating methods to the new API.

I haven't tested on older Python versions (< 3.10) yet, just waiting for a proper release.

## Highlights in Mistune Code

- Dropped CI tests for Python 2.7 and 3.6 (see [commit](/lepture/mistune/commit/b117a18a3a1681cd05c53ade9bdd686fea95c0fb))
- New base Parser that doesn't use the [hidden `re.Scanner`](https://www.reddit.com/r/ProgrammerTIL/comments/4tpt03/python_til_about_rescanner_which_is_useful_for/) (see [commits](/lepture/mistune/commits/bea4b718a9844e3071e4bf84a83986dc15febc2d)), we can even used named groups now!
- Benchmarking code to avoid [perfomance regressions](/lepture/mistune/issues/236) (see [benchmark files](/lepture/mistune/blob/v3/benchmark/))