### PR TITLE
Add eol --newline option for text content in nbconvert.writers.files

### DIFF
--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -17,7 +17,16 @@ import typing as t
 from textwrap import dedent, fill
 
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
-from traitlets import Bool, DottedObjectName, Instance, List, Type, Unicode, default, observe
+from traitlets import (
+    Bool,
+    DottedObjectName,
+    Instance,
+    List,
+    Type,
+    Unicode,
+    default,
+    observe,
+)
 from traitlets.config import Configurable, catch_config_error
 from traitlets.utils.importstring import import_item
 
@@ -60,6 +69,7 @@ nbconvert_aliases.update(
         "writer": "NbConvertApp.writer_class",
         "post": "NbConvertApp.postprocessor_class",
         "output": "NbConvertApp.output_base",
+        "newline": "NbConvertApp.newline",
         "output-dir": "FilesWriter.build_directory",
         "reveal-prefix": "SlidesExporter.reveal_url_prefix",
         "nbformat": "NotebookExporter.nbformat_version",
@@ -120,7 +130,10 @@ nbconvert_flags.update(
         ),
         "coalesce-streams": (
             {
-                "NbConvertApp": {"use_output_suffix": False, "export_format": "notebook"},
+                "NbConvertApp": {
+                    "use_output_suffix": False,
+                    "export_format": "notebook",
+                },
                 "FilesWriter": {"build_directory": ""},
                 "CoalesceStreamsPreprocessor": {"enabled": True},
             },
@@ -303,6 +316,12 @@ class NbConvertApp(JupyterApp):
         "stdoutwriter": "nbconvert.writers.stdout.StdoutWriter",
     }
     writer_factory = Type(allow_none=True)
+
+    newline = Unicode(
+        None,
+        help="""The line ending to use when writing text. See builtin:`open`""",
+        allow_none=True,
+    ).tag(config=True)
 
     @observe("writer_class")
     def _writer_class_changed(self, change):
@@ -523,7 +542,9 @@ class NbConvertApp(JupyterApp):
         if not self.writer:
             msg = "No writer object defined!"
             raise ValueError(msg)
-        return self.writer.write(output, resources, notebook_name=notebook_name)
+        return self.writer.write(
+            output, resources, notebook_name=notebook_name, newline=self.newline
+        )
 
     def postprocess_single_notebook(self, write_results):
         """Step 4: Post-process the written file
@@ -628,7 +649,13 @@ class NbConvertApp(JupyterApp):
         """
         categories = {
             category: [c for c in self._classes_inc_parents() if category in c.__name__.lower()]
-            for category in ["app", "exporter", "writer", "preprocessor", "postprocessor"]
+            for category in [
+                "app",
+                "exporter",
+                "writer",
+                "preprocessor",
+                "postprocessor",
+            ]
         }
         accounted_for = {c for category in categories.values() for c in category}
         categories["other"] = [c for c in self._classes_inc_parents() if c not in accounted_for]

--- a/nbconvert/writers/files.py
+++ b/nbconvert/writers/files.py
@@ -77,7 +77,7 @@ class FilesWriter(WriterBase):
             with open(dest, "wb") as f:
                 f.write(data)
 
-    def write(self, output, resources, notebook_name=None, **kw):
+    def write(self, output, resources, notebook_name=None, newline=None, **kw):
         """
         Consume and write Jinja output to the file system.  Output directory
         is set via the 'build_directory' variable of this instance (a
@@ -147,11 +147,25 @@ class FilesWriter(WriterBase):
         dest_path = Path(build_directory) / dest
 
         # Write conversion results.
-        self.log.info("Writing %i bytes to %s", len(output), dest_path)
+        if "\\\\" in repr(newline):
+            self.log.warning(
+                "Argument 'newline' contains escaped escape characters: %s",
+                format(repr(newline)),
+            )
+
         if isinstance(output, str):
-            with open(dest_path, "w", encoding="utf-8") as f:
+            self.log.info(
+                "Writing %i len string to %s, (repr(newline): %s)",
+                len(output),
+                dest_path,
+                repr(newline),
+            )
+            with open(dest_path, "w", encoding="utf-8", newline=newline) as f:
                 f.write(output)
+
         else:
+            # newline only applies in text mode.
+            self.log.info("Writing %i bytes to %s", len(output), dest_path)
             with open(dest_path, "wb") as f:
                 f.write(output)
 


### PR DESCRIPTION
closes #1062 

Now users can specify the newline string to be passed to [open](https://docs.python.org/3/library/functions.html#open) for string data.

This is fiddly requiring `--newline $'\r\n'` on Bash to force windows newline.

The default is to fall back onto `os.linesep` as currently used.

I didn't look closely at tests but wanted to see what the CI makes of this.