### PR TITLE
Do not display mathjax overlay

### DIFF
--- a/share/templates/base/mathjax.html.j2
+++ b/share/templates/base/mathjax.html.j2
@@ -21,6 +21,7 @@
                     processEnvironments: true
                 },
                 displayAlign: 'center',
+                messageStyle: 'none',
                 CommonHTML: {
                     linebreaks: {
                     automatic: true


### PR DESCRIPTION
There seems to be a possible race condition when using e.g. webpdf, or when generating html outputs and then attempting to screenshot them or print as pdf, due to the MathJax overlay. This means the MathJax loading overlay can sometimes be included in the final output asset (e.g. in the PDF itself). This is definitely unexpected behavior!

Here I am refreshing the html output, and you can see the MathJax loading bar. 

![tmp](https://github.com/user-attachments/assets/d3dded4c-bdf4-406c-9dea-db80e138356d)

In this PR, I disable this loading bar. I'm not sure if anyone is relying on this loading bar, and to be honest I don't see a ton of value in it, but open to changes or making it parameterized. 

