### PR TITLE
Drop support for Python 3.8, fix the CI tests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.11"]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-22.04", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
         include:
-          - os: "windows-latest"
-            python-version: "3.9"
           - os: "macos-latest"
             python-version: "3.10"
           - os: "ubuntu-22.04"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,14 +22,14 @@ jobs:
       NBFORMAT_VALIDATOR: jsonschema
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "macos-latest", "windows-latest"]
+        os: ["ubuntu-22.04", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.12"]
         include:
           - os: "windows-latest"
             python-version: "3.9"
           - os: "macos-latest"
             python-version: "3.10"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             python-version: "3.11"
       fail-fast: false
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1634,6 +1634,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,7 +11,7 @@ Installation
 Supported Python versions
 -------------------------
 
-Currently Python 3.8-3.11 is supported and tested by nbconvert.
+Currently Python 3.9-3.12 is supported and tested by nbconvert.
 
 Installing nbconvert
 --------------------

--- a/nbconvert/_version.py
+++ b/nbconvert/_version.py
@@ -1,7 +1,6 @@
 """nbconvert version info."""
 
 import re
-from typing import List
 
 # Version string must appear intact for versioning
 __version__ = "7.16.6"
@@ -10,7 +9,7 @@ __version__ = "7.16.6"
 pattern = r"(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)"
 match = re.match(pattern, __version__)
 assert match is not None
-parts: List[object] = [int(match[part]) for part in ["major", "minor", "patch"]]
+parts: list[object] = [int(match[part]) for part in ["major", "minor", "patch"]]
 if match["rest"]:
     parts.append(match["rest"])
 version_info = tuple(parts)

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -8,14 +8,13 @@ import json
 import mimetypes
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 import jinja2
 import markupsafe
 from bs4 import BeautifulSoup
 from jupyter_core.paths import jupyter_path
-from traitlets import Bool, Unicode, default, validate
-from traitlets import Dict as TraitletsDict
+from traitlets import Bool, Dict, Unicode, default, validate
 from traitlets.config import Config
 
 if tuple(int(x) for x in jinja2.__version__.split(".")[:3]) < (3, 0, 0):
@@ -184,7 +183,7 @@ class HTMLExporter(TemplateExporter):
 
     output_mimetype = "text/html"
 
-    lexer_options = TraitletsDict(
+    lexer_options = Dict(
         {},
         help=(
             "Options to be passed to the pygments lexer for highlighting markdown code blocks. "
@@ -258,8 +257,8 @@ class HTMLExporter(TemplateExporter):
         yield ("markdown2html", self.markdown2html)
 
     def from_notebook_node(  # type:ignore[explicit-override, override]
-        self, nb: NotebookNode, resources: Optional[Dict[str, Any]] = None, **kw: Any
-    ) -> Tuple[str, Dict[str, Any]]:
+        self, nb: NotebookNode, resources: Optional[dict[str, Any]] = None, **kw: Any
+    ) -> tuple[str, dict[str, Any]]:
         """Convert from notebook node."""
         langinfo = nb.metadata.get("language_info", {})
         lexer = langinfo.get("pygments_lexer", langinfo.get("name", None))

--- a/nbconvert/exporters/qt_screenshot.py
+++ b/nbconvert/exporters/qt_screenshot.py
@@ -44,8 +44,8 @@ if QT_INSTALLED:
 
                 def cleanup(*args):
                     """Cleanup the app."""
-                    self.app.quit()  # type:ignore[union-attr]
                     self.get_data()
+                    self.app.quit()  # type:ignore[union-attr]
 
                 self.page().pdfPrintingFinished.connect(cleanup)
             elif output_file.endswith(".png"):
@@ -81,8 +81,8 @@ if QT_INSTALLED:
         def export_png(self):
             """Export to png."""
             self.grab().save(self.output_file, "PNG")
-            self.app.quit()  # type:ignore[union-attr]
             self.get_data()
+            self.app.quit()  # type:ignore[union-attr]
 
         def get_data(self):
             """Get output data."""

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -8,8 +8,10 @@ Used from markdown.py
 import base64
 import mimetypes
 import os
+from collections.abc import Iterable
 from html import escape
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterable, Match, Optional, Protocol, Tuple
+from re import Match
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Protocol
 
 import bs4
 from pygments import highlight
@@ -220,7 +222,7 @@ else:  # Parsers for Mistune >= 2.0.0 < 3.0.0
         # Multiline math must be searched before other rules
         RULE_NAMES = ("multiline_math", *BlockParser.RULE_NAMES)  # type: ignore[attr-defined]
 
-        def parse_multiline_math(self, m: Match[str], state: Any) -> Dict[str, str]:
+        def parse_multiline_math(self, m: Match[str], state: Any) -> dict[str, str]:
             """Pass token through mutiline math."""
             return {"type": "multiline_math", "text": m.group(0)}
 
@@ -253,29 +255,29 @@ else:  # Parsers for Mistune >= 2.0.0 < 3.0.0
             *InlineParser.RULE_NAMES,  # type: ignore[attr-defined]
         )
 
-        def parse_block_math_tex(self, m: Match[str], state: Any) -> Tuple[str, str]:
+        def parse_block_math_tex(self, m: Match[str], state: Any) -> tuple[str, str]:
             """Parse block text math."""
             # sometimes the Scanner keeps the final '$$', so we use the
             # full matched string and remove the math markers
             text = m.group(0)[2:-2]
             return "block_math", text
 
-        def parse_block_math_latex(self, m: Match[str], state: Any) -> Tuple[str, str]:
+        def parse_block_math_latex(self, m: Match[str], state: Any) -> tuple[str, str]:
             """Parse block latex math ."""
             text = m.group(1)
             return "block_math", text
 
-        def parse_inline_math_tex(self, m: Match[str], state: Any) -> Tuple[str, str]:
+        def parse_inline_math_tex(self, m: Match[str], state: Any) -> tuple[str, str]:
             """Parse inline tex math."""
             text = m.group(1)
             return "inline_math", text
 
-        def parse_inline_math_latex(self, m: Match[str], state: Any) -> Tuple[str, str]:
+        def parse_inline_math_latex(self, m: Match[str], state: Any) -> tuple[str, str]:
             """Parse inline latex math."""
             text = m.group(1)
             return "inline_math", text
 
-        def parse_latex_environment(self, m: Match[str], state: Any) -> Tuple[str, str, str]:
+        def parse_latex_environment(self, m: Match[str], state: Any) -> tuple[str, str, str]:
             """Parse a latex environment."""
             name, text = m.group(1), m.group(2)
             return "latex_environment", name, text
@@ -292,7 +294,7 @@ class IPythonRenderer(HTMLRenderer):
         exclude_anchor_links: bool = False,
         anchor_link_text: str = "¶",
         path: str = "",
-        attachments: Optional[Dict[str, Dict[str, str]]] = None,
+        attachments: Optional[dict[str, dict[str, str]]] = None,
         **lexer_options,
     ):
         """Initialize the renderer."""
@@ -352,7 +354,7 @@ class IPythonRenderer(HTMLRenderer):
 
         return super().inline_html(html)
 
-    def heading(self, text: str, level: int, **attrs: Dict[str, Any]) -> str:
+    def heading(self, text: str, level: int, **attrs: dict[str, Any]) -> str:
         """Handle a heading."""
         html = super().heading(text, level, **attrs)
         if self.exclude_anchor_links:

--- a/nbconvert/postprocessors/serve.py
+++ b/nbconvert/postprocessors/serve.py
@@ -80,7 +80,7 @@ class ServePostProcessor(PostProcessorBase):
             handlers.insert(0, (r"/(%s)/(.*)" % self.reveal_prefix, ProxyHandler))
 
         app = web.Application(
-            handlers,  # type:ignore[arg-type]
+            handlers,
             cdn=self.reveal_cdn,
             client=AsyncHTTPClient(),
         )

--- a/nbconvert/utils/io.py
+++ b/nbconvert/utils/io.py
@@ -9,7 +9,7 @@ import os
 import random
 import shutil
 import sys
-from typing import Any, Dict
+from typing import Any
 
 
 def unicode_std_stream(stream="stdout"):
@@ -52,7 +52,7 @@ def unicode_stdin_stream():
     return codecs.getreader("utf-8")(stream_b)
 
 
-class FormatSafeDict(Dict[Any, Any]):
+class FormatSafeDict(dict[Any, Any]):
     """Format a dictionary safely."""
 
     def __missing__(self, key):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 urls = {Homepage = "https://jupyter.org"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "beautifulsoup4",
     "bleach[css]!=5.0.0",
@@ -182,7 +182,7 @@ source = ["nbconvert"]
 
 [tool.mypy]
 files = "nbconvert"
-python_version = "3.8"
+python_version = "3.9"
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 disable_error_code = ["no-untyped-def", "no-untyped-call"]


### PR DESCRIPTION
Python 3.8 reached end of life on October 7, 2024.

https://peps.python.org/pep-0569/

It is also now below jupyterlab/maintainer-tools' minimum supported
version.

https://github.com/jupyterlab/maintainer-tools/blob/d5b08e36724fe4271b4751cc0d84c80c2e5c982c/.github/actions/base-setup/action.yml#L25-L26

Ubuntu 20.04 was disabled by GitHub April 15, 2025.

https://github.com/actions/runner-images/issues/11101

As such, this PR drops support for Python 3.8 and bumps the test runner image up to the next version of Ubuntu, 22.04. This includes some type hinting checks that the linter started complaining about in the new version.

Additionally, there was a race condition in the QtExporter that was causing my tests to sporadically fail, so this includes a fix to eliminate that race condition as well.