### PR TITLE
Add table, td, tr to allowed list of tags

### DIFF
--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -89,7 +89,7 @@ def clean_html(element):
         kwargs["css_sanitizer"] = css_sanitizer
     return bleach.clean(
         element,
-        tags=[*bleach.ALLOWED_TAGS, "div", "pre", "code", "span"],
+        tags=[*bleach.ALLOWED_TAGS, "div", "pre", "code", "span", "table", "tr", "td"],
         attributes={
             **bleach.ALLOWED_ATTRIBUTES,
             "*": ["class", "id"],


### PR DESCRIPTION
pygments emits line numbers via tables, with tr and td elements (https://pygments.org/docs/formatters/#HtmlFormatter). lxml's clean_html considers table, tr and td as safe elements, but with https://github.com/jupyter/nbconvert/pull/1854 they are now considered unsafe. So instead of displaying line numbers, the table, tr and td elements are escaped, and show up as literal HTML if trying to enable line numbers via the method introduced in https://github.com/jupyter/nbconvert/pull/1683.

This PR adds table, tr and td as safe elements so that line numbers can continue to work.

I know that there are probably plans to move away from bleach (https://github.com/jupyter/nbconvert/issues/1892), but this is a small and focused change so hopefully doesn't need to block on

Without this change:

![image](https://github.com/jupyter/nbconvert/assets/30430/7fa242b8-7e51-497f-b242-abb5d8b02dbe)

With this change:

![image](https://github.com/jupyter/nbconvert/assets/30430/8c9083ca-c283-497f-ab46-63eb7d3c04ad)
