### PR TITLE
Fix markdown2asciidoc function for pandoc >= 3.0 (closes #2017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1586,6 +1586,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/filters/markdown.py
+++ b/nbconvert/filters/markdown.py
@@ -8,6 +8,10 @@ markdown within Jinja templates.
 
 import re
 
+from packaging.version import Version
+
+from nbconvert.utils.pandoc import get_pandoc_version
+
 try:
     from .markdown_mistune import markdown2html_mistune
 
@@ -66,7 +70,16 @@ def markdown2html_pandoc(source, extra_args=None):
 
 def markdown2asciidoc(source, extra_args=None):
     """Convert a markdown string to asciidoc via pandoc"""
-    extra_args = extra_args or ["--atx-headers"]
+
+    # Prior to version 3.0, pandoc supported the --atx-headers flag.
+    # For later versions, we must instead pass --markdown-headings=atx.
+    # See https://pandoc.org/releases.html#pandoc-3.0-2023-01-18
+    atx_args = ["--atx-headers"]
+    pandoc_version = get_pandoc_version()
+    if pandoc_version and Version(pandoc_version) >= Version("3.0"):
+        atx_args = ["--markdown-headings=atx"]
+
+    extra_args = extra_args or atx_args
     asciidoc = convert_pandoc(source, "markdown", "asciidoc", extra_args=extra_args)
     # workaround for https://github.com/jgm/pandoc/issues/3068
     if "__" in asciidoc:

--- a/tests/exporters/test_asciidoc.py
+++ b/tests/exporters/test_asciidoc.py
@@ -50,6 +50,10 @@ class TestASCIIDocExporter(ExportersTestsBase):
         assert re.findall(in_regex, output)
         assert re.findall(out_regex, output)
 
+        # Assert that the Markdown header from our test notebook made it into the output.
+        # This can fail when nbconvert invokes pandoc incorrectly, as in issue #2017.
+        assert "== NumPy and Matplotlib examples" in output
+
     @onlyif_cmds_exist("pandoc")
     def test_export_no_prompt(self):
         """


### PR DESCRIPTION
Pass different arguments to `pandoc` depending on whether the version is >= 3.0, to fix #2017.