### PR TITLE
Restore 'media=print' option

### DIFF
--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -103,6 +103,7 @@ class WebPDFExporter(HTMLExporter):
                 raise RuntimeError(msg) from e
 
             page = await browser.new_page()
+            await page.emulate_media(media="print")
             await page.goto(f"file://{temp_file.name}", wait_until="networkidle")
 
             pdf_params = {"print_background": True}


### PR DESCRIPTION
Follow up the playwright adoption to restore a option that has been removed.

Ref: https://github.com/jupyter/nbconvert/pull/2013#discussion_r1265239380