### PR TITLE
Allow configureable WebPDF JavaScript processing timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1672,6 +1672,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 from importlib import util as importlib_util
 
-from traitlets import Bool, List, Unicode, default
+from traitlets import Bool, Int, List, Unicode, default
 
 from .html import HTMLExporter
 
@@ -41,6 +41,15 @@ class WebPDFExporter(HTMLExporter):
         If False, a PDF with one long page will be generated.
 
         Set to True to match behavior of LaTeX based PDF generator
+        """,
+    ).tag(config=True)
+
+    page_render_timeout = Int(
+        100,
+        help="""
+        Time to wait for the page to render before converting to PDF, in milliseconds.
+        Increase this value if your notebook has a lot of complex JavaScript
+        output that needs more time to load.
         """,
     ).tag(config=True)
 
@@ -123,7 +132,7 @@ class WebPDFExporter(HTMLExporter):
             await page.emulate_media(media="print")
             await page.wait_for_timeout(100)
             await page.goto(f"file://{temp_file.name}", wait_until="networkidle")
-            await page.wait_for_timeout(100)
+            await page.wait_for_timeout(self.page_render_timeout)
 
             pdf_params = {"print_background": True}
             if not self.paginate:


### PR DESCRIPTION
Fixes #2244 

Note that i don't think we can do something like "wait for all activity to cease" as some stuff may never cease, so putting it in the user's hands make sense. 