### PR TITLE
fix markdown table not render bug

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -122,11 +122,11 @@ class MarkdownWithMath(Markdown):
             plugins = [
                 # "abbr",
                 # 'footnotes',
-                'strikethrough',
-                'table',
-                'url',
-                'task_lists',
-                'def_list',
+                "strikethrough",
+                "table",
+                "url",
+                "task_lists",
+                "def_list",
             ]
             _plugins = []
             for p in plugins:

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -21,7 +21,7 @@ except ImportError:
     from cgi import escape as html_escape
 
 import bs4
-from mistune import BlockParser, HTMLRenderer, InlineParser, Markdown
+from mistune import BlockParser, HTMLRenderer, InlineParser, Markdown, PLUGINS
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_lexer_by_name
@@ -118,6 +118,23 @@ class MarkdownWithMath(Markdown):
             block = MathBlockParser()
         if inline is None:
             inline = MathInlineParser(renderer, hard_wrap=False)
+        if plugins is None:
+            plugins = [
+                # "abbr",
+                # 'footnotes',
+                'strikethrough',
+                'table',
+                'url',
+                'task_lists',
+                'def_list',
+            ]
+            _plugins = []
+            for p in plugins:
+                if isinstance(p, str):
+                    _plugins.append(PLUGINS[p])
+                else:
+                    _plugins.append(p)
+            plugins = _plugins
         super().__init__(renderer, block, inline, plugins)
 
     def render(self, s):

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -21,7 +21,7 @@ except ImportError:
     from cgi import escape as html_escape
 
 import bs4
-from mistune import BlockParser, HTMLRenderer, InlineParser, Markdown, PLUGINS
+from mistune import PLUGINS, BlockParser, HTMLRenderer, InlineParser, Markdown
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_lexer_by_name


### PR DESCRIPTION
no default plugins for `mistune.Markdown` for mistune update to v2, I added default plugins to `MarkdownWithMath` class