### PR TITLE
Directly depend on bleach[css], instead of pulling in tinycss2.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ urls = {Homepage = "https://jupyter.org"}
 requires-python = ">=3.8"
 dependencies = [
     "beautifulsoup4",
-    "bleach!=5.0.0",
+    "bleach[css]!=5.0.0",
     "defusedxml",
     "importlib_metadata>=3.6;python_version<\"3.10\"",
     "jinja2>=3.0",
@@ -40,7 +40,6 @@ dependencies = [
     "packaging",
     "pandocfilters>=1.4.1",
     "pygments>=2.4.1",
-    "tinycss2",
     "traitlets>=5.1",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Tinycss2 is not used in our code, so it may be better that let it in bleach requirements.