### PR TITLE
Fix: Prevent error from all whitespace lang string

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -299,8 +299,9 @@ class IPythonRenderer(HTMLRenderer):
                 return self.block_mermaidjs(code)
 
             try:
-                lang = info.strip().split(maxsplit=1)[0]
-                lexer = get_lexer_by_name(lang, stripall=True)
+                if info.strip().split(None, 1):
+                    lang = info.strip().split(maxsplit=1)[0]
+                    lexer = get_lexer_by_name(lang, stripall=True)
             except ClassNotFound:
                 code = f"{lang}\n{code}"
                 lang = None


### PR DESCRIPTION
Add a check to make sure lang string is not an empty list after stripping out whitespace characters. Prevents error when user has a space after code block docstring but no language name.

Fixes jupyter/nbgrader#1689