### PR TITLE
rst exporter: Re-enable coalescing streams

### DIFF
--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -29,6 +29,7 @@ class RSTExporter(TemplateExporter):
     def default_config(self):
         c = Config(
             {
+                "CoalesceStreamsPreprocessor": {"enabled": True},
                 "ExtractOutputPreprocessor": {"enabled": True},
                 "HighlightMagicsPreprocessor": {"enabled": True},
             }


### PR DESCRIPTION
This has been (I guess inadvertently) disabled in #2089.

Other exporters might be affected as well, but this has been reported for the reST exporter, see #2092.