### PR TITLE
Work around pip 24.1 bug which prevents installing pandocfilters 1.4.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,6 +122,8 @@ jobs:
 
       - name: Run tests
         run: |
+          # Attempt to work around https://github.com/pypa/pip/issues/12781
+          PIP_CONSTRAINT= hatch env run -e test -- pip install 'pip>=24.2'
           xvfb-run --auto-servernum hatch run test:nowarn || xvfb-run --auto-servernum hatch run test:nowarn --lf
 
   test_prereleases:


### PR DESCRIPTION
Originally debugged in #2167, but this fix is separate, and required for CI to pass on main.

pip 24.1 introduced a bug (https://github.com/pypa/pip/issues/12781 ) which breaks installing pandocfilters 1.4.1. pip 24.2 fixed that again.