### PR TITLE
LaTeX and PDF export: Support SVG image files via the `svg` LaTeX package

### DIFF
--- a/nbconvert/exporters/pdf.py
+++ b/nbconvert/exporters/pdf.py
@@ -60,7 +60,7 @@ class PDFExporter(LatexExporter):
     latex_count = Integer(3, help="How many times latex will be called.").tag(config=True)
 
     latex_command = List(
-        ["xelatex", "{filename}", "-quiet"], help="Shell command used to compile latex."
+        ["xelatex", "-shell-escape", "{filename}", "-quiet"], help="Shell command used to compile latex."
     ).tag(config=True)
 
     bib_command = List(["bibtex", "{filename}"], help="Shell command used to run bibtex.").tag(

--- a/share/templates/latex/base.tex.j2
+++ b/share/templates/latex/base.tex.j2
@@ -20,8 +20,6 @@ override this.-=))
     \usepackage{graphicx}
     % Keep aspect ratio if custom image width or height is specified
     \setkeys{Gin}{keepaspectratio}
-    % Maintain compatibility with old templates. Remove in nbconvert 6.0
-    \let\Oldincludegraphics\includegraphics
     % Ensure that by default, figures have no caption (until we provide a
     % proper Figure object with a Caption API and a way to capture that
     % in the conversion process - todo).
@@ -93,6 +91,23 @@ override this.-=))
                                 % normalem makes italics be italics, not underlines
     \usepackage{soul}      % strikethrough (\st) support for pandoc >= 3.0.0
     \usepackage{mathrsfs}
+    \usepackage{svg} % enable support for rendering SVGs via Inkscape
+    \makeatletter
+    % Hook to includgraphics to pass SVGs to \includesvg
+    \let\includegraphics@original\includegraphics
+    % Hook
+    \renewcommand{\includegraphics}[2][]{%
+    \def\svgextension{svg}
+    \filename@parse{#2}%
+    \ifx\filename@ext\svgextension
+      \includesvg[#1]{#2}
+    \else
+      \includegraphics@original[#1]{#2}
+    \fi
+    }%
+    \makeatother
+    % Maintain compatibility with old templates. Remove in nbconvert 6.0
+    \let\Oldincludegraphics\includegraphics
     ((* endblock packages *))
 
     ((* block definitions *))


### PR DESCRIPTION
> [!NOTE]
> This is a draft pull request which is a WIP. Community contributions and suggestions are welcome.

# Summary
Jupyter notebooks allow inclusion of SVG images via `![Caption](image.svg)`. However, for `LaTeX` and `PDF via LaTeX` exports, unlike other image formats, SVG images does not work. This is mainly because `\includegraphics` doesn't support SVGs yet.

In this PR, a solution is provided via `\usepackage{svg}`. The fix works by hooking onto `\includegraphics` to detect SVG images from their file extension and replace the `\includegraphics` call by `\includesvg`.

# Cautionary areas
The following are the reasons why we have to be cautious before merging this PR.

- The `svg` LaTeX package utilizes Inkscape to convert SVGs to PDFs. Hence, the experience for LaTeX export may not be seamless for novice LaTeX users.
- PDF export requires `-shell-escape` options to be passed to `XeTeX`.

# Pending issues
- While `LaTeX` export works well for SVG files if the requirements of the `svg` LaTeX package are met, **the `PDF via LaTeX` export is still broken.** Community inputs are welcome here.

    - Initial look at the issue reveals that the compilation of `notebook.tex` in a temporary directory is a likely cause of the issue. It seems that the `svg` package cannot handle paths from `TEXINPUTS` well yet. Or, maybe I've not setup the package or `pdf.py` exporter file properly.
