### PR TITLE
Fix for webpdf Print Margins

### DIFF
--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -127,6 +127,14 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
   display: none;
 }
 
+@page {
+    margin: 0.5in; /* Margin for each printed piece of paper */
+}
+  
+@page :first {
+    margin-top: 0.5in; /* Top margin for first page of paper */
+}
+
 @media print {
   .jp-Cell-inputWrapper,
   .jp-Cell-outputWrapper {

--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -131,10 +131,6 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
     margin: 0.5in; /* Margin for each printed piece of paper */
 }
 
-@page :first {
-    margin-top: 0.5in; /* Top margin for first page of paper */
-}
-
 @media print {
   .jp-Cell-inputWrapper,
   .jp-Cell-outputWrapper {

--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -130,7 +130,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 @page {
     margin: 0.5in; /* Margin for each printed piece of paper */
 }
-  
+
 @page :first {
     margin-top: 0.5in; /* Top margin for first page of paper */
 }


### PR DESCRIPTION
When converting to webpdf the margins on the resulting printout are tiny. After a page break there are no margins at all. This code fixes that by placing a 0.5 inch margin on all sides of the printed page. This fixes issue #1660.