### PR TITLE
Add support for jupyter_client 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,8 +156,6 @@ jobs:
           pip check
       - name: Run the tests
         run: |
-          pip install jupyter_client@https://github.com/blink1073/jupyter_client/archive/refs/heads/synchronous_managers.zip
-          pip install nbclient==0.7.0
           pytest -vv -W default || pytest -vv -W default --lf
 
   make_sdist:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,6 +156,8 @@ jobs:
           pip check
       - name: Run the tests
         run: |
+          pip install jupyter_client@https://github.com/blink1073/jupyter_client/archive/refs/heads/synchronous_managers.zip
+          pip install nbclient@https://github.com/blink1073/nbclient/archive/refs/heads/client-8-handling.zip
           pytest -vv || pytest -vv --lf
 
   make_sdist:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
           pip freeze
           pip check
 
-      - name: Run tests with coverage
+      - name: Run tests on MacOS
         if: ${{ startsWith(runner.os, 'macos')  }}
         shell: bash -l {0}
         run: |
@@ -76,15 +76,14 @@ jobs:
           pip install -U websockets
           python -m pytest --cov nbconvert -vv
 
-      - name: Run tests on pypy and Windows
+      - name: Run tests on Linux
         if: ${{ startsWith(runner.os, 'linux') }}
         shell: bash -l {0}
         run: |
           conda activate nbconvert
           # See https://github.com/pyppeteer/pyppeteer/pull/321
           pip install -U websockets
-          #python -m pytest -vv
-          xvfb-run --auto-servernum `which coverage` run -m pytest -vv
+          NBFORMAT_VALIDATOR=jsonschema xvfb-run --auto-servernum `which coverage` run -m pytest -vv
 
       - name: Run tests on pypy and Windows
         if: ${{ startsWith(runner.os, 'Windows') }}
@@ -136,6 +135,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
       - name: Run the unit tests
         run: |
+          export NBFORMAT_VALIDATOR=jsonschema
           pytest -vv -W default || pytest -vv -W default --lf
 
   test_prereleases:
@@ -158,7 +158,7 @@ jobs:
         run: |
           pip install jupyter_client@https://github.com/blink1073/jupyter_client/archive/refs/heads/synchronous_managers.zip
           pip install nbclient==0.7.0
-          pytest -vv || pytest -vv --lf
+          pytest -vv -W default || pytest -vv -W default --lf
 
   make_sdist:
     name: Make SDist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Run the tests
         run: |
           pip install jupyter_client@https://github.com/blink1073/jupyter_client/archive/refs/heads/synchronous_managers.zip
-          pip install nbclient@https://github.com/blink1073/nbclient/archive/refs/heads/client-8-handling.zip
+          pip install nbclient==0.7.0
           pytest -vv || pytest -vv --lf
 
   make_sdist:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,7 +9,7 @@ Changes in nbconvert
 * Fix markdown table not render bug by @Neutree in :ghpull:`1853`
 * Replace lxml.html.clean_html with bleach; drop lxml dependency by @akx in :ghpull:`1854`
 * Remove CircleCI badge from README by @akx in :ghpull:`1857`
-* Added support for section (slide) "data-*" attributes by @bouzidanas in :ghpull:`1861`
+* Added support for section (slide) ``"data-*"`` attributes by @bouzidanas in :ghpull:`1861`
 
 7.0.0
 -----

--- a/nbconvert/exporters/tests/test_latex.py
+++ b/nbconvert/exporters/tests/test_latex.py
@@ -160,6 +160,7 @@ class TestLatexExporter(ExportersTestsBase):
         Can a LatexExporter export when it recieves raw binary strings form svg?
         """
         filename = os.path.join(current_dir, "files", "svg.ipynb")
+
         (output, resources) = LatexExporter().from_filename(filename)
         assert len(output) > 0
 

--- a/nbconvert/exporters/tests/test_rst.py
+++ b/nbconvert/exporters/tests/test_rst.py
@@ -40,11 +40,13 @@ class TestRSTExporter(ExportersTestsBase):
         with open(nbname, encoding="utf8") as f:
             nb = nbformat.read(f, 4)
 
+        nb = v4.upgrade(nb)
         exporter = self.exporter_class()
 
         (output, resources) = exporter.from_notebook_node(nb)
         # add an empty code cell
         nb.cells.append(v4.new_code_cell(source=""))
+
         (output2, resources) = exporter.from_notebook_node(nb)
         # adding an empty code cell shouldn't change output
         self.assertEqual(output.strip(), output2.strip())

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -83,6 +83,7 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         self._check_assign_resources(resources)
 
         with self.setup_kernel():
+            import pdb; pdb.set_trace()
             info_msg = self.wait_for_reply(self.kc.kernel_info())
             self.nb.metadata["language_info"] = info_msg["content"]["language_info"]
             for index, cell in enumerate(self.nb.cells):

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -3,6 +3,7 @@ and updates outputs"""
 
 from nbclient import NotebookClient
 from nbclient import execute as _execute
+from jupyter_client.manager import KernelManager
 
 # Backwards compatability for imported name
 from nbclient.exceptions import CellExecutionError  # noqa
@@ -35,6 +36,7 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
 
     def __init__(self, **kw):
         nb = kw.get("nb")
+        kw.setdefault('kernel_manager_class', KernelManager)
         Preprocessor.__init__(self, nb=nb, **kw)
         NotebookClient.__init__(self, nb, **kw)
 
@@ -83,7 +85,6 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         self._check_assign_resources(resources)
 
         with self.setup_kernel():
-            import pdb; pdb.set_trace()
             info_msg = self.wait_for_reply(self.kc.kernel_info())
             self.nb.metadata["language_info"] = info_msg["content"]["language_info"]
             for index, cell in enumerate(self.nb.cells):

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -1,9 +1,9 @@
 """Module containing a preprocessor that executes the code cells
 and updates outputs"""
 
+from jupyter_client.manager import KernelManager
 from nbclient import NotebookClient
 from nbclient import execute as _execute
-from jupyter_client.manager import KernelManager
 
 # Backwards compatability for imported name
 from nbclient.exceptions import CellExecutionError  # noqa
@@ -36,7 +36,7 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
 
     def __init__(self, **kw):
         nb = kw.get("nb")
-        kw.setdefault('kernel_manager_class', KernelManager)
+        kw.setdefault("kernel_manager_class", KernelManager)
         Preprocessor.__init__(self, nb=nb, **kw)
         NotebookClient.__init__(self, nb, **kw)
 

--- a/nbconvert/preprocessors/svg2pdf.py
+++ b/nbconvert/preprocessors/svg2pdf.py
@@ -148,6 +148,6 @@ class SVG2PDFPreprocessor(ConvertFiguresPreprocessor):
             if os.path.isfile(output_filename):
                 with open(output_filename, "rb") as f:
                     # PDF is a nb supported binary, data type, so base64 encode.
-                    return base64.encodebytes(f.read())
+                    return base64.encodebytes(f.read()).decode("utf-8")
             else:
                 raise TypeError("Inkscape svg to pdf conversion failed")


### PR DESCRIPTION
Testing against https://github.com/jupyter/jupyter_client/pull/835 in the prerelease build.   Relies on changes in https://github.com/jupyter/nbclient/pull/253 to allow for synchronous clients.