### PR TITLE
Support configureable width and height of reveal presentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1483,6 +1483,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -171,7 +171,7 @@ class SlidesExporter(HTMLExporter):
     reveal_width = Unicode(
         "",
         help="""
-        width used to determine the aspect ratio of your presentation. 
+        width used to determine the aspect ratio of your presentation.
         Use the horizontal pixels available on your inteded presentation
         equpment.
         """,
@@ -180,7 +180,7 @@ class SlidesExporter(HTMLExporter):
     reveal_height = Unicode(
         "",
         help="""
-        height used to determine the aspect ratio of your presentation. 
+        height used to determine the aspect ratio of your presentation.
         Use the horizontal pixels available on your inteded presentation
         equpment.
         """,

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -204,4 +204,6 @@ class SlidesExporter(HTMLExporter):
         resources["reveal"]["transition"] = self.reveal_transition
         resources["reveal"]["scroll"] = self.reveal_scroll
         resources["reveal"]["number"] = self.reveal_number
+        resources["reveal"]["height"] = self.reveal_height
+        resources["reveal"]["width"] = self.reveal_width
         return resources

--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -168,6 +168,24 @@ class SlidesExporter(HTMLExporter):
         """,
     ).tag(config=True)
 
+    reveal_width = Unicode(
+        "",
+        help="""
+        width used to determine the aspect ratio of your presentation. 
+        Use the horizontal pixels available on your inteded presentation
+        equpment.
+        """,
+    ).tag(config=True)
+
+    reveal_height = Unicode(
+        "",
+        help="""
+        height used to determine the aspect ratio of your presentation. 
+        Use the horizontal pixels available on your inteded presentation
+        equpment.
+        """,
+    ).tag(config=True)
+
     font_awesome_url = Unicode(
         "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css",
         help="""

--- a/share/templates/reveal/index.html.j2
+++ b/share/templates/reveal/index.html.j2
@@ -6,6 +6,8 @@
 {% set reveal_theme = resources.reveal.theme | default('white', true) %}
 {% set reveal_transition = resources.reveal.transition | default('slide', true) %}
 {% set reveal_number = resources.reveal.number | default('', true) %}
+{% set reveal_width = resources.reveal.width | default('960', true) %}
+{% set reveal_height = resources.reveal.height | default('700', true) %}
 {% set reveal_scroll = resources.reveal.scroll | default(false, true) | json_dumps %}
 
 {%- block header -%}
@@ -154,7 +156,10 @@ require(
             history: true,
             transition: "{{reveal_transition}}",
             slideNumber: "{{reveal_number}}",
-            plugins: [RevealNotes]
+            plugins: [RevealNotes],
+            width: {{reveal_width}},
+			      height: {{reveal_height}},
+
         });
 
         var update = function(event){


### PR DESCRIPTION
This is important, as reveal keeps the ratio, wasting serious monitor space if this is not configured correctly...