### PR TITLE
Encode SVG image data as UTF-8 before calling lxml cleaner (fixes #1836)

### DIFF
--- a/share/templates/classic/base.html.j2
+++ b/share/templates/classic/base.html.j2
@@ -131,7 +131,7 @@ unknown type  {{ cell.type }}
 {%- if output.svg_filename %}
 <img src="{{ output.svg_filename | posix_path | escape_html }}">
 {%- else %}
-{{ output.data['image/svg+xml'] | clean_html }}
+{{ output.data['image/svg+xml'].encode("utf-8") | clean_html }}
 {%- endif %}
 </div>
 {%- endblock data_svg %}

--- a/share/templates/lab/base.html.j2
+++ b/share/templates/lab/base.html.j2
@@ -163,7 +163,7 @@ unknown type  {{ cell.type }}
 {%- if output.svg_filename %}
 <img src="{{ output.svg_filename | posix_path | escape_html }}">
 {%- else %}
-{{ output.data['image/svg+xml'] | clean_html }}
+{{ output.data['image/svg+xml'].encode("utf-8") | clean_html }}
 {%- endif %}
 </div>
 {%- endblock data_svg %}


### PR DESCRIPTION
SVG image data generated by matplotlib contains an encoding header 

`"<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n"`

The `clean_html` function from lxml refuses to parse this (see #1836)

   ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.

To avoid the problem, encode the string to bytes before calling `clean_html`. 