### PR TITLE
Add a toggle to skip the svg encoding of images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements made
 
-- Support configureable width and height of reveal presentations [#2104](https://github.com/jupyter/nbconvert/pull/2104) ([@franzhaas](https://github.com/franzhaas))
+- Support configurable width and height of reveal presentations [#2104](https://github.com/jupyter/nbconvert/pull/2104) ([@franzhaas](https://github.com/franzhaas))
 
 ### Maintenance and upkeep improvements
 
@@ -440,7 +440,7 @@
 
 ### Maintenance and upkeep improvements
 
-- Clean up license  [#1949](https://github.com/jupyter/nbconvert/pull/1949) ([@dcsaba89](https://github.com/dcsaba89))
+- Clean up license [#1949](https://github.com/jupyter/nbconvert/pull/1949) ([@dcsaba89](https://github.com/dcsaba89))
 - Add more linting [#1943](https://github.com/jupyter/nbconvert/pull/1943) ([@blink1073](https://github.com/blink1073))
 
 ### Contributors to this release
@@ -564,7 +564,7 @@
 
 ### Bugs fixed
 
-- clean_html: allow SVG tags and SVG attributes  [#1890](https://github.com/jupyter/nbconvert/pull/1890) ([@akx](https://github.com/akx))
+- clean_html: allow SVG tags and SVG attributes [#1890](https://github.com/jupyter/nbconvert/pull/1890) ([@akx](https://github.com/akx))
 
 ### Maintenance and upkeep improvements
 
@@ -1501,6 +1501,7 @@ class AttrExporter(TemplateExporter):
 raw template
 {%- endblock in_prompt -%}
     """
+
 
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -172,6 +172,13 @@ class HTMLExporter(TemplateExporter):
         ),
     ).tag(config=True)
 
+    skip_svg_encoding = Bool(
+        False,
+        help=(
+            "Whether the svg to image data attribute encoding should occur"
+        ),
+    ).tag(config=True)
+
     embed_images = Bool(
         False, help="Whether or not to embed images as base64 in markdown cells."
     ).tag(config=True)
@@ -352,4 +359,5 @@ class HTMLExporter(TemplateExporter):
         resources["html_manager_semver_range"] = self.html_manager_semver_range
         resources["should_sanitize_html"] = self.sanitize_html
         resources["language_code"] = self.language_code
+        resources["should_not_encode_svg"] = self.skip_svg_encoding
         return resources

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -174,9 +174,7 @@ class HTMLExporter(TemplateExporter):
 
     skip_svg_encoding = Bool(
         False,
-        help=(
-            "Whether the svg to image data attribute encoding should occur"
-        ),
+        help=("Whether the svg to image data attribute encoding should occur"),
     ).tag(config=True)
 
     embed_images = Bool(

--- a/share/templates/classic/base.html.j2
+++ b/share/templates/classic/base.html.j2
@@ -132,7 +132,11 @@ unknown type  {{ cell.type }}
 {%- if output.svg_filename %}
 <img src="{{ output.svg_filename | posix_path | escape_html }}">
 {%- else %}
-<img src="data:image/svg+xml;base64,{{ output.data['image/svg+xml'] | text_base64 | escape_html }}">
+    {%- if resources.should_not_encode_svg %}
+        {{ output.data['image/svg+xml'].encode("utf-8") | clean_html }}
+    {%- else %}
+        <img src="data:image/svg+xml;base64,{{ output.data['image/svg+xml'] | text_base64 | escape_html }}">
+    {%- endif %}
 {%- endif %}
 </div>
 {%- endblock data_svg %}

--- a/share/templates/lab/base.html.j2
+++ b/share/templates/lab/base.html.j2
@@ -164,7 +164,11 @@ unknown type  {{ cell.type }}
 {%- if output.svg_filename %}
 <img src="{{ output.svg_filename | posix_path | escape_html }}">
 {%- else %}
-<img src="data:image/svg+xml;base64,{{ output.data['image/svg+xml'] | text_base64 | escape_html }}">
+    {%- if resources.should_not_encode_svg %}
+        {{ output.data['image/svg+xml'].encode("utf-8") | clean_html }}
+    {%- else %}
+        <img src="data:image/svg+xml;base64,{{ output.data['image/svg+xml'] | text_base64 | escape_html }}">
+    {%- endif %}
 {%- endif %}
 </div>
 {%- endblock data_svg %}


### PR DESCRIPTION
The svg being encoded to base64 introduced in https://github.com/jupyter/nbconvert/pull/2018 is not a secure option for GitHub's use case. This pr adds an option to bypass this encoding so we can continue to use the standard svg output.