### PR TITLE
Ensure TEXINPUTS is an absolute path

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -186,7 +186,7 @@ class PDFExporter(LatexExporter):
         latex, resources = super().from_notebook_node(nb, resources=resources, **kw)
         # set texinputs directory, so that local files will be found
         if resources and resources.get("metadata", {}).get("path"):
-            self.texinputs = resources["metadata"]["path"]
+            self.texinputs = os.path.abspath(resources["metadata"]["path"])
         else:
             self.texinputs = os.getcwd()
 

--- a/nbconvert/exporters/tests/test_pdf.py
+++ b/nbconvert/exporters/tests/test_pdf.py
@@ -8,6 +8,7 @@ import shutil
 from tempfile import TemporaryDirectory
 
 from ...tests.utils import onlyif_cmds_exist
+from ...utils import _contextlib_chdir
 from ..pdf import PDFExporter
 from .base import ExportersTestsBase
 
@@ -39,3 +40,24 @@ class TestPDF(ExportersTestsBase):
             assert len(output) > 0
             # all temporary file should be cleaned up
             assert {file_name} == set(os.listdir(td))
+
+    @onlyif_cmds_exist("xelatex", "pandoc")
+    def test_texinputs(self):
+        """
+        Is TEXINPUTS set properly when we are converting
+        - in the same directory, and
+        - in a different directory?
+        """
+        with TemporaryDirectory() as td, _contextlib_chdir.chdir(td):
+            os.mkdir("folder")
+            file_name = os.path.basename(self._get_notebook())
+            nb1 = os.path.join(td, file_name)
+            nb2 = os.path.join(td, "folder", file_name)
+            ex1 = self.exporter_class(latex_count=1)  # type:ignore
+            ex2 = self.exporter_class(latex_count=1)  # type:ignore
+            shutil.copy(self._get_notebook(), nb1)
+            shutil.copy(self._get_notebook(), nb2)
+            _ = ex1.from_filename(nb1)
+            _ = ex2.from_filename(nb2)
+            assert ex1.texinputs == os.path.abspath(".")
+            assert ex2.texinputs == os.path.abspath("./folder")


### PR DESCRIPTION
Fixes #2001. At the time of `self.texinputs` being set, we are still in the directory where `nbconvert` is called, so this fix should resolve correctly.

~To-do: Add tests~