### PR TITLE
Fix pdf conversion with explicitly relative paths

### DIFF
--- a/nbconvert/filters/pandoc.py
+++ b/nbconvert/filters/pandoc.py
@@ -1,4 +1,12 @@
-"""Convert between any two formats using pandoc."""
+"""
+Convert between any two formats using pandoc,
+and related filters
+"""
+import os
+
+from pandocfilters import Image, applyJSONFilters  # type:ignore
+
+from nbconvert.utils.base import NbConvertBase
 from nbconvert.utils.pandoc import pandoc
 
 
@@ -23,3 +31,43 @@ def convert_pandoc(source, from_format, to_format, extra_args=None):
         Output as returned by pandoc.
     """
     return pandoc(source, from_format, to_format, extra_args=extra_args)
+
+
+# When converting to pdf, explicitly relative references
+# like "./" and "../" doesn't work with TEXINPUTS.
+# So we need to convert them to absolute paths.
+# See https://github.com/jupyter/nbconvert/issues/1998
+class ConvertExplicitlyRelativePaths(NbConvertBase):
+    def __init__(self, texinputs=None, **kwargs):
+        # texinputs should be the directory of the notebook file
+        self.nb_dir = os.path.abspath(texinputs) if texinputs else ""
+        self.ancestor_dirs = self.nb_dir.split("/")
+        super().__init__(**kwargs)
+
+    def __call__(self, source):
+        # If this is not set for some reason, we can't do anything,
+        if self.nb_dir:
+            return applyJSONFilters([self.action], source)
+        return source
+
+    def action(self, key, value, frmt, meta):
+        # Convert explicitly relative paths:
+        # ./path -> path  (This should be visible to the latex engine since TEXINPUTS already has .)
+        # ../path -> /abs_path
+        # assuming all relative references are at the start of a given path
+        if key == "Image":
+            # Image seems to have this composition, according to https://github.com/jgm/pandoc-types
+            attr, caption, [filename, typedef] = value
+
+            if filename[:2] == "./":
+                filename = filename[2:]
+            elif filename[:3] == "../":
+                n_up = 0
+                while filename[:3] == "../":
+                    n_up += 1
+                    filename = filename[3:]
+                ancestors = "/".join(self.ancestor_dirs[:-n_up]) + "/"
+                filename = ancestors + filename
+            return Image(attr, caption, [filename, typedef])
+        # If not image, return "no change"
+        return None

--- a/nbconvert/filters/pandoc.py
+++ b/nbconvert/filters/pandoc.py
@@ -39,6 +39,7 @@ def convert_pandoc(source, from_format, to_format, extra_args=None):
 # See https://github.com/jupyter/nbconvert/issues/1998
 class ConvertExplicitlyRelativePaths(NbConvertBase):
     """A converter that handles relative path references."""
+
     def __init__(self, texinputs=None, **kwargs):
         """Initialize the converter."""
         # texinputs should be the directory of the notebook file

--- a/nbconvert/filters/pandoc.py
+++ b/nbconvert/filters/pandoc.py
@@ -39,18 +39,21 @@ def convert_pandoc(source, from_format, to_format, extra_args=None):
 # See https://github.com/jupyter/nbconvert/issues/1998
 class ConvertExplicitlyRelativePaths(NbConvertBase):
     def __init__(self, texinputs=None, **kwargs):
+        """Initialize the converter."""
         # texinputs should be the directory of the notebook file
         self.nb_dir = os.path.abspath(texinputs) if texinputs else ""
         self.ancestor_dirs = self.nb_dir.split("/")
         super().__init__(**kwargs)
 
     def __call__(self, source):
+        """Invoke the converter."""
         # If this is not set for some reason, we can't do anything,
         if self.nb_dir:
             return applyJSONFilters([self.action], source)
         return source
 
     def action(self, key, value, frmt, meta):
+        """Perform the action."""
         # Convert explicitly relative paths:
         # ./path -> path  (This should be visible to the latex engine since TEXINPUTS already has .)
         # ../path -> /abs_path

--- a/nbconvert/filters/pandoc.py
+++ b/nbconvert/filters/pandoc.py
@@ -38,6 +38,7 @@ def convert_pandoc(source, from_format, to_format, extra_args=None):
 # So we need to convert them to absolute paths.
 # See https://github.com/jupyter/nbconvert/issues/1998
 class ConvertExplicitlyRelativePaths(NbConvertBase):
+    """A converter that handles relative path references."""
     def __init__(self, texinputs=None, **kwargs):
         """Initialize the converter."""
         # texinputs should be the directory of the notebook file

--- a/nbconvert/filters/tests/test_pandoc.py
+++ b/nbconvert/filters/tests/test_pandoc.py
@@ -1,0 +1,59 @@
+"""
+Module with tests for Pandoc filters
+"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+
+from ...tests.base import TestsBase
+from ...tests.utils import onlyif_cmds_exist
+from ..pandoc import ConvertExplicitlyRelativePaths, convert_pandoc
+
+
+class TestPandocFilters(TestsBase):
+    @onlyif_cmds_exist("pandoc")
+    def test_convert_explicitly_relative_paths(self):
+        """
+        Do the image links in a markdown file located in dir get processed correctly?
+        """
+        inp_dir = "/home/user/src"
+        fltr = ConvertExplicitlyRelativePaths(texinputs=inp_dir)
+
+        # pairs of input, expected
+        tests = {
+            # TEXINPUTS is enough, abs_path not needed
+            "im.png": "im.png",
+            "./im.png": "im.png",
+            "./images/im.png": "images/im.png",
+            # TEXINPUTS is not enough, abs_path needed
+            "../im.png": "/home/user/im.png",
+            "../images/im.png": "/home/user/images/im.png",
+            "../../images/im.png": "/home/images/im.png",
+        }
+
+        # this shouldn't be modified by the filter
+        # since it is a code block inside markdown,
+        # not an image link itself
+        fake = """
+        ```
+        \\includegraphics{../fake.png}
+        ```
+        """
+
+        # convert to markdown image
+        def foo(filename):
+            return f"![]({filename})"
+
+        # create input markdown and convert to pandoc json
+        inp = convert_pandoc(fake + "\n".join(map(foo, tests.keys())), "markdown", "json")
+        expected = convert_pandoc(fake + "\n".join(map(foo, tests.values())), "markdown", "json")
+        # Do this to fix string formatting
+        expected = json.dumps(json.loads(expected))
+        self.assertEqual(expected, fltr(inp))
+
+    def test_convert_explicitly_relative_paths_no_texinputs(self):
+        # no texinputs should lead to just returning
+        fltr = ConvertExplicitlyRelativePaths(texinputs="")
+        self.assertEqual("test", fltr("test"))

--- a/share/templates/latex/document_contents.tex.j2
+++ b/share/templates/latex/document_contents.tex.j2
@@ -65,7 +65,7 @@
 
 % Render markdown
 ((* block markdowncell scoped *))
-    ((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown+tex_math_double_backslash', 'json',extra_args=[]) | resolve_references | convert_pandoc('json','latex'))))
+    ((( cell.source | citation2latex | strip_files_prefix | convert_pandoc('markdown+tex_math_double_backslash', 'json',extra_args=[]) | resolve_references | convert_explicitly_relative_paths | convert_pandoc('json','latex'))))
 ((* endblock markdowncell *))
 
 % Don't display unknown types


### PR DESCRIPTION
Contains #2002, fixes #1998. ~Also related #1674 and #1938.~

LaTeX engines use `kpathsea` for their path searching needs. When converting a notebook to pdf, the latex to pdf step happens in a temporary directory, with `TEXINPUTS` pointing to the original directory.

The problem is that `kpathsea` ignores `TEXINPUTS` for explicitly relative paths (like `./image.jpg` or `../image.jpg`). 

This PR adds a new filter used in `LatexExporter` to convert such paths:
- `./path` -> `path`, this will be visible through `TEXINPUTS`
- `../path` -> `/absolute_path`, because I think this is simpler and better other alternatives I can think of.

## Some notes
- Even though this is only relevant to conversion to PDF, right now the filter is actually used in `LatexExporter` because the filter needs to be added to the template as well. This means that the outputs of latex conversion might be slightly different as well (if they contain such paths), but I think this is harmless.
  - An alternative solution that would avoid this could be applying the filter logic to the latex file in `PDFExporter` manually. But this would in my opinion be weird to do when filters exist, and would make applying the same idea to webpdf's more difficult.
- ~The paths to change are detected by matching a configurable regex of a latex command (by default `\includegraphics`). This aims to prevent accidentally modifying other paths in the file that won't break the conversion process. However, this is not completely perfect, i.e. the markdown cell might contain a code block with `\includegraphics{./path}`~
  - ~Could this be fixed if the filter is implemented to modify the Pandoc AST instead of the latex file?~
  - Converted to filter on Pandoc AST, not an issue anymore

## To-dos
- [ ? ] Make this work on Windows as well: 
  - Do absolute paths on Windows require adding "C:\\" or something like that (for markdown/latex)? I can't test it myself, but the CI tests are passing.
- [x] Tests for filter
- ~[ ] Use it to fix webpdf as well?~ (The underlying idea would fix webpdf conversion as well, but using this filter would require using `pandoc` for markdown to html conversion.)