### PR TITLE
Allow including `text/x-rst` outputs in rst conversion, transition away from `text/restructuredtext`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,6 +122,8 @@ jobs:
 
       - name: Run tests
         run: |
+          # Attempt to work around https://github.com/pypa/pip/issues/12781
+          PIP_CONSTRAINT= hatch env run -e test -- pip install 'pip>=24.2'
           xvfb-run --auto-servernum hatch run test:nowarn || xvfb-run --auto-servernum hatch run test:nowarn --lf
 
   test_prereleases:

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -23,7 +23,14 @@ class RSTExporter(TemplateExporter):
     def _template_name_default(self):
         return "rst"
 
-    output_mimetype = "text/restructuredtext"
+    @default("raw_mimetypes")
+    def _raw_mimetypes_default(self):
+        # Up to summer 2024, nbconvert had a mistaken output_mimetype.
+        # Listing that as an extra option here maintains compatibility for
+        # notebooks with raw cells marked as that mimetype.
+        return [self.output_mimetype, "text/restructuredtext", ""]
+
+    output_mimetype = "text/x-rst"
     export_from_notebook = "reST"
 
     def default_filters(self):

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -6,6 +6,7 @@
 from traitlets import default
 from traitlets.config import Config
 
+from ..filters import DataTypeFilter
 from .templateexporter import TemplateExporter
 
 
@@ -24,6 +25,13 @@ class RSTExporter(TemplateExporter):
 
     output_mimetype = "text/restructuredtext"
     export_from_notebook = "reST"
+
+    def default_filters(self):
+        dtf = DataTypeFilter()
+        dtf.display_data_priority = [self.output_mimetype] + dtf.display_data_priority
+        filters = dict(super().default_filters())
+        filters["filter_data_type"] = dtf
+        return filters.items()
 
     @property
     def default_config(self):

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -28,7 +28,7 @@ class RSTExporter(TemplateExporter):
 
     def default_filters(self):
         dtf = DataTypeFilter()
-        dtf.display_data_priority = [self.output_mimetype] + dtf.display_data_priority
+        dtf.display_data_priority = [self.output_mimetype, *dtf.display_data_priority]
         filters = dict(super().default_filters())
         filters["filter_data_type"] = dtf
         return filters.items()

--- a/nbconvert/exporters/rst.py
+++ b/nbconvert/exporters/rst.py
@@ -27,6 +27,7 @@ class RSTExporter(TemplateExporter):
     export_from_notebook = "reST"
 
     def default_filters(self):
+        """Override filter_data_type to use native rst outputs"""
         dtf = DataTypeFilter()
         dtf.display_data_priority = [self.output_mimetype, *dtf.display_data_priority]
         filters = dict(super().default_filters())

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -407,6 +407,7 @@ class TemplateExporter(Exporter):
         """
         nb_copy, resources = super().from_notebook_node(nb, resources, **kw)
         resources.setdefault("raw_mimetypes", self.raw_mimetypes)
+        resources.setdefault("output_mimetype", self.output_mimetype)
         resources["global_content_filter"] = {
             "include_code": not self.exclude_code_cell,
             "include_markdown": not self.exclude_markdown,

--- a/share/templates/base/display_priority.j2
+++ b/share/templates/base/display_priority.j2
@@ -38,6 +38,9 @@
         {%- elif type == 'application/vnd.jupyter.widget-view+json' -%}
             {%- block data_widget_view -%}
             {%- endblock -%}
+        {%- elif type == resources.output_mimetype -%}
+            {%- block data_native -%}
+            {%- endblock -%}
         {%- else -%}
             {%- block data_other -%}
             {%- endblock -%}

--- a/share/templates/rst/conf.json
+++ b/share/templates/rst/conf.json
@@ -1,6 +1,6 @@
 {
   "base_template": "base",
   "mimetypes": {
-    "text/restructuredtext": true
+    "text/x-rst": true
   }
 }

--- a/share/templates/rst/index.rst.j2
+++ b/share/templates/rst/index.rst.j2
@@ -44,6 +44,10 @@
 {{ output.text | indent }}
 {% endblock stream %}
 
+{% block data_native %}
+{{ output.data['text/restructuredtext'] }}
+{% endblock data_native %}
+
 {% block data_svg %}
 .. image:: {{ output.metadata.filenames['image/svg+xml'] | urlencode }}
 {% endblock data_svg %}

--- a/share/templates/rst/index.rst.j2
+++ b/share/templates/rst/index.rst.j2
@@ -45,7 +45,7 @@
 {% endblock stream %}
 
 {% block data_native %}
-{{ output.data['text/restructuredtext'] }}
+{{ output.data['text/x-rst'] }}
 {% endblock data_native %}
 
 {% block data_svg %}

--- a/tests/exporters/files/rst_output.ipynb
+++ b/tests/exporters/files/rst_output.ipynb
@@ -18,7 +18,7 @@
     "        return f'<div style=\"font-weight: bold; font-size: 16pt;\">{self.text}</div>'\n",
     "\n",
     "    def _repr_mimebundle_(self, include=None, exclude=None):\n",
-    "        return {\"text/restructuredtext\": \".. note::\\n\\n\" + indent(self.text, \"    \")}"
+    "        return {\"text/x-rst\": \".. note::\\n\\n\" + indent(self.text, \"    \")}"
    ]
   },
   {
@@ -33,9 +33,9 @@
        "<div style=\"font-weight: bold; font-size: 16pt;\">Testing testing</div>"
       ],
       "text/plain": [
-       "<__main__.Note at 0x7fe804028740>"
+       "<__main__.Note at 0x7f457c0250d0>"
       ],
-      "text/restructuredtext": [
+      "text/x-rst": [
        ".. note::\n",
        "\n",
        "    Testing testing"

--- a/tests/exporters/files/rst_output.ipynb
+++ b/tests/exporters/files/rst_output.ipynb
@@ -9,15 +9,16 @@
    "source": [
     "from textwrap import indent\n",
     "\n",
+    "\n",
     "class Note:\n",
     "    def __init__(self, text):\n",
     "        self.text = text\n",
-    "    \n",
+    "\n",
     "    def _repr_html_(self):\n",
     "        return f'<div style=\"font-weight: bold; font-size: 16pt;\">{self.text}</div>'\n",
     "\n",
     "    def _repr_mimebundle_(self, include=None, exclude=None):\n",
-    "        return {'text/restructuredtext': '.. note::\\n\\n' + indent(self.text, '    ')}"
+    "        return {\"text/restructuredtext\": \".. note::\\n\\n\" + indent(self.text, \"    \")}"
    ]
   },
   {

--- a/tests/exporters/files/rst_output.ipynb
+++ b/tests/exporters/files/rst_output.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d5202f0f-21b8-4509-a9e2-45caf1c7db7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from textwrap import indent\n",
+    "\n",
+    "class Note:\n",
+    "    def __init__(self, text):\n",
+    "        self.text = text\n",
+    "    \n",
+    "    def _repr_html_(self):\n",
+    "        return f'<div style=\"font-weight: bold; font-size: 16pt;\">{self.text}</div>'\n",
+    "\n",
+    "    def _repr_mimebundle_(self, include=None, exclude=None):\n",
+    "        return {'text/restructuredtext': '.. note::\\n\\n' + indent(self.text, '    ')}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5145b05f-3a07-4cff-8738-516a9c27cb58",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"font-weight: bold; font-size: 16pt;\">Testing testing</div>"
+      ],
+      "text/plain": [
+       "<__main__.Note at 0x7fe804028740>"
+      ],
+      "text/restructuredtext": [
+       ".. note::\n",
+       "\n",
+       "    Testing testing"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Note(\"Testing testing\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/exporters/test_rst.py
+++ b/tests/exporters/test_rst.py
@@ -71,7 +71,7 @@ class TestRSTExporter(ExportersTestsBase):
 
     def test_rst_output(self):
         """
-        Is native text/restructuredtext output included when converting
+        Is native text/x-rst output included when converting
         """
         (output, resources) = RSTExporter().from_filename(
             self._get_notebook(nb_name="rst_output.ipynb")

--- a/tests/exporters/test_rst.py
+++ b/tests/exporters/test_rst.py
@@ -77,5 +77,5 @@ class TestRSTExporter(ExportersTestsBase):
             self._get_notebook(nb_name="rst_output.ipynb")
         )
         assert len(output) > 0
-        assert ".. note::" in output
+        assert "\n.. note::" in output
         assert ".. raw:: html" not in output  # rst should shadow html output

--- a/tests/exporters/test_rst.py
+++ b/tests/exporters/test_rst.py
@@ -77,5 +77,5 @@ class TestRSTExporter(ExportersTestsBase):
             self._get_notebook(nb_name="rst_output.ipynb")
         )
         assert len(output) > 0
-        assert '.. note::' in output
-        assert '.. raw:: html' not in output  # rst should shadow html output
+        assert ".. note::" in output
+        assert ".. raw:: html" not in output  # rst should shadow html output

--- a/tests/exporters/test_rst.py
+++ b/tests/exporters/test_rst.py
@@ -68,3 +68,14 @@ class TestRSTExporter(ExportersTestsBase):
         assert ":width:" in attr_string
         assert ":height:" in attr_string
         assert "px" in attr_string
+
+    def test_rst_output(self):
+        """
+        Is native text/restructuredtext output included when converting
+        """
+        (output, resources) = RSTExporter().from_filename(
+            self._get_notebook(nb_name="rst_output.ipynb")
+        )
+        assert len(output) > 0
+        assert '.. note::' in output
+        assert '.. raw:: html' not in output  # rst should shadow html output


### PR DESCRIPTION
Outputs in a notebook can include arbitrary mimetypes. From IPython this can be done with `_repr_mimebundle_` method, for instance. Most of the export formats that nbconvert knows about have a corresponding template block for output already in that format, e.g. `data_latex` or `data_html`. However, there's no template block for rst output.

I've partially generalised this, by adding a `data_native` block to the display priority template rather than a specific `data_rst`. This is meant to hold output in the exporter's native format (its `output_mimetype`), iff there isn't already a dedicated block for that format. I admit that's not the tidiest definition, but it seemed the best way to avoid breaking anything.

The exporter class then has to customise `filter_data_type` to accept its additional mimetype. I've done this in `RSTExporter`. It could be generalised in `TemplateExporter`, but that runs more risk of surprising behaviour for subclasses, which are unlikely to have a `data_native` block in their templates.