### PR TITLE
avoid cov environment on free-threaded Pythons

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,20 +47,21 @@ jobs:
       - name: Run tests on Linux
         if: ${{ startsWith(runner.os, 'linux') }}
         run: |
-          if [[ "${{ matrix.python-version }}" = *t ]]; then
-            target="cov:test"
-          else
+          # cov: is not installable on free-threaded yet
+          if [[ "${{ matrix.python-version }}" == *t ]]; then
             target="test:test"
+          else
+            target="cov:test"
           fi
           xvfb-run --auto-servernum hatch run $target
 
       - name: Run tests on other platforms
         if: ${{ !startsWith(runner.os, 'linux')  }}
         run: |
-          if [[ "${{ matrix.python-version }}" = *t ]]; then
-            target="cov:nowarn"
-          else
+          if [[ "${{ matrix.python-version }}" == *t ]]; then
             target="test:nowarn"
+          else
+            target="cov:nowarn"
           fi
           hatch run $target
 


### PR DESCRIPTION
since cov pulls in a qt dependency that won't build on 3.14t

try to get CI back