### PR TITLE
env var for extra_template_basedirs

### DIFF
--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -260,7 +260,13 @@ class TemplateExporter(Exporter):
 
     @default("extra_template_basedirs")
     def _default_extra_template_basedirs(self):
-        return [os.getcwd()]
+        basedirs = [os.getcwd()]
+        env = os.environ
+        if "NBCONVERT_EXTRA_TEMPLATE_BASEDIR" in env:
+            extra_template_path = env["NBCONVERT_EXTRA_TEMPLATE_BASEDIR"]
+            if os.path.exists(extra_template_path):
+                basedirs.append(extra_template_path)
+        return basedirs
 
     # Extension that the template files use.
     template_extension = Unicode().tag(config=True, affects_environment=True)


### PR DESCRIPTION
This commit add the following three items.

- Updates the method `_default_extra_template_basedirs` in the module `templateexporter.py` to search for a new environment variable called `NBCONVERT_EXTRA_TEMPLATE_BASEDIRS`. This environment variable will be added to the basedirs list if it is found, and it exists.
- Updates the tests to ensure if the new environment variable exists then it is included in the `TemplateExporter.template_paths`.
- Adds a context manager method that modifies the `os.environ` dictionary.

Closes #2026