### PR TITLE
Support es modules in js includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1355,6 +1355,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -304,10 +304,10 @@ class HTMLExporter(TemplateExporter):
             code = """<style type="text/css">\n%s</style>""" % data
             return markupsafe.Markup(code)
 
-        def resources_include_js(name):
-            """Get the resources include JS for a name."""
+        def resources_include_js(name, module=False):
+            """Get the resources include JS for a name. If module=True, import as ES module"""
             env = self.environment
-            code = """<script>\n%s</script>""" % (env.loader.get_source(env, name)[0])
+            code = f"""<script {'type="module"' if module else ""}>\n{env.loader.get_source(env, name)[0]}</script>"""
             return markupsafe.Markup(code)
 
         def resources_include_url(name):

--- a/tests/exporters/files/esmodule.html.j2
+++ b/tests/exporters/files/esmodule.html.j2
@@ -1,0 +1,4 @@
+{%- extends 'lab/index.html.j2' -%}
+{%- block html_head_js -%}
+{{ resources.include_js("esmodule.js", True) }}
+{%- endblock html_head_js -%}

--- a/tests/exporters/files/esmodule.js
+++ b/tests/exporters/files/esmodule.js
@@ -1,0 +1,2 @@
+const blerg = true
+export { blerg };

--- a/tests/exporters/test_templateexporter.py
+++ b/tests/exporters/test_templateexporter.py
@@ -307,6 +307,15 @@ class TestExporter(ExportersTestsBase):
         output, resources = exporter.from_notebook_node(nb)
         assert "UNIQUE" in output
 
+    def test_local_template_file_esmodule_js(self):
+        template_file = os.path.join(self._get_files_path(), "esmodule.html.j2")
+        exporter = HTMLExporter(template_file=template_file, template_name="lab")
+        nb = v4.new_notebook()
+        nb.cells.append(v4.new_code_cell("some_text"))
+        output, resources = exporter.from_notebook_node(nb)
+        print(output[:1000])
+        assert '<script type="module">\nconst blerg = true' in output
+
     def test_raw_template_attr(self):
         """
         Verify that you can assign a in memory template string by overwriting


### PR DESCRIPTION
Straightforward update, adds a second argument to `include_js` resource to add module type to script tag. Tested on a real example to confirm working, and added a simple test to ensure the right html is created (Though this test does not run in a browser). 