### PR TITLE
Remove twitter links that cause linkcheck to fail

### DIFF
--- a/docs/source/nbconvert_library.ipynb
+++ b/docs/source/nbconvert_library.ipynb
@@ -488,15 +488,6 @@
    "source": [
     "@damianavila wrote the Nikola Plugin to [write blog post as Notebooks](http://damianavila.github.io/blog/posts/one-line-deployment-of-your-site-to-gh-pages.html) and is developing a js-extension to publish notebooks via one click from the web app."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<center>\n",
-    "<blockquote class=\"twitter-tweet\"><p>As <a href=\"https://twitter.com/Mbussonn\">@Mbussonn</a> requested... easieeeeer! Deploy your Nikola site with just a click in the IPython notebook! <a href=\"http://t.co/860sJunZvj\">http://t.co/860sJunZvj</a> cc <a href=\"https://twitter.com/ralsina\">@ralsina</a></p>&mdash; Damián Avila (@damian_avila) <a href=\"https://twitter.com/damian_avila/statuses/370306057828335616\">August 21, 2013</a></blockquote>\n",
-    "</center>"
-   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Twitter links now cause linkcheck to fail, and I can't access the contents of those links from my browser either (I believe they are behind a paywall / loginwall now). So just removing the links.

See https://github.com/jupyter/nbconvert/actions/runs/7244142071/job/19731995736?pr=2083 for a check_links failure