### PR TITLE
Bump version to 7.16.7 in order to release CVE-2025-53000

### DIFF
--- a/nbconvert/_version.py
+++ b/nbconvert/_version.py
@@ -3,7 +3,7 @@
 import re
 
 # Version string must appear intact for versioning
-__version__ = "7.16.6"
+__version__ = "7.16.7"
 
 # Build up version_info tuple for backwards compatibility
 pattern = r"(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)"


### PR DESCRIPTION
### **Version bump**
The PR for the [CVE-2025-53000 fix](https://github.com/jupyter/nbconvert/pull/2261) did not bump the version number up.
Bumping to 7.16.7.

#### **_Request for info: test-qtpng::test_export unit test failure_**
I also noticed that the unit test for macOS-latest, python 3.14 [failed](https://github.com/jupyter/nbconvert/actions/runs/21425126098/job/61692599518) when the PR was merged: unsure if that will block a release, and curious if these tests will intermittently fail. I tried reproducing the error locally with a Python3.14 on my Mac (Sequoia 15.7.3), but had no luck.