### PR TITLE
Fix title

### DIFF
--- a/share/templates/classic/index.html.j2
+++ b/share/templates/classic/index.html.j2
@@ -9,7 +9,7 @@
 {%- block html_head -%}
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{% set nb_title = nb.metadata.get('title', resources['metadata']['name']) | clean_html %}
+{% set nb_title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 <title>{{nb_title}}</title>
 
 {%- block html_head_js -%}

--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -9,7 +9,7 @@
 {%- block html_head -%}
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{% set nb_title = nb.metadata.get('title', resources['metadata']['name']) | clean_html %}
+{% set nb_title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 <title>{{nb_title}}</title>
 
 {%- block html_head_js -%}

--- a/share/templates/reveal/index.html.j2
+++ b/share/templates/reveal/index.html.j2
@@ -20,7 +20,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
-{% set nb_title = nb.metadata.get('title', resources['metadata']['name']) | clean_html %}
+{% set nb_title = nb.metadata.get('title', resources['metadata']['name']) | escape_html_keep_quotes %}
 <title>{{nb_title}} slides</title>
 
 {%- block html_head_js -%}


### PR DESCRIPTION
`clean_html` returns valid HTML (wrapping the input around `<p></p>`) so we should not use it for the title or anything that's not HTML. Instead we can safely escape the HTML while keeping quotes.

### before
![Screenshot from 2022-08-11 10-01-49](https://user-images.githubusercontent.com/21197331/184090144-7f76a096-ad2f-451c-9779-5f0398177c9f.png)


### after
![Screenshot from 2022-08-11 10-03-48](https://user-images.githubusercontent.com/21197331/184090171-e6914c63-784e-41ee-bdd4-148c4c496ec3.png)
