### PR TITLE
always pass relax_add_props=True when validating

### DIFF
--- a/nbconvert/exporters/exporter.py
+++ b/nbconvert/exporters/exporter.py
@@ -315,10 +315,7 @@ class Exporter(LoggingConfigurable):
 
     def _validate_preprocessor(self, nbc, preprocessor):
         try:
-            if not hasattr(validator, "normalize"):
-                nbformat.validate(nbc, relax_add_props=True)
-            else:
-                nbformat.validate(nbc)
+            nbformat.validate(nbc, relax_add_props=True)
         except nbformat.ValidationError:
             self.log.error("Notebook is invalid after preprocessor %s", preprocessor)
             raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,10 +153,6 @@ testpaths = [
 filterwarnings = [
     "error",
     "ignore:nbconvert.utils.lexers is deprecated as of 5.0:UserWarning",
-    # Pending https://github.com/jupyter/nbformat/pull/343
-    "ignore:`relax_add_props` kwargs of validate has been deprecated for security:DeprecationWarning",
-    # Pending https://github.com/jupyter/nbformat/pull/256
-    "ignore:Passing a schema to Validator.iter_errors is deprecated:DeprecationWarning",
     # https://github.com/pyppeteer/pyppeteer/issues/342
     "ignore:remove loop argument:DeprecationWarning:websockets",
     # https://github.com/mhammond/pywin32/issues/1802

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,8 @@ testpaths = [
 filterwarnings = [
     "error",
     "ignore:nbconvert.utils.lexers is deprecated as of 5.0:UserWarning",
+    # Pending https://github.com/jupyter/nbformat/pull/343
+    "ignore:`relax_add_props` kwargs of validate has been deprecated for security:DeprecationWarning",
     # Pending https://github.com/jupyter/nbformat/pull/256
     "ignore:Passing a schema to Validator.iter_errors is deprecated:DeprecationWarning",
     # https://github.com/pyppeteer/pyppeteer/issues/342


### PR DESCRIPTION
avoids crashing on notebooks that have no practical issues.

I think the relevant deprecation was a mistake, and is reverted in https://github.com/jupyter/nbformat/pull/343 because it's not related to normalization, and https://github.com/jupyter/nbformat/pull/282 deprecated normalization args passed to validate.