### PR TITLE
exclude bleach 5.0.0 from dependencies resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ urls = {Homepage = "https://jupyter.org"}
 requires-python = ">=3.7"
 dependencies = [
     "beautifulsoup4",
-    "bleach",
+    "bleach!=5.0.0",
     "defusedxml",
     "importlib_metadata>=3.6;python_version<\"3.10\"",
     "jinja2>=3.0",


### PR DESCRIPTION
bleach 5.0.0 introduces a typo in tinycss dependency (missing comma), which breaks some dependency analysis tools https://github.com/mozilla/bleach/commit/cb6dca73d0d15f8c26acb28e7cc53482526bbe1b#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R35

The issue was fixed in bleach 5.0.1 https://github.com/mozilla/bleach/blob/13d6c0c91d2b1bef52ad2b5a2812f76dda18298f/CHANGES#L128

Possibly relevant https://github.com/jupyter/nbconvert/issues/1941