### PR TITLE
Pull Request: Fix “AXT Heading” Typos to “ATX Heading” in Markdown …

### DIFF
--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -75,8 +75,8 @@ if MISTUNE_V3:  # Parsers for Mistune >= 3.0.0
         is ignored here.
         """
 
-        AXT_HEADING_WITHOUT_LEADING_SPACES = (
-            r"^ {0,3}(?P<axt_1>#{1,6})(?!#+)(?P<axt_2>[ \t]*(.*?)?)$"
+        ATX_HEADING_WITHOUT_LEADING_SPACES = (
+            r"^ {0,3}(?P<atx_1>#{1,6})(?!#+)(?P<atx_2>[ \t]*(.*?)?)$"
         )
 
         MULTILINE_MATH = _dotall(
@@ -92,7 +92,7 @@ if MISTUNE_V3:  # Parsers for Mistune >= 3.0.0
 
         SPECIFICATION = {
             **BlockParser.SPECIFICATION,
-            "axt_heading": AXT_HEADING_WITHOUT_LEADING_SPACES,
+            "atx_heading": ATX_HEADING_WITHOUT_LEADING_SPACES,
             "multiline_math": MULTILINE_MATH,
         }
 
@@ -196,7 +196,7 @@ else:  # Parsers for Mistune >= 2.0.0 < 3.0.0
         )
 
         # Regex for header that doesn't require space after '#'
-        AXT_HEADING = re.compile(r" {0,3}(#{1,6})(?!#+)(?: *\n+|([^\n]*?)(?:\n+|\s+?#+\s*\n+))")
+        ATX_HEADING = re.compile(r" {0,3}(#{1,6})(?!#+)(?: *\n+|([^\n]*?)(?:\n+|\s+?#+\s*\n+))")
 
         # Multiline math must be searched before other rules
         RULE_NAMES = ("multiline_math", *BlockParser.RULE_NAMES)  # type: ignore[attr-defined]


### PR DESCRIPTION
…Filters

## Overview

### What’s wrong
In the markdown filtering code for **nbconvert**, the standard Markdown headings (commonly referred to as “ATX headings”) were mistakenly spelled as **“AXT.”** This can lead to confusion and errors such as:

```
AttributeError: 'MathBlockParser' object has no attribute 'parse_axt_heading'
```

if something tries to call a method by the wrong name.

### Why it matters

- Markdown headings of the form `# Heading` are typically referred to as **ATX headings**.  
- Maintaining consistent naming is helpful for contributors and future maintainers; it also aligns with official Mistune 2.x/3.x naming conventions.

---

## Proposed Changes

### Rename All Instances of “AXT” to “ATX”

In the `MathBlockParser` for Mistune ≥ 3.0, rename:

```diff
- AXT_HEADING_WITHOUT_LEADING_SPACES
+ ATX_HEADING_WITHOUT_LEADING_SPACES
```

```diff
- "axt_heading": AXT_HEADING_WITHOUT_LEADING_SPACES
+ "atx_heading": ATX_HEADING_WITHOUT_LEADING_SPACES
```

Also, change any internal references accordingly (for example, if there were a `parse_axt_heading` method, rename it to `parse_atx_heading`).

---

### Ensure Backward Compatibility
- The change is purely a naming fix, so it should not break existing code or templates, as long as the references within **nbconvert** are updated consistently.  
- If any external plugins or code rely on the old `axt_heading` name, they might need a minor update, but that’s highly unlikely unless they were already overriding **nbconvert**’s internal parser.
```