### PR TITLE
escape_html: prevent escaping quotes

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -71,7 +71,7 @@ default_filters = {
     "convert_pandoc": filters.convert_pandoc,
     "json_dumps": json.dumps,
     # For removing any HTML
-    "escape_html": lambda s: html.escape(str(s)),
+    "escape_html": lambda s: html.escape(str(s), quote=False),
     # For sanitizing HTML for any XSS
     "clean_html": clean_html,
     "strip_trailing_newline": filters.strip_trailing_newline,

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -71,7 +71,8 @@ default_filters = {
     "convert_pandoc": filters.convert_pandoc,
     "json_dumps": json.dumps,
     # For removing any HTML
-    "escape_html": lambda s: html.escape(str(s), quote=False),
+    "escape_html": lambda s: html.escape(str(s)),
+    "escape_html_keep_quotes": lambda s: html.escape(str(s), quote=False),
     # For sanitizing HTML for any XSS
     "clean_html": clean_html,
     "strip_trailing_newline": filters.strip_trailing_newline,

--- a/share/jupyter/nbconvert/templates/classic/base.html.j2
+++ b/share/jupyter/nbconvert/templates/classic/base.html.j2
@@ -268,7 +268,7 @@ var element = $('#{{ div_id }}');
 var element = $('#{{ div_id }}');
 </script>
 <script type="{{ datatype }}">
-{{ output.data[datatype] | json_dumps | escape_html }}
+{{ output.data[datatype] | json_dumps | escape_html_keep_quotes }}
 </script>
 </div>
 {%- endif %}
@@ -279,7 +279,7 @@ var element = $('#{{ div_id }}');
 {% set mimetype = 'application/vnd.jupyter.widget-state+json'%}
 {% if mimetype in nb.metadata.get("widgets",{})%}
 <script type="{{ mimetype }}">
-{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html }}
+{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html_keep_quotes }}
 </script>
 {% endif %}
 {%- endif %}

--- a/share/jupyter/nbconvert/templates/lab/base.html.j2
+++ b/share/jupyter/nbconvert/templates/lab/base.html.j2
@@ -298,7 +298,7 @@ var element = document.getElementById('{{ div_id }}');
 var element = document.getElementById('{{ div_id }}');
 </script>
 <script type="{{ datatype }}">
-{{ output.data[datatype] | json_dumps | escape_html }}
+{{ output.data[datatype] | json_dumps | escape_html_keep_quotes }}
 </script>
 </div>
 {%- endblock data_widget_view -%}
@@ -307,7 +307,7 @@ var element = document.getElementById('{{ div_id }}');
 {% set mimetype = 'application/vnd.jupyter.widget-state+json'%}
 {% if mimetype in nb.metadata.get("widgets",{})%}
 <script type="{{ mimetype }}">
-{{ nb.metadata.widgets[mimetype] | json_dumps | clean_html }}
+{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html_keep_quotes }}
 </script>
 {% endif %}
 {{ super() }}


### PR DESCRIPTION
This fixes an issue in Voila and the ipywidgets's HTMLManager for widgets support https://github.com/voila-dashboards/voila/issues/1186

Escaping quotes in the widget view mimetype being:
```
{&quot;version_major&quot;: 2, &quot;version_minor&quot;: 0, &quot;model_id&quot;: &quot;3b69871380984eae832c53f5ba8afa56&quot;}
```

Breaking the JSON representation of the widget in the Notebook