### PR TITLE
Update to mermaid 10.6.0, docs keyboard navigation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,3 +21,5 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - pandoc

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,5 +21,3 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  apt_packages:
-    - pandoc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -155,7 +155,10 @@ html_theme = "pydata_sphinx_theme"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    # prefer browser defaults over custom JS keyboard event handlers
+    "navigation_with_keys": False,
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -124,7 +124,7 @@ class HTMLExporter(TemplateExporter):
     ).tag(config=True)
 
     mermaid_js_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.5.0/mermaid.esm.min.mjs",
+        "https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.6.0/mermaid.esm.min.mjs",
         help="""
         URL to load MermaidJS from.
 

--- a/share/templates/lab/mermaidjs.html.j2
+++ b/share/templates/lab/mermaidjs.html.j2
@@ -1,5 +1,5 @@
 {%- macro mermaid_js(
-url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.5.0/mermaid.esm.min.mjs"
+url="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.6.0/mermaid.esm.min.mjs"
 ) -%}
 <script type="module">
   document.addEventListener("DOMContentLoaded", async () => {


### PR DESCRIPTION
## References

- for parity with https://github.com/jupyterlab/jupyterlab/pull/15302

## Changes

- [x] update to `mermaidjs 10.6.0` for bug fixes, new charts
- [x] add `navigation_with_keys` to `conf.py` to avoid new warning and restore browser-native navigation