### PR TITLE
Fix templates not found when jupyter is installed in an external folder

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -640,8 +640,10 @@ class TemplateExporter(Exporter):
         root_dirs = []
         if DEV_MODE:
             root_dirs.append(os.path.abspath(os.path.join(ROOT, "..", "..", "share", "jupyter")))
-        #Add a path relative to jupyter root directory, for modules installed in external folders
-        root_dirs.append(os.path.abspath(os.path.join(ROOT, "..", "..", "..", "..", "share", "jupyter")))
+        # Add a path relative to jupyter root directory, for modules installed in external folders
+        root_dirs.append(
+            os.path.abspath(os.path.join(ROOT, "..", "..", "..", "..", "share", "jupyter"))
+        )
         root_dirs.extend(jupyter_path())
         return root_dirs
 


### PR DESCRIPTION
For issue nbconvert #1773.
Look for the standard templates folder using their expected relative path compared to the existing script. When jupyter is installed using pip install jupyter --prefix=XXX,  root_dirs did not contain XXX/share/jupyter as candidate. Maybe even jupyter_path() should be updated instead to potentially fix other places? I don't know the project enough to decide