### PR TITLE
Fix for webpdf print margins

### DIFF
--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -127,6 +127,10 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
   display: none;
 }
 
+@page {
+    margin: 0.5in; /* Margin for each printed piece of paper */
+}
+
 @media print {
   .jp-Cell-inputWrapper,
   .jp-Cell-outputWrapper {


### PR DESCRIPTION
This is a fix for the webpdf print margins. It adds 0.5 inch margins to each printed page. This fixes Issue #1660 