### PR TITLE
Add cell-id anchor for cell identification

### DIFF
--- a/share/templates/base/cell_id_anchor.j2
+++ b/share/templates/base/cell_id_anchor.j2
@@ -1,0 +1,5 @@
+{%- macro cell_id_anchor(cell) -%}
+    {% if cell.id | length > 0 -%}
+        id="{{ ('cell-id=' ~ cell.id) | escape_html -}}"
+    {%- endif %}
+{%- endmacro %}

--- a/share/templates/classic/base.html.j2
+++ b/share/templates/classic/base.html.j2
@@ -1,8 +1,9 @@
 {%- extends 'display_priority.j2' -%}
 {% from 'celltags.j2' import celltags %}
+{% from 'cell_id_anchor.j2' import cell_id_anchor %}
 
 {% block codecell %}
-<div class="cell border-box-sizing code_cell rendered{{ celltags(cell) }}">
+<div {{ cell_id_anchor(cell) }} class="cell border-box-sizing code_cell rendered{{ celltags(cell) }}">
 {{ super() }}
 </div>
 {%- endblock codecell %}
@@ -75,7 +76,7 @@
 {% endblock output %}
 
 {% block markdowncell scoped %}
-<div class="cell border-box-sizing text_cell rendered{{ celltags(cell) }}">
+<div {{ cell_id_anchor(cell) }} class="cell border-box-sizing text_cell rendered{{ celltags(cell) }}">
 {%- if resources.global_content_filter.include_input_prompt-%}
     {{ self.empty_in_prompt() }}
 {%- endif -%}

--- a/share/templates/lab/base.html.j2
+++ b/share/templates/lab/base.html.j2
@@ -1,5 +1,6 @@
 {%- extends 'display_priority.j2' -%}
 {% from 'celltags.j2' import celltags %}
+{% from 'cell_id_anchor.j2' import cell_id_anchor %}
 
 {% block codecell %}
 {%- if not cell.outputs -%}
@@ -8,7 +9,7 @@
 {%- if not resources.global_content_filter.include_input -%}
 {%- set no_input_class="jp-mod-noInput" -%}
 {%- endif -%}
-<div class="jp-Cell jp-CodeCell jp-Notebook-cell {{ no_output_class }} {{ no_input_class }} {{ celltags(cell) }}">
+<div {{ cell_id_anchor(cell) }} class="jp-Cell jp-CodeCell jp-Notebook-cell {{ no_output_class }} {{ no_input_class }} {{ celltags(cell) }}">
 {{ super() }}
 </div>
 {%- endblock codecell %}
@@ -93,7 +94,7 @@
 {% endblock output %}
 
 {% block markdowncell scoped %}
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div {{ cell_id_anchor(cell) }} class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>


### PR DESCRIPTION
Addresses #1862.

Reference implementation for https://github.com/jupyter/nbformat/issues/317. Accompanies a PR for JupyterLab: https://github.com/jupyterlab/jupyterlab/pull/13285.

Adds a `id` attribute to code and markdown cells for cells which have ID, which contains cell id prefixed with `cell-id`.

Code cell:

```html
<div id="cell-id=a91264b6-ccda-4dad-ab2e-60bcc12c0066" class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
    <div class="jp-Cell-inputWrapper">
        <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser"></div>
        <div class="jp-InputArea jp-Cell-inputArea">
            <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
            <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
                <div class="CodeMirror cm-s-jupyter">
                    <div class="highlight hl-ipython3">
                        <pre><span></span><span class="n">test</span></pre>
                    </div>
                </div>
            </div>
        </div>
    </div>
</div>

```

Markdown:

```html
<div id="cell-id=0df699d1-77ea-432a-a203-fafd77e87462" class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
    <div class="jp-Cell-inputWrapper">
        <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser"></div>
        <div class="jp-InputArea jp-Cell-inputArea">
            <div class="jp-InputPrompt jp-InputArea-prompt"></div>
            <div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
                <p>test</p>
            </div>
        </div>
    </div>
</div>
```

Question: why are cell tags for markdown cells in lab template applied on `jp-MarkdownOutput` rather than for `jp-MarkdownCell`, differently to code cells and classic template?