### PR TITLE
Fix broken image scaling in case a custom width or height is provided for the image

### DIFF
--- a/share/templates/latex/base.tex.j2
+++ b/share/templates/latex/base.tex.j2
@@ -18,6 +18,8 @@ override this.-=))
     % Basic figure setup, for now with no caption control since it's done
     % automatically by Pandoc (which extracts ![](path) syntax from Markdown).
     \usepackage{graphicx}
+    % Keep aspect ratio if custom image width or height is specified
+    \setkeys{Gin}{keepaspectratio}
     % Maintain compatibility with old templates. Remove in nbconvert 6.0
     \let\Oldincludegraphics\includegraphics
     % Ensure that by default, figures have no caption (until we provide a


### PR DESCRIPTION
With the current implementation, if a custom image width or height is specified 
``` markdown
![alt](./some/img.png){ width=80% }
```
the image gets distorted during pdf export.

This pull request fixes the issue. It doesn't interfere with the feature that prevents images from overflowing the page.

Before:
![grafik](https://github.com/jupyter/nbconvert/assets/32336962/070f60e8-6ce3-43fa-9c10-f0b6957d2f11)

After:
![grafik](https://github.com/jupyter/nbconvert/assets/32336962/e4687caf-ec75-432c-b34d-d2e92bd5a756)
