### PR TITLE
Remove tests from bdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,12 @@ path = "nbconvert/_version.py"
 [tool.hatch.build.targets.sdist]
 artifacts = ["share/templates/lab/static/*.*"]
 
+[tool.hatch.build.targets.wheel]
+exclude = [
+    "nbconvert/tests/",
+    "nbconvert/**/tests/",
+]
+
 [tool.hatch.build.targets.wheel.shared-data]
 "share/templates" = "share/jupyter/nbconvert/templates"
 


### PR DESCRIPTION
As @wvxvw pointed out in #1819, nbconvert shouldn't be packaging and distributing test files in binary wheels. This PR is a simple solution for that.