### PR TITLE
CI: allow Python 3.14t job to fail (QtWebEngine build issue)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ defaults:
 
 jobs:
   run-tests:
+    continue-on-error: ${{ matrix.python-version == '3.14t' }}
     runs-on: ${{ matrix.os }}
     env:
       NBFORMAT_VALIDATOR: jsonschema


### PR DESCRIPTION
The Python 3.14t (free-threaded) CI job currently fails during dependency installation because PyQtWebEngine is built from source (no compatible wheels available for 3.14t), which requires a full Qt toolchain including qmake. This toolchain is not present on GitHub-hosted runners.

This failure happens before tests run and is unrelated to the changes in this PR.

Mark the 3.14t matrix entry as continue-on-error to keep CI signal for other Python versions while unblocking merges.