### PR TITLE
bump pandoc max version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install xvfb x11-utils libxkbcommon-x11-0  libxcb-xinerama0 python3-pyqt5
 
           # pandoc is not up to date in the ubuntu repos, so we install directly
-          wget https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb && sudo dpkg -i pandoc-2.14.2-1-amd64.deb
+          wget https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-1-amd64.deb && sudo dpkg -i pandoc-3.1.2-1-amd64.deb
 
       - name: Run tests on Linux
         if: ${{ startsWith(runner.os, 'linux') }}
@@ -110,10 +110,18 @@ jobs:
         with:
           dependency_type: minimum
           only_create_file: 1
-      - name: Run the unit tests
+      - name: Install dependencies
         run: |
-          export NBFORMAT_VALIDATOR=jsonschema
-          hatch run test:nowarn || hatch run test:nowarn --lf
+          sudo apt-get update
+          sudo apt-get install texlive-plain-generic inkscape texlive-xetex latexmk
+          sudo apt-get install xvfb x11-utils libxkbcommon-x11-0  libxcb-xinerama0 python3-pyqt5
+
+          # pandoc is not up to date in the ubuntu repos, so we install directly
+          wget https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb && sudo dpkg -i pandoc-2.14.2-1-amd64.deb
+
+      - name: Run tests
+        run: |
+          xvfb-run --auto-servernum hatch run test:nowarn || xvfb-run --auto-servernum hatch run test:nowarn --lf
 
   test_prereleases:
     name: Test Prereleases

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install xvfb x11-utils libxkbcommon-x11-0  libxcb-xinerama0 python3-pyqt5
 
           # pandoc is not up to date in the ubuntu repos, so we install directly
-          wget https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-1-amd64.deb && sudo dpkg -i pandoc-3.1.2-1-amd64.deb
+          wget https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb && sudo dpkg -i pandoc-3.1.2-1-amd64.deb
 
       - name: Run tests on Linux
         if: ${{ startsWith(runner.os, 'linux') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install xvfb x11-utils libxkbcommon-x11-0  libxcb-xinerama0 python3-pyqt5
 
           # pandoc is not up to date in the ubuntu repos, so we install directly
-          wget https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb && sudo dpkg -i pandoc-3.1.2-1-amd64.deb
+          wget https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb && sudo dpkg -i pandoc-2.14.2-1-amd64.deb
 
       - name: Run tests on Linux
         if: ${{ startsWith(runner.os, 'linux') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install xvfb x11-utils libxkbcommon-x11-0  libxcb-xinerama0 python3-pyqt5
 
           # pandoc is not up to date in the ubuntu repos, so we install directly
-          wget https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb && sudo dpkg -i pandoc-2.14.2-1-amd64.deb
+          wget https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-1-amd64.deb && sudo dpkg -i pandoc-3.1.2-1-amd64.deb
 
       - name: Run tests on Linux
         if: ${{ startsWith(runner.os, 'linux') }}

--- a/nbconvert/utils/pandoc.py
+++ b/nbconvert/utils/pandoc.py
@@ -14,7 +14,7 @@ from nbconvert.utils.version import check_version
 from .exceptions import ConversionException
 
 _minimal_version = "1.12.1"
-_maximal_version = "3.0.0"
+_maximal_version = "4.0.0"
 
 
 def pandoc(source, fmt, to, extra_args=None, encoding="utf-8"):

--- a/nbconvert/utils/pandoc.py
+++ b/nbconvert/utils/pandoc.py
@@ -13,7 +13,7 @@ from nbconvert.utils.version import check_version
 
 from .exceptions import ConversionException
 
-_minimal_version = "1.12.1"
+_minimal_version = "2.14.2"
 _maximal_version = "4.0.0"
 
 

--- a/share/templates/latex/base.tex.j2
+++ b/share/templates/latex/base.tex.j2
@@ -89,6 +89,7 @@ override this.-=))
     \usepackage[inline]{enumitem} % IRkernel/repr support (it uses the enumerate* environment)
     \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
                                 % normalem makes italics be italics, not underlines
+    \usepackage{soul}      % strikethrough (\st) support for pandoc >= 3.0.0
     \usepackage{mathrsfs}
     ((* endblock packages *))
 


### PR DESCRIPTION
Closes #1996.

Changes:
- `soul` package is added to the template ([relevant](https://github.com/jgm/pandoc/issues/8411))
  - There is an additional change relevant to this [here](https://github.com/jgm/pandoc/issues/8707) made for `lualatex`, but it seems to cause additional issues. I am not sure what is the best way forward. Given that `lualatex` is not the default engine, I opted to not include said change.

The tests are passing and skimming through the [release notes](https://pandoc.org/releases.html#pandoc-3.0-2023-01-18) I didn't see anything concerning (though I am not the expert).