### PR TITLE
Revert unintended effects of #1966

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -420,9 +420,7 @@ class NbConvertApp(JupyterApp):
         """
         basename = os.path.basename(notebook_filename)
         notebook_name = basename[: basename.rfind(".")]
-        notebook_name = self.output_base.format(
-            notebook_name=notebook_name
-        )
+        notebook_name = self.output_base.format(notebook_name=notebook_name)
 
         return notebook_name
 

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -218,7 +218,7 @@ class NbConvertApp(JupyterApp):
     output_base = Unicode(
         "{notebook_name}",
         help="""Overwrite base name use for output files.
-            Supports pattern replacements '{notebook_name}' and '{notebook_filename}'.
+            Supports pattern replacements '{notebook_name}'.
             """,
     ).tag(config=True)
 
@@ -421,7 +421,7 @@ class NbConvertApp(JupyterApp):
         basename = os.path.basename(notebook_filename)
         notebook_name = basename[: basename.rfind(".")]
         notebook_name = self.output_base.format(
-            notebook_name=notebook_name, notebook_filename=notebook_filename
+            notebook_name=notebook_name
         )
 
         return notebook_name
@@ -513,7 +513,7 @@ class NbConvertApp(JupyterApp):
             raise KeyError(msg)
 
         notebook_name = resources["unique_key"]
-        if self.use_output_suffix:
+        if self.use_output_suffix and self.output_base == "{notebook_name}":
             notebook_name += resources.get("output_suffix", "")
 
         write_results = self.writer.write(output, resources, notebook_name=notebook_name)
@@ -584,18 +584,6 @@ class NbConvertApp(JupyterApp):
             base, ext = os.path.splitext(self.output_base)
             if ext == self.exporter.file_extension:
                 self.output_base = base
-
-        # Validate that output_base does not cause us to overwrite already generated
-        # files
-        notebook_names = [self._notebook_filename_to_name(fn) for fn in self.notebooks]
-        if len(notebook_names) != len(set(notebook_names)):
-            msg = (
-                "Conversion would override an already generated output. "
-                "This is probably due to --output or output_base configuration "
-                "leading to non-unique output names. "
-                f"Output notebook names were: {notebook_names}"
-            )
-            raise ValueError(msg)
 
         # convert each notebook
         if not self.from_stdin:

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -654,7 +654,6 @@ class TestNbConvertApp(TestsBase):
             for nbn in notebook_names:
                 assert os.path.isfile(f"{nbn}.md")
 
-
         # Test single output with static output name
         nbname = notebook_names[0]
         with self.create_temp_cwd([nbname + ".ipynb"]):

--- a/nbconvert/tests/test_nbconvertapp.py
+++ b/nbconvert/tests/test_nbconvertapp.py
@@ -654,16 +654,32 @@ class TestNbConvertApp(TestsBase):
             for nbn in notebook_names:
                 assert os.path.isfile(f"{nbn}.md")
 
-        with pytest.raises(OSError), self.create_temp_cwd([x + ".ipynb" for x in notebook_names]):
-            self.nbconvert("*.ipynb --output notebook_test_name --to markdown")
 
         # Test single output with static output name
-        with self.create_temp_cwd([notebook_names[0] + ".ipynb"]):
-            self.nbconvert("*.ipynb --output notebook_test_name --to markdown")
+        nbname = notebook_names[0]
+        with self.create_temp_cwd([nbname + ".ipynb"]):
+            self.nbconvert(f"{nbname}.ipynb --output notebook_test_name --to markdown")
             assert os.path.isfile("notebook_test_name.md")
+
+            self.nbconvert(f"{nbname}.ipynb --to notebook")
+            assert os.path.isfile("notebook1.nbconvert.ipynb")
+
+            self.nbconvert(f"{nbname}.ipynb --to notebook --output out.ipynb")
+            assert os.path.isfile("out.ipynb")
 
         # Test double extension fix
         with self.create_temp_cwd([notebook_names[0] + ".ipynb"]):
             self.nbconvert("*.ipynb --output notebook_test_name.md --to markdown")
             assert os.path.isfile("notebook_test_name.md")
             assert not os.path.isfile("notebook_test_name.md.md")
+
+    def test_same_filename_different_dir(self):
+        """
+        Check if files with same name in different directories pose a problem
+        """
+        with self.create_temp_cwd() as temp_wd:
+            self.copy_files_to(["notebook1.ipynb"], temp_wd + "/dir1")
+            self.copy_files_to(["notebook1.ipynb"], temp_wd + "/dir2")
+            self.nbconvert("dir1/notebook1.ipynb dir2/notebook1.ipynb --to markdown")
+            assert os.path.isfile("dir1/notebook1.md")
+            assert os.path.isfile("dir2/notebook1.md")


### PR DESCRIPTION
Revert to the previous default filename behavior
```
$ ls
test.ipynb
$ jupyter nbconvert --to notebook --output out.ipynb test.ipynb 
[NbConvertApp] Converting notebook test.ipynb to notebook
[NbConvertApp] Writing 72 bytes to out.ipynb
$ jupyter nbconvert --to notebook test.ipynb 
[NbConvertApp] Converting notebook test.ipynb to notebook
[NbConvertApp] Writing 72 bytes to test.nbconvert.ipynb
```

Closes #1970.

Edit:
Additional things to fix:
- [x] #1979 same nb names in different directories 
  - Fixed by removing the incorrect check that was failing (and an associated test). As a result, if `output_base` doesn't include some format section (like `{notebook_name}`), some files might get overwritten. This should not happen unless the user specifically wants it.
- [x] I don't think using `{notebook_filename}` will always work the way it was intended. Even if it does, it doesn't have any tests, which I should add.
  - Just removed this functionality as it doesn't seem to work cohesively with existing `FilesWriter` configuration.

Now also closes #1979.