### PR TITLE
Do not import pyppeteer for installation check (#1947)Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com> Co-authored-by: Matthias Bussonnier <bussonniermatthias@gmail.com>

### DIFF
--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -67,7 +67,7 @@ class WebPDFExporter(HTMLExporter):
 
     def _check_launch_reqs(self):
         try:
-            from pyppeteer import launch  # type: ignore
+            from pyppeteer import launch  # type: ignore[import]
             from pyppeteer.util import check_chromium  # type:ignore
         except ModuleNotFoundError as e:
             msg = (

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -13,7 +13,6 @@ from traitlets import Bool, default
 
 from .html import HTMLExporter
 
-
 PYPPETEER_INSTALLED = importlib_util.find_spec("pyppeteer") is not None
 
 

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -7,17 +7,14 @@ import asyncio
 import concurrent.futures
 import os
 import tempfile
+from importlib import util as importlib_util
 
 from traitlets import Bool, default
 
 from .html import HTMLExporter
 
-try:
-    import pyppeteer  # type:ignore  # noqa
 
-    PYPPETEER_INSTALLED = True
-except ImportError:
-    PYPPETEER_INSTALLED = False
+PYPPETEER_INSTALLED = importlib_util.find_spec("pyppeteer") is not None
 
 
 class WebPDFExporter(HTMLExporter):

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -67,7 +67,7 @@ class WebPDFExporter(HTMLExporter):
 
     def _check_launch_reqs(self):
         try:
-            from pyppeteer import launch
+            from pyppeteer import launch  # type: ignore
             from pyppeteer.util import check_chromium  # type:ignore
         except ModuleNotFoundError as e:
             msg = (


### PR DESCRIPTION
Should fix #1944 because `importlib.util.find_spec` does not import the package.