### PR TITLE
[HTMLExporter] Initialize resources before widget filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1536,6 +1536,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -257,6 +257,8 @@ class HTMLExporter(TemplateExporter):
             "highlight_code", Highlight2HTML(pygments_lexer=lexer, parent=self)
         )
 
+        resources = self._init_resources(resources)
+
         filter_data_type = WidgetsDataTypeFilter(
             notebook_metadata=self._nb_metadata, parent=self, resources=resources
         )


### PR DESCRIPTION
`WidgetsDataTypeFilter` is responsible for outputting appropriate widgets code where needed. If `resources` is passed to it, it looks inside for `path` and `name` parameters to figure out where to find metadata. The default `name` is `"Notebook"`, set in [`Exporter._init_resources`](https://github.com/jupyter/nbconvert/blob/fec19fa4d538495c3c02b85708878287463412ae/nbconvert/exporters/exporter.py#L314). However, in `HTMLExporter`, `resources` is passed to `WidgetsDataTypeFilter` [here](https://github.com/jupyter/nbconvert/blob/fec19fa4d538495c3c02b85708878287463412ae/nbconvert/exporters/html.py#L260), *before* `Exporter.init_resources` is called (indirectly [here](https://github.com/jupyter/nbconvert/blob/fec19fa4d538495c3c02b85708878287463412ae/nbconvert/exporters/html.py#L266)).

This works ok as long as the default behavior for setting `name` is not needed - so all commandline conversions work. But when used programmatically (like [here](https://github.com/yuvipanda/notebooksharing.space/blob/f37fda886b8e565a82b1bf3f4851ad89e2b00e47/nbss/app.py#L250), for notebooksharing.space), this causes widgets to not be rendered, as the `text/plain` mime type is chosen each time.

This PR explicicly calls `_init_resources` before instantiating `WidgetsDataTypeFilter`, so the defaulting behavior of `_init_resources` is exercised.