### PR TITLE
- bump reveal.js

### DIFF
--- a/nbconvert/exporters/slides.py
+++ b/nbconvert/exporters/slides.py
@@ -128,7 +128,7 @@ class SlidesExporter(HTMLExporter):
                 stacklevel=2,
             )
             return self.config.RevealHelpPreprocessor.url_prefix
-        return "https://unpkg.com/reveal.js@4.0.2"
+        return "https://unpkg.com/reveal.js@5.2.1"
 
     reveal_theme = Unicode(
         "simple",

--- a/share/templates/reveal/index.html.j2
+++ b/share/templates/reveal/index.html.j2
@@ -2,7 +2,7 @@
 {% from 'mathjax.html.j2' import mathjax %}
 {% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
 
-{% set reveal_url_prefix = resources.reveal.url_prefix | default('https://unpkg.com/reveal.js@4.0.2', true) %}
+{% set reveal_url_prefix = resources.reveal.url_prefix | default('https://unpkg.com/reveal.js@5.2.1', true) %}
 {% set reveal_theme = resources.reveal.theme | default('white', true) %}
 {% set reveal_transition = resources.reveal.transition | default('slide', true) %}
 {% set reveal_number = resources.reveal.number | default('', true) %}


### PR DESCRIPTION
reveal.js is currently at version 4.0.2, this is quite outdated.

This is an attempt to move reveal.js to the current 5.2.x releases.

This is an initial effort, but i expect more steps to be necessary. Lets see what CI finds and carry on from there.