### PR TITLE
Fixed issue with INLINE_MATH_TEX regex to accept spaces within inline

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -119,7 +119,7 @@ if MISTUNE_V3:  # Parsers for Mistune >= 3.0.0
         # Display math mode, using newer LaTeX delimiter: \[ \pi \]
         BLOCK_MATH_LATEX = _dotall(r"(?<!\\)\\\\\[(?P<math_block_latex>.*?)(?<!\\)\\\\\]")
         # Inline math mode, using older TeX delimiter: $ \pi $  (cannot be empty!)
-        INLINE_MATH_TEX = _dotall(r"(?<![$\\])\$(?P<math_inline_tex>.+?)(?<![$\\])\$")
+        INLINE_MATH_TEX = _dotall(r"(?<![$\\])$(?!\s)(?P<math_inline_tex>[^$\\\s]+?)(?<!\s)(?<![$\\])$")
         # Inline math mode, using newer LaTeX delimiter: \( \pi \)
         INLINE_MATH_LATEX = _dotall(r"(?<!\\)\\\\\((?P<math_inline_latex>.*?)(?<!\\)\\\\\)")
         # LaTeX math environment: \begin{equation} \pi \end{equation}

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -119,7 +119,9 @@ if MISTUNE_V3:  # Parsers for Mistune >= 3.0.0
         # Display math mode, using newer LaTeX delimiter: \[ \pi \]
         BLOCK_MATH_LATEX = _dotall(r"(?<!\\)\\\\\[(?P<math_block_latex>.*?)(?<!\\)\\\\\]")
         # Inline math mode, using older TeX delimiter: $ \pi $  (cannot be empty!)
-        INLINE_MATH_TEX = _dotall(r"(?<![$\\])$(?!\s)(?P<math_inline_tex>[^$\\\s]+?)(?<!\s)(?<![$\\])$")
+        INLINE_MATH_TEX = _dotall(
+            r"(?<![$\\])$(?!\s)(?P<math_inline_tex>[^$\\\s]+?)(?<!\s)(?<![$\\])$"
+        )
         # Inline math mode, using newer LaTeX delimiter: \( \pi \)
         INLINE_MATH_LATEX = _dotall(r"(?<!\\)\\\\\((?P<math_inline_latex>.*?)(?<!\\)\\\\\)")
         # LaTeX math environment: \begin{equation} \pi \end{equation}


### PR DESCRIPTION
Updated the INLINE_MATH_TEX regex pattern to allow spaces within the inline math expression. Ensured proper escaping of dollar signs and backslashes. This change addresses the issue with spaces that users encounter.

This is a further fix for this issue from Jupyter Lab/Notebook since the original style may confuse the users with issues, such as in the following: https://github.com/jupyterlab/jupyterlab/issues/11062

Transformed oriignal INLINE_MATH_TEX to INLINE_MATH_TEX = _dotall(r"(?<![$\\])$(?!\s)(?P<math_inline_tex>[^$\\\s]+?)(?<!\s)(?<![$\\])$")

Feel free to decide what you think should be done, and if further testing should be done.