### PR TITLE
add mermaidjs 10.2.3

### DIFF
--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -122,7 +122,7 @@ class HTMLExporter(TemplateExporter):
     ).tag(config=True)
 
     mermaid_js_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.0.2/mermaid.esm.min.mjs",
+        "https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.2.3/mermaid.esm.min.mjs",
         help="""
         URL to load MermaidJS from.
 

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -121,6 +121,15 @@ class HTMLExporter(TemplateExporter):
         """,
     ).tag(config=True)
 
+    mermaid_js_url = Unicode(
+        "https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.0.2/mermaid.esm.min.mjs",
+        help="""
+        URL to load MermaidJS from.
+
+        Defaults to loading from cdnjs.
+        """,
+    )
+
     jquery_url = Unicode(
         "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js",
         help="""
@@ -300,6 +309,7 @@ class HTMLExporter(TemplateExporter):
         resources["include_url"] = resources_include_url
         resources["require_js_url"] = self.require_js_url
         resources["mathjax_url"] = self.mathjax_url
+        resources["mermaid_js_url"] = self.mermaid_js_url
         resources["jquery_url"] = self.jquery_url
         resources["jupyter_widgets_base_url"] = self.jupyter_widgets_base_url
         resources["widget_renderer_url"] = self.widget_renderer_url

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -172,6 +172,7 @@ class IPythonRenderer(HTMLRenderer):
         else:
             self.attachments = {}
 
+
     def block_code(self, code, info=None):
         """Handle block code."""
         lang = ""
@@ -198,7 +199,7 @@ class IPythonRenderer(HTMLRenderer):
 
     def block_mermaidjs(self, code, info=None):
         """Handle mermaid syntax."""
-        return f"""<div class="jp-RenderedMermaid">
+        return f"""<div class="jp-Mermaid">
             <pre class="mermaid">{code}</pre>
         </div>"""
 

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -176,19 +176,17 @@ class IPythonRenderer(HTMLRenderer):
         """Handle block code."""
         lang = ""
         lexer = None
-        raw_code = code
-        raw_lang = info
+
+        if info and info.startswith("mermaid"):
+            return self.block_mermaidjs(code)
 
         if info:
             try:
-                lang = raw_lang
+                lang = info.strip().split(None, 1)[0]
                 lexer = get_lexer_by_name(lang, stripall=True)
             except ClassNotFound:
-                code = lang + "\n" + raw_code
+                code = lang + "\n" + code
                 lang = None  # type:ignore
-
-        if raw_lang.startswith("mermaid"):
-            return self.block_mermaidjs(raw_code)
 
         if not lang:
             return super().block_code(code)
@@ -198,9 +196,11 @@ class IPythonRenderer(HTMLRenderer):
 
     def block_mermaidjs(self, code, info=None):
         """Handle mermaid syntax."""
-        return f"""<div class="jp-Mermaid">
-            <pre class="mermaid">{code}</pre>
-        </div>"""
+        return (
+            """<div class="jp-Mermaid"><pre class="mermaid">\n"""
+            f"""{code.strip()}"""
+            """\n</pre></div>"""
+        )
 
     def block_html(self, html):
         """Handle block html."""

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -176,19 +176,31 @@ class IPythonRenderer(HTMLRenderer):
         """Handle block code."""
         lang = ""
         lexer = None
+        raw_code = code
+        raw_lang = info
+
         if info:
             try:
-                lang = info.strip().split(None, 1)[0]
+                lang = raw_lang
                 lexer = get_lexer_by_name(lang, stripall=True)
             except ClassNotFound:
-                code = lang + "\n" + code
+                code = lang + "\n" + raw_code
                 lang = None  # type:ignore
+
+        if raw_lang.startswith("mermaid"):
+            return self.block_mermaidjs(raw_code)
 
         if not lang:
             return super().block_code(code)
 
         formatter = HtmlFormatter()
         return highlight(code, lexer, formatter)
+
+    def block_mermaidjs(self, code, info=None):
+        """Handle mermaid syntax."""
+        return f"""<div class="jp-RenderedMermaid">
+            <pre class="mermaid">{code}</pre>
+        </div>"""
 
     def block_html(self, html):
         """Handle block html."""

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -172,7 +172,6 @@ class IPythonRenderer(HTMLRenderer):
         else:
             self.attachments = {}
 
-
     def block_code(self, code, info=None):
         """Handle block code."""
         lang = ""

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -250,7 +250,7 @@ i.e. the $i^{th}$""",
     def test_mermaid_markdown(self):
         code = """flowchart LR
             chicken --> egg --> chicken"""
-        case = """```mermaid\n + """ f"""{code}""" + """\n```"""
+        case = """```mermaid\n  """ + f"""{code}""" + """\n```"""
 
         output_check = (
             """<div class="jp-Mermaid"><pre class="mermaid">\n"""

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -250,7 +250,7 @@ i.e. the $i^{th}$""",
     def test_mermaid_markdown(self):
         code = """flowchart LR
             chicken --> egg --> chicken"""
-        case = """```mermaid\n  """ + f"""{code}""" + """\n```"""
+        case = f"""```mermaid\n  {code}\n```"""
 
         output_check = (
             """<div class="jp-Mermaid"><pre class="mermaid">\n"""

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -250,11 +250,7 @@ i.e. the $i^{th}$""",
     def test_mermaid_markdown(self):
         code = """flowchart LR
             chicken --> egg --> chicken"""
-        case = (
-            """```mermaid\n"""
-            f"""{code}"""
-            """\n```"""
-        )
+        case = """```mermaid\n""" f"""{code}""" """\n```"""
 
         output_check = (
             """<div class="jp-Mermaid"><pre class="mermaid">\n"""

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -250,7 +250,7 @@ i.e. the $i^{th}$""",
     def test_mermaid_markdown(self):
         code = """flowchart LR
             chicken --> egg --> chicken"""
-        case = """```mermaid\n""" f"""{code}""" """\n```"""
+        case = """```mermaid\n + """ f"""{code}""" + """\n```"""
 
         output_check = (
             """<div class="jp-Mermaid"><pre class="mermaid">\n"""

--- a/nbconvert/filters/tests/test_markdown.py
+++ b/nbconvert/filters/tests/test_markdown.py
@@ -247,6 +247,23 @@ i.e. the $i^{th}$""",
                 tokens[index],
             )
 
+    def test_mermaid_markdown(self):
+        code = """flowchart LR
+            chicken --> egg --> chicken"""
+        case = (
+            """```mermaid\n"""
+            f"""{code}"""
+            """\n```"""
+        )
+
+        output_check = (
+            """<div class="jp-Mermaid"><pre class="mermaid">\n"""
+            f"""{code.strip()}"""
+            """\n</pre></div>"""
+        )
+
+        self._try_markdown(markdown2html, case, output_check)
+
     def _try_markdown(self, method, test, tokens):
         results = method(test)
         if isinstance(tokens, (str,)):

--- a/share/templates/classic/index.html.j2
+++ b/share/templates/classic/index.html.j2
@@ -19,6 +19,12 @@
 {%- block html_head_js_requirejs -%}
 <script src="{{ resources.require_js_url }}"></script>
 {%- endblock html_head_js_requirejs -%}
+{%- block html_head_js_mermaidjs -%}
+<script type="module">
+  import mermaid from '{{ resources.mermaid_js_url }}';
+  mermaid.initialize({ startOnLoad: true });
+</script>
+{%- endblock html_head_js_mermaidjs -%}
 {%- endblock html_head_js -%}
 
 {% block jupyter_widgets %}

--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -16,6 +16,12 @@
 {%- block html_head_js_requirejs -%}
 <script src="{{ resources.require_js_url }}"></script>
 {%- endblock html_head_js_requirejs -%}
+{%- block html_head_js_mermaidjs -%}
+<script type="module">
+  import mermaid from '{{ resources.mermaid_js_url }}';
+  mermaid.initialize({ startOnLoad: true });
+</script>
+{%- endblock html_head_js_mermaidjs -%}
 {%- endblock html_head_js -%}
 
 {% block jupyter_widgets %}

--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -1,5 +1,6 @@
 {%- extends 'base.html.j2' -%}
 {% from 'mathjax.html.j2' import mathjax %}
+{% from 'mermaidjs.html.j2' import mermaid_js %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
 {%- block header -%}
@@ -16,12 +17,6 @@
 {%- block html_head_js_requirejs -%}
 <script src="{{ resources.require_js_url }}"></script>
 {%- endblock html_head_js_requirejs -%}
-{%- block html_head_js_mermaidjs -%}
-<script type="module">
-  import mermaid from '{{ resources.mermaid_js_url }}';
-  mermaid.initialize({ startOnLoad: true });
-</script>
-{%- endblock html_head_js_mermaidjs -%}
 {%- endblock html_head_js -%}
 
 {% block jupyter_widgets %}
@@ -154,6 +149,10 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 {%- block html_head_js_mathjax -%}
 {{ mathjax(resources.mathjax_url) }}
 {%- endblock html_head_js_mathjax -%}
+
+{%- block html_head_js_mermaidjs -%}
+{{ mermaid_js(resources.mermaid_js_url) }}
+{%- endblock html_head_js_mermaidjs -%}
 
 {%- block html_head_css -%}
 {%- endblock html_head_css -%}

--- a/share/templates/lab/mermaidjs.html.j2
+++ b/share/templates/lab/mermaidjs.html.j2
@@ -1,5 +1,5 @@
 {%- macro mermaid_js(
-url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.0.2/mermaid.esm.min.mjs"
+url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.2.3/mermaid.esm.min.mjs"
 ) -%}
 <script type="module">
   document.addEventListener("DOMContentLoaded", async () => {

--- a/share/templates/lab/mermaidjs.html.j2
+++ b/share/templates/lab/mermaidjs.html.j2
@@ -1,0 +1,101 @@
+{%- macro mermaid_js(
+url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.0.2/mermaid.esm.min.mjs"
+) -%}
+<script type="module">
+  document.addEventListener("DOMContentLoaded", async () => {
+    const diagrams = document.querySelectorAll(".jp-Mermaid > pre.mermaid");
+    // do not load mermaidjs if not needed
+    if (!diagrams.length) {
+      return;
+    }
+    const mermaid = (await import("{{ url }}")).default;
+
+    mermaid.initialize({
+      maxTextSize: 100000,
+      startOnLoad: false,
+      fontFamily: window
+        .getComputedStyle(document.body)
+        .getPropertyValue("--jp-ui-font-family"),
+      theme: document.querySelector("body[data-jp-theme-light='true']")
+        ? "default"
+        : "dark",
+    });
+
+    let _nextMermaidId = 0;
+
+    function makeMermaidImage(svg) {
+      const img = document.createElement("img");
+      const maxWidth = svg.match(/max-width: (\d+)/);
+      if (maxWidth && maxWidth[1]) {
+        const width = parseInt(maxWidth[1]);
+        if (width && !Number.isNaN(width) && Number.isFinite(width)) {
+          img.width = width;
+        }
+      }
+      img.setAttribute("src", `data:image/svg+xml,${encodeURIComponent(svg)}`);
+      return img;
+    }
+
+    async function renderOneMarmaid(src) {
+      const id = `jp-mermaid-${_nextMermaidId++}`;
+      let svg = "";
+      let error = "";
+      const parent = src.parentNode;
+      let raw = src.textContent;
+      const el = document.createElement("div");
+      el.style.visibility = "hidden";
+      document.body.appendChild(el);
+      try {
+        svg = (await mermaid.render(id, raw, el)).svg;
+        parent.appendChild(makeMermaidImage(svg));
+        src.remove();
+      } catch (err) {
+        try {
+          await mermaid.parse(raw);
+        } catch (err) {
+          error = `${err}`;
+        }
+      } finally {
+        el.remove();
+      }
+      parent.classList.add("jp-RenderedMermaid");
+      if (error) {
+        parent.innerHTML = `<details>
+          <summary>
+            <pre><code>${raw}</code></pre>
+          </summary>
+          <pre><code>${error}</code></pre>
+        </details>`;
+        parent.classList.add("jp-mod-warning");
+      }
+    }
+
+    void Promise.all([...diagrams].map(renderOneMarmaid));
+  });
+</script>
+<style>
+  .jp-RenderedMarkdown .jp-Mermaid:not(.jp-RenderedMermaid) {
+    display: none;
+  }
+  .jp-RenderedMarkdown .jp-RenderedMermaid.jp-mod-warning {
+    width: auto;
+    padding: 10px;
+    border: var(--jp-border-width) solid var(--jp-warn-color2);
+    border-radius: var(--jp-border-radius);
+    color: var(--jp-ui-font-color1);
+    font-size: var(--jp-ui-font-size1);
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+  .jp-RenderedMarkdown .jp-RenderedMermaid.jp-mod-warning details > pre {
+    margin-top: 1em;
+  }
+  .jp-RenderedMarkdown .jp-RenderedMermaid.jp-mod-warning summary {
+    color: var(--jp-warn-color2);
+  }
+  .jp-RenderedMarkdown .jp-RenderedMermaid.jp-mod-warning summary > pre {
+    display: inline-block;
+  }
+</style>
+<!-- End of mermaid configuration -->
+{%- endmacro %}

--- a/share/templates/lab/mermaidjs.html.j2
+++ b/share/templates/lab/mermaidjs.html.j2
@@ -1,5 +1,5 @@
 {%- macro mermaid_js(
-url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.2.3/mermaid.esm.min.mjs"
+url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.0.2/mermaid.esm.min.mjs"
 ) -%}
 <script type="module">
   document.addEventListener("DOMContentLoaded", async () => {
@@ -24,7 +24,7 @@ url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.2.3/mermaid.esm.min.mjs"
     let _nextMermaidId = 0;
 
     function makeMermaidImage(svg) {
-      const img = document.createElement("img");
+      const img = document.createElement('img');
       const maxWidth = svg.match(/max-width: (\d+)/);
       if (maxWidth && maxWidth[1]) {
         const width = parseInt(maxWidth[1]);
@@ -32,42 +32,52 @@ url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.2.3/mermaid.esm.min.mjs"
           img.width = width;
         }
       }
-      img.setAttribute("src", `data:image/svg+xml,${encodeURIComponent(svg)}`);
+      img.setAttribute('src', `data:image/svg+xml,${encodeURIComponent(svg)}`);
       return img;
+    }
+
+    async function makeMermaidError(text) {
+      let errorMessage = '';
+      try {
+        await mermaid.parse(text);
+      } catch (err) {
+        errorMessage = `${err}`;
+      }
+
+      const result = document.createElement('details');
+      const summary = document.createElement('summary');
+      const pre = document.createElement('pre');
+      const code = document.createElement('code');
+      code.innerText = text;
+      pre.appendChild(code);
+      summary.appendChild(pre);
+      result.appendChild(summary);
+
+      const warning = document.createElement('pre');
+      warning.innerText = errorMessage;
+      result.appendChild(warning);
+      return result;
     }
 
     async function renderOneMarmaid(src) {
       const id = `jp-mermaid-${_nextMermaidId++}`;
-      let svg = "";
-      let error = "";
       const parent = src.parentNode;
-      let raw = src.textContent;
+      let raw = src.textContent.trim();
       const el = document.createElement("div");
       el.style.visibility = "hidden";
       document.body.appendChild(el);
+      let result = null;
       try {
-        svg = (await mermaid.render(id, raw, el)).svg;
-        parent.appendChild(makeMermaidImage(svg));
-        src.remove();
+        const { svg } = await mermaid.render(id, raw, el);
+        result = makeMermaidImage(svg);
       } catch (err) {
-        try {
-          await mermaid.parse(raw);
-        } catch (err) {
-          error = `${err}`;
-        }
+        parent.classList.add("jp-mod-warning");
+        result = await makeMermaidError(raw);
       } finally {
         el.remove();
       }
       parent.classList.add("jp-RenderedMermaid");
-      if (error) {
-        parent.innerHTML = `<details>
-          <summary>
-            <pre><code>${raw}</code></pre>
-          </summary>
-          <pre><code>${error}</code></pre>
-        </details>`;
-        parent.classList.add("jp-mod-warning");
-      }
+      parent.appendChild(result);
     }
 
     void Promise.all([...diagrams].map(renderOneMarmaid));
@@ -95,6 +105,9 @@ url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.2.3/mermaid.esm.min.mjs"
   }
   .jp-RenderedMarkdown .jp-RenderedMermaid.jp-mod-warning summary > pre {
     display: inline-block;
+  }
+  .jp-RenderedMermaid > .mermaid {
+    display: none;
   }
 </style>
 <!-- End of mermaid configuration -->

--- a/share/templates/reveal/index.html.j2
+++ b/share/templates/reveal/index.html.j2
@@ -30,6 +30,12 @@
 {%- block html_head_js_requirejs -%}
 <script src="{{ resources.require_js_url }}"></script>
 {%- endblock html_head_js_requirejs -%}
+{%- block html_head_js_mermaidjs -%}
+<script type="module">
+  import mermaid from '{{ resources.mermaid_js_url }}';
+  mermaid.initialize({ startOnLoad: true });
+</script>
+{%- endblock html_head_js_mermaidjs -%}
 {%- endblock html_head_js -%}
 
 {% block jupyter_widgets %}


### PR DESCRIPTION
Adds [mermaidjs diagram support](https://mermaid.js.org/), which is the most commonly-available, open source ascii-based diagram tool, supporting a large number of broadly-useful diagrams.

The motivation is that this syntax <code>```mermaid</code> is supported natively by a large number of existing platforms under a consistent syntax, most notably GitHub, which theoretically we track. 

## References

- related [JupyterLab PR](https://github.com/jupyterlab/jupyterlab/pull/14102#issuecomment-1453134883)

## Changes

- [x] adds a CDN URL for mermaidjs
- [x] adds via the recommended `<script type="module"` 
  - > this supports the lazy loading without e.g. requirejs for [95% of browser market share](https://caniuse.com/es6-module)
- [x] only load/start mermaid assets when mermaid actually found

## User-facing changes
- example output with rich display and markdown cells
  - [gist](https://gist.github.com/bollwyvl/b250b5ad584819b68923c97a45d68b22)
- this would _not_ yet be supported in
  - notebook classic
  - bespoke renderers of notebooks, such as the GitLab notebook viewer
  - other jupyter clients (beyond any linked PRs above)