### PR TITLE
Restore pauses during webpdf render

### DIFF
--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -104,7 +104,9 @@ class WebPDFExporter(HTMLExporter):
 
             page = await browser.new_page()
             await page.emulate_media(media="print")
+            await page.wait_for_timeout(100)
             await page.goto(f"file://{temp_file.name}", wait_until="networkidle")
+            await page.wait_for_timeout(100)
 
             pdf_params = {"print_background": True}
             if not self.paginate:


### PR DESCRIPTION
nbconvert recently adopted playwright for webpdf output. This pull request restores two 100ms timeouts that existed previously but were omitted from the new rendering chain.

Without the timeouts webpdf output can include a gray "Loading [MathJax]/jax/output/CommonHTML/fonts/TeX/fontdata.js" boxed message in the footer and MathJax has not processed the page.

A simple example can be created as follows:

    echo "# Hello" | jupytext --from md --to ipynb --set-kernel python3 | jupyter nbconvert --stdin --to webpdf --output test

Viewing the resulting `test.pdf` will have the grey box in the footer with the loading mathjax message. Generating `html` version using the same command and viewing the html in a browser shows that the message flashes briefly before disappearing. The 100ms pause seems to have avoided that in the past.

There may be better ways to ensure MathJax and other things have completed rendering (playwright documentation discourages use of `wait_for_timeout` and it might be a good idea to make the timeout available as a command line option in case some very slow javascript needs to run), but this should at least more closely emulate the previous behavior.