### PR TITLE
Replace `@flaky.flaky` decorate with pytest marker

### DIFF
--- a/tests/exporters/test_qtpng.py
+++ b/tests/exporters/test_qtpng.py
@@ -6,7 +6,6 @@
 import os
 
 import pytest
-from flaky import flaky
 
 from nbconvert.exporters.qt_screenshot import QT_INSTALLED
 from nbconvert.exporters.qtpng import QtPNGExporter
@@ -20,7 +19,7 @@ class TestQtPNGExporter(ExportersTestsBase):
 
     exporter_class = QtPNGExporter  # type:ignore
 
-    @flaky
+    @pytest.mark.flaky()
     def test_export(self):
         """
         Can a TemplateExporter export something?

--- a/tests/test_nbconvertapp.py
+++ b/tests/test_nbconvertapp.py
@@ -8,7 +8,6 @@ from tempfile import TemporaryDirectory
 
 import nbformat
 import pytest
-from flaky import flaky  # type:ignore
 from traitlets.tests.utils import check_help_all_output
 
 from nbconvert.exporters import HTMLExporter
@@ -150,7 +149,7 @@ class TestNbConvertApp(TestsBase):
             )
             assert os.path.isfile("notebook with spaces.pdf")
 
-    @flaky
+    @pytest.mark.flaky()
     @pytest.mark.network()
     @pytest.mark.skipif(not PLAYWRIGHT_INSTALLED, reason="Playwright not installed")
     def test_webpdf_with_chromium(self):


### PR DESCRIPTION
Use the `@pytest.mark.flaky` marker in place of the `@flaky.flaky` decorator, to modernize the code and improve compatibility with other plugins providing the feature such as `pytest-rerunfailures`.