### PR TITLE
Move the `check_release.yml` to its own workflow

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,33 @@
+name: Check Release
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+
+  check_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Check Release
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version_spec: next
+
+      - name: Upload Assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: nbconvert-releaser-dist-${{ github.run_number }}
+          path: |
+            .jupyter_releaser_checkout/dist/*.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,18 +79,6 @@ jobs:
           pipx run interrogate -v .
           pipx run doc8 --max-line-length=200  --ignore-path=docs/source/other/full-config.rst
 
-  check_release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - run: pip install -e .
-      - uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
-        with:
-          version_spec: 10.10.10
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   check_links:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
- [x] Move the `check_release` step to a separate workflow, so it's easier to see if it passes
- [x] And add an extra step to upload the artifacts built by the releaser, so it's easier to test PRs locally by installing the built wheel from a branch.
