### PR TITLE
Fix ALLOWED_STYLES import error in sanitize.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1634,6 +1634,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/preprocessors/sanitize.py
+++ b/nbconvert/preprocessors/sanitize.py
@@ -34,13 +34,15 @@ except ImportError:
         )
 
     except ImportError:
+        ALLOWED_STYLES = []
+        _USE_BLEACH_CSS_SANITIZER = False
+        _USE_BLEACH_STYLES = False
         warnings.warn(
             "The installed bleach/tinycss2 do not provide CSS sanitization, "
             "please upgrade to bleach >=5",
             UserWarning,
             stacklevel=2,
         )
-
 
 __all__ = ["SanitizeHTML"]
 


### PR DESCRIPTION
Fixes #2209 <!-- Needed for GitHub to link the issue to the PR -->

## Fix ALLOWED_STYLES import error in sanitize.py
This patch resolves a `NameError` where `ALLOWED_STYLES` was undefined during import when bleach/tinycss2 dependencies are missing. The fix:

- Defines fallback empty `ALLOWED_STYLES` list and related flags when CSS sanitization isn&#39;t available
- Maintains backward compatibility while preventing import crashes

This handles edge cases where optional sanitization dependencies aren&#39;t present while still warning users to upgrade their bleach installation.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1Yi5jb20vaGFycnktcGF0Y2hlci80YzM2OTcxZTFhOWZmZWU2YTNkYWJmZWI0ZDhmY2YzYy9yYXcvc3dlYmVuY2hfanVweXRlcl9fbmJjb252ZXJ0LTIyMDkuanNvbg&amp;pr=aHR0cHM6Ly9naXRodWIuY29tL2p1cHl0ZXIvbmJjb252ZXJ0L3B1bGwvMjIxOQ) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=https%3A//github.com/jupyter/nbconvert/pull/2219&rb85bea8de07843f9835f9d001f689f4c=https%3A//github.com/jupyter/nbconvert&r034de175aef248b29aaf36f2a5e92912=https%3A//github.com/jupyter/nbconvert/pull/2219&r9e0cc5d7ff8b484e81eb97531d4cefd7=https%3A//github.com/jupyter/nbconvert/pull/2219) 📬.