### PR TITLE
Fix font for code elements

### DIFF
--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -68,7 +68,6 @@ a.anchor-link {
   padding: var(--jp-code-padding) 4px;
   margin: 0;
 
-  font-family: inherit;
   font-size: inherit;
   line-height: inherit;
   color: inherit;


### PR DESCRIPTION
Without this change exported html notebooks use a proportional font for the code blocks. Really not what one usually wants.