### PR TITLE
Update to Jupyterlab 4

### DIFF
--- a/docs/api_examples/template_path/project_templates/nbconvert/templates/classic_clone/static/style.css
+++ b/docs/api_examples/template_path/project_templates/nbconvert/templates/classic_clone/static/style.css
@@ -10570,14 +10570,14 @@ ul#new-menu {
   }
 }
 @media print {
-  #texteditor-backdrop #texteditor-container .cm-gutter,
-  #texteditor-backdrop #texteditor-container .cm-gutters {
+  #texteditor-backdrop #texteditor-container .CodeMirror-gutter,
+  #texteditor-backdrop #texteditor-container .CodeMirror-gutters {
     background-color: #fff;
   }
 }
 @media not print {
-  #texteditor-backdrop #texteditor-container .cm-gutter,
-  #texteditor-backdrop #texteditor-container .cm-gutters {
+  #texteditor-backdrop #texteditor-container .CodeMirror-gutter,
+  #texteditor-backdrop #texteditor-container .CodeMirror-gutters {
     background-color: #fff;
   }
 }
@@ -10589,7 +10589,7 @@ ul#new-menu {
     box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
   }
 }
-.cm-dialog {
+.CodeMirror-dialog {
   background-color: #fff;
 }
 /*!
@@ -11025,11 +11025,11 @@ div.input_area > div.highlight > pre {
  * respect to the rest of the text.  The user should select a better font.
  * See: https://github.com/ipython/ipython/issues/1503
  *
- * .cm-editor span {
+ * .CodeMirror span {
  *      vertical-align: bottom;
  * }
  */
-.cm-editor {
+.CodeMirror {
   line-height: 1.21429em;
   /* Changed from 1em to our global default */
   font-size: 14px;
@@ -11038,43 +11038,43 @@ div.input_area > div.highlight > pre {
   background: none;
   /* Changed from white to allow our bg to show through */
 }
-.cm-scroller {
+.CodeMirror-scroll {
   /*  The CodeMirror docs are a bit fuzzy on if overflow-y should be hidden or visible.*/
   /*  We have found that if it is visible, vertical scrollbars appear with font size changes.*/
   overflow-y: hidden;
   overflow-x: auto;
 }
-.cm-line {
+.CodeMirror-lines {
   /* In CM2, this used to be 0.4em, but in CM3 it went to 4px. We need the em value because */
   /* we have set a different line-height and want this to scale with that. */
   /* Note that this should set vertical padding only, since CodeMirror assumes
-       that horizontal padding will be set on cm-editor pre */
+       that horizontal padding will be set on CodeMirror pre */
   padding: 0.4em 0;
 }
-.cm-lineNumbers {
+.CodeMirror-linenumber {
   padding: 0 8px 0 4px;
 }
-.cm-gutters {
+.CodeMirror-gutters {
   border-bottom-left-radius: 2px;
   border-top-left-radius: 2px;
 }
-.cm-editor pre {
+.CodeMirror pre {
   /* In CM3 this went to 4px from 0 in CM2. This sets horizontal padding only,
-    use .cm-cursor for vertical */
+    use .CodeMirror-lines for vertical */
   padding: 0 0.4em;
   border: 0;
   border-radius: 0;
 }
-.cm-cursor {
+.CodeMirror-cursor {
   border-left: 1.4px solid black;
 }
 @media screen and (min-width: 2138px) and (max-width: 4319px) {
-  .cm-cursor {
+  .CodeMirror-cursor {
     border-left: 2px solid black;
   }
 }
 @media screen and (min-width: 4320px) {
-  .cm-cursor {
+  .CodeMirror-cursor {
     border-left: 4px solid black;
   }
 }

--- a/docs/api_examples/template_path/project_templates/nbconvert/templates/classic_clone/static/style.css
+++ b/docs/api_examples/template_path/project_templates/nbconvert/templates/classic_clone/static/style.css
@@ -10570,14 +10570,14 @@ ul#new-menu {
   }
 }
 @media print {
-  #texteditor-backdrop #texteditor-container .CodeMirror-gutter,
-  #texteditor-backdrop #texteditor-container .CodeMirror-gutters {
+  #texteditor-backdrop #texteditor-container .cm-gutter,
+  #texteditor-backdrop #texteditor-container .cm-gutters {
     background-color: #fff;
   }
 }
 @media not print {
-  #texteditor-backdrop #texteditor-container .CodeMirror-gutter,
-  #texteditor-backdrop #texteditor-container .CodeMirror-gutters {
+  #texteditor-backdrop #texteditor-container .cm-gutter,
+  #texteditor-backdrop #texteditor-container .cm-gutters {
     background-color: #fff;
   }
 }
@@ -10589,7 +10589,7 @@ ul#new-menu {
     box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
   }
 }
-.CodeMirror-dialog {
+.cm-dialog {
   background-color: #fff;
 }
 /*!
@@ -11025,11 +11025,11 @@ div.input_area > div.highlight > pre {
  * respect to the rest of the text.  The user should select a better font.
  * See: https://github.com/ipython/ipython/issues/1503
  *
- * .CodeMirror span {
+ * .cm-editor span {
  *      vertical-align: bottom;
  * }
  */
-.CodeMirror {
+.cm-editor {
   line-height: 1.21429em;
   /* Changed from 1em to our global default */
   font-size: 14px;
@@ -11038,43 +11038,43 @@ div.input_area > div.highlight > pre {
   background: none;
   /* Changed from white to allow our bg to show through */
 }
-.CodeMirror-scroll {
+.cm-scroller {
   /*  The CodeMirror docs are a bit fuzzy on if overflow-y should be hidden or visible.*/
   /*  We have found that if it is visible, vertical scrollbars appear with font size changes.*/
   overflow-y: hidden;
   overflow-x: auto;
 }
-.CodeMirror-lines {
+.cm-line {
   /* In CM2, this used to be 0.4em, but in CM3 it went to 4px. We need the em value because */
   /* we have set a different line-height and want this to scale with that. */
   /* Note that this should set vertical padding only, since CodeMirror assumes
-       that horizontal padding will be set on CodeMirror pre */
+       that horizontal padding will be set on cm-editor pre */
   padding: 0.4em 0;
 }
-.CodeMirror-linenumber {
+.cm-lineNumbers {
   padding: 0 8px 0 4px;
 }
-.CodeMirror-gutters {
+.cm-gutters {
   border-bottom-left-radius: 2px;
   border-top-left-radius: 2px;
 }
-.CodeMirror pre {
+.cm-editor pre {
   /* In CM3 this went to 4px from 0 in CM2. This sets horizontal padding only,
-    use .CodeMirror-lines for vertical */
+    use .cm-cursor for vertical */
   padding: 0 0.4em;
   border: 0;
   border-radius: 0;
 }
-.CodeMirror-cursor {
+.cm-cursor {
   border-left: 1.4px solid black;
 }
 @media screen and (min-width: 2138px) and (max-width: 4319px) {
-  .CodeMirror-cursor {
+  .cm-cursor {
     border-left: 2px solid black;
   }
 }
 @media screen and (min-width: 4320px) {
-  .CodeMirror-cursor {
+  .cm-cursor {
     border-left: 4px solid black;
   }
 }

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -8,18 +8,18 @@ from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 notebook_css_version = "5.4.0"
 notebook_css_url = "https://cdn.jupyter.org/notebook/%s/style/style.min.css" % notebook_css_version
 
-jupyterlab_css_version = "3.6.1"
+jupyterlab_css_version = "4.0.2"
 jupyterlab_css_url = (
     "https://unpkg.com/@jupyterlab/nbconvert-css@%s/style/index.css" % jupyterlab_css_version
 )
 
-jupyterlab_theme_light_version = "3.6.1"
+jupyterlab_theme_light_version = "4.0.2"
 jupyterlab_theme_light_url = (
     "https://unpkg.com/@jupyterlab/theme-light-extension@%s/style/variables.css"
     % jupyterlab_theme_light_version
 )
 
-jupyterlab_theme_dark_version = "3.6.1"
+jupyterlab_theme_dark_version = "4.0.2"
 jupyterlab_theme_dark_url = (
     "https://unpkg.com/@jupyterlab/theme-dark-extension@%s/style/variables.css"
     % jupyterlab_theme_dark_version

--- a/share/templates/lab/base.html.j2
+++ b/share/templates/lab/base.html.j2
@@ -26,7 +26,7 @@
 
 {% block input %}
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
+     <div class="cm-editor cm-s-jupyter">
 {{ cell.source | highlight_code(metadata=cell.metadata) | clean_html }}
      </div>
 </div>

--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -63,8 +63,8 @@ a.anchor-link {
   overflow: hidden;
 }
 
-.CodeMirror.cm-s-jupyter .highlight pre {
-/* weird, but --jp-code-padding defined to be 5px but 4px horizontal padding is hardcoded for pre.CodeMirror-line */
+.cm-editor.cm-s-jupyter .highlight pre {
+/* weird, but --jp-code-padding defined to be 5px but 4px horizontal padding is hardcoded for pre.cm-line */
   padding: var(--jp-code-padding) 4px;
   margin: 0;
 

--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -85,44 +85,6 @@ a.anchor-link {
   font-size: var(--jp-code-font-size);
 }
 
-/* Using table instead of flexbox so that we can use break-inside property */
-/* CSS rules under this comment should not be required anymore after we move to the JupyterLab 4.0 CSS */
-
-
-.jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-prompt {
-  min-width: calc(
-    var(--jp-cell-prompt-width) - var(--jp-private-cell-scrolling-output-offset)
-  );
-}
-
-.jp-OutputArea-child {
-  display: table;
-  width: 100%;
-}
-
-.jp-OutputPrompt {
-  display: table-cell;
-  vertical-align: top;
-  min-width: var(--jp-cell-prompt-width);
-}
-
-body[data-format='mobile'] .jp-OutputPrompt {
-  display: table-row;
-}
-
-.jp-OutputArea-output {
-  display: table-cell;
-  width: 100%;
-}
-
-body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
-  display: table-row;
-}
-
-.jp-OutputArea-output.jp-OutputArea-executeResult {
-  width: 100%;
-}
-
 /* Hiding the collapser by default */
 .jp-Collapser {
   display: none;
@@ -136,10 +98,6 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
   .jp-Cell-inputWrapper,
   .jp-Cell-outputWrapper {
     display: block;
-  }
-
-  .jp-OutputArea-child {
-    break-inside: avoid-page;
   }
 }
 </style>


### PR DESCRIPTION
This PR uses the Jupyterlab 4 CSS assets.

It has been successfully tested for conversion to HTML, PDF or webPDF.

