### PR TITLE
escape_html: prevent escaping quotes on widgets JSON reprs (#1829)

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -70,6 +70,7 @@ default_filters = {
     "json_dumps": json.dumps,
     # For removing any HTML
     "escape_html": lambda s: html.escape(str(s)),
+    "escape_html_keep_quotes": lambda s: html.escape(str(s), quote=False),
     # For sanitizing HTML for any XSS
     "clean_html": clean_html,
     "strip_trailing_newline": filters.strip_trailing_newline,

--- a/share/templates/classic/base.html.j2
+++ b/share/templates/classic/base.html.j2
@@ -268,7 +268,7 @@ var element = $('#{{ div_id }}');
 var element = $('#{{ div_id }}');
 </script>
 <script type="{{ datatype }}">
-{{ output.data[datatype] | json_dumps | escape_html }}
+{{ output.data[datatype] | json_dumps | escape_html_keep_quotes }}
 </script>
 </div>
 {%- endif %}
@@ -279,7 +279,7 @@ var element = $('#{{ div_id }}');
 {% set mimetype = 'application/vnd.jupyter.widget-state+json'%}
 {% if mimetype in nb.metadata.get("widgets",{})%}
 <script type="{{ mimetype }}">
-{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html }}
+{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html_keep_quotes }}
 </script>
 {% endif %}
 {%- endif %}

--- a/share/templates/lab/base.html.j2
+++ b/share/templates/lab/base.html.j2
@@ -302,7 +302,7 @@ var element = document.getElementById('{{ div_id }}');
 var element = document.getElementById('{{ div_id }}');
 </script>
 <script type="{{ datatype }}">
-{{ output.data[datatype] | json_dumps | escape_html }}
+{{ output.data[datatype] | json_dumps | escape_html_keep_quotes }}
 </script>
 </div>
 {%- endblock data_widget_view -%}
@@ -311,7 +311,7 @@ var element = document.getElementById('{{ div_id }}');
 {% set mimetype = 'application/vnd.jupyter.widget-state+json'%}
 {% if mimetype in nb.metadata.get("widgets",{})%}
 <script type="{{ mimetype }}">
-{{ nb.metadata.widgets[mimetype] | json_dumps | clean_html }}
+{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html_keep_quotes }}
 </script>
 {% endif %}
 {{ super() }}


### PR DESCRIPTION
Forward port of https://github.com/jupyter/nbconvert/pull/1829

* escape_html: prevent escaping quotes

This fixes an issue in Voila and the ipywidgets's HTMLManager for widgets support

* Add method for escaping html while keeping quotes

For escaping HTML from JSON reprs