### PR TITLE
Tweak exporter default_config merging behavior

### DIFF
--- a/nbconvert/exporters/asciidoc.py
+++ b/nbconvert/exporters/asciidoc.py
@@ -48,5 +48,8 @@ class ASCIIDocExporter(TemplateExporter):
                 "HighlightMagicsPreprocessor": {"enabled": True},
             }
         )
-        c.merge(super().default_config)
+        if super().default_config:
+            c2 = super().default_config.copy()
+            c2.merge(c)
+            c = c2
         return c

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -187,7 +187,10 @@ class HTMLExporter(TemplateExporter):
                 "HighlightMagicsPreprocessor": {"enabled": True},
             }
         )
-        c.merge(super().default_config)
+        if super().default_config:
+            c2 = super().default_config.copy()
+            c2.merge(c)
+            c = c2
         return c
 
     @contextfilter

--- a/nbconvert/exporters/latex.py
+++ b/nbconvert/exporters/latex.py
@@ -61,7 +61,10 @@ class LatexExporter(TemplateExporter):
                 "HighlightMagicsPreprocessor": {"enabled": True},
             }
         )
-        c.merge(super().default_config)
+        if super().default_config:
+            c2 = super().default_config.copy()
+            c2.merge(c)
+            c = c2
         return c
 
     def from_notebook_node(self, nb, resources=None, **kw):

--- a/nbconvert/exporters/markdown.py
+++ b/nbconvert/exporters/markdown.py
@@ -49,5 +49,8 @@ class MarkdownExporter(TemplateExporter):
                 "HighlightMagicsPreprocessor": {"enabled": True},
             }
         )
-        c.merge(super().default_config)
+        if super().default_config:
+            c2 = super().default_config.copy()
+            c2.merge(c)
+            c = c2
         return c

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -33,5 +33,8 @@ class RSTExporter(TemplateExporter):
                 "HighlightMagicsPreprocessor": {"enabled": True},
             }
         )
-        c.merge(super().default_config)
+        if super().default_config:
+            c2 = super().default_config.copy()
+            c2.merge(c)
+            c = c2
         return c

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -183,7 +183,10 @@ class TemplateExporter(Exporter):
                 "TagRemovePreprocessor": {"enabled": True},
             }
         )
-        c.merge(super().default_config)
+        if super().default_config:
+            c2 = super().default_config.copy()
+            c2.merge(c)
+            c = c2
         return c
 
     template_name = Unicode(help="Name of the template to use").tag(

--- a/nbconvert/exporters/tests/test_exporter.py
+++ b/nbconvert/exporters/tests/test_exporter.py
@@ -45,9 +45,7 @@ class DummyExporter(TemplateExporter):
 
     @property
     def default_config(self):
-        c = Config(
-            {"TagRemovePreprocessor": {"enabled": False}}
-        )
+        c = Config({"TagRemovePreprocessor": {"enabled": False}})
         if super().default_config:
             c2 = super().default_config.copy()
             c2.merge(c)
@@ -113,4 +111,3 @@ class TestExporter(ExportersTestsBase):
         e = DummyExporter()
         self.assertFalse(e.default_config["TagRemovePreprocessor"]["enabled"])
         self.assertTrue(e.default_config["RegexRemovePreprocessor"]["enabled"])
-


### PR DESCRIPTION
Re #1980, changes `Config` merging so that `child` configuration overwrites `parent` configuration as opposed to the other way around.

Closes #1980 