### PR TITLE
Allow pre-fetch of css files without attempting download

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -43,6 +43,9 @@ def _get_css_file(template_name, url, filename):
     """Get a css file and download it to the templates dir"""
     directory = osp.join(templates_dir, template_name, "static")
     dest = osp.join(directory, filename)
+    if osp.exists(dest):
+        print("Already have CSS: %s, moving on." % dest)
+        return
     if not osp.exists(directory):
         os.makedirs(directory)
     print("Downloading CSS: %s" % url)
@@ -51,11 +54,8 @@ def _get_css_file(template_name, url, filename):
     except Exception as e:
         msg = f"Failed to download css from {url}: {e}"
         print(msg, file=sys.stderr)
-        if osp.exists(dest):
-            print("Already have CSS: %s, moving on." % dest)
-        else:
-            msg = "Need CSS to proceed."
-            raise OSError(msg) from None
+        msg = "Need CSS to proceed."
+        raise OSError(msg) from None
         return
 
     with open(dest, "wb") as f:


### PR DESCRIPTION
This PR allows for pre-fetching of css files (outside of the build system) without first attempting a download (which on some non-internet connected systems may cause the installation to hang indefinitely). Specifically, it rearranges the logic in hatch_build.py, checking to see whether the destination file exists before attempting a download (if the destination exists, then the `_get_css_file` function returns). I have tested installing on internet-connected systems (i.e., the normal way), as well as on non-internet connected systems with the css files pre-fetched through Spack (as resources).

Fixes #2093