### PR TITLE
add gif support

### DIFF
--- a/nbconvert/exporters/asciidoc.py
+++ b/nbconvert/exporters/asciidoc.py
@@ -40,6 +40,7 @@ class ASCIIDocExporter(TemplateExporter):
                         "image/svg+xml",
                         "image/png",
                         "image/jpeg",
+                        "image/gif",
                         "text/plain",
                         "text/latex",
                     ]

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -215,6 +215,7 @@ class HTMLExporter(TemplateExporter):
                         "text/latex",
                         "image/png",
                         "image/jpeg",
+                        "image/gif",
                         "text/plain",
                     ]
                 },

--- a/nbconvert/exporters/markdown.py
+++ b/nbconvert/exporters/markdown.py
@@ -44,6 +44,7 @@ class MarkdownExporter(TemplateExporter):
                         "text/latex",
                         "image/png",
                         "image/jpeg",
+                        "image/gif",
                         "text/plain",
                     ]
                 },

--- a/nbconvert/preprocessors/extractoutput.py
+++ b/nbconvert/preprocessors/extractoutput.py
@@ -49,7 +49,7 @@ class ExtractOutputPreprocessor(Preprocessor):
         config=True
     )
 
-    extract_output_types = Set({"image/png", "image/jpeg", "image/svg+xml", "application/pdf"}).tag(
+    extract_output_types = Set({"image/png", "image/jpeg", "image/svg+xml", "application/pdf", "image/gif"}).tag(
         config=True
     )
 
@@ -90,7 +90,7 @@ class ExtractOutputPreprocessor(Preprocessor):
                     data = out.data[mime_type]
 
                     # Binary files are base64-encoded, SVG is already XML
-                    if mime_type in {"image/png", "image/jpeg", "application/pdf"}:
+                    if mime_type in {"image/png", "image/jpeg", "image/gif", "application/pdf"}:
                         # data is b64-encoded as text (str, unicode),
                         # we want the original bytes
                         data = a2b_base64(data)

--- a/nbconvert/preprocessors/extractoutput.py
+++ b/nbconvert/preprocessors/extractoutput.py
@@ -49,9 +49,9 @@ class ExtractOutputPreprocessor(Preprocessor):
         config=True
     )
 
-    extract_output_types = Set({"image/png", "image/jpeg", "image/svg+xml", "application/pdf", "image/gif"}).tag(
-        config=True
-    )
+    extract_output_types = Set(
+        {"image/png", "image/jpeg", "image/svg+xml", "application/pdf", "image/gif"}
+    ).tag(config=True)
 
     def preprocess_cell(self, cell, resources, cell_index):
         """

--- a/nbconvert/utils/base.py
+++ b/nbconvert/utils/base.py
@@ -21,6 +21,7 @@ class NbConvertBase(LoggingConfigurable):
             "image/svg+xml",
             "image/png",
             "image/jpeg",
+            "image/gif",
             "text/markdown",
             "text/plain",
         ],

--- a/share/templates/asciidoc/index.asciidoc.j2
+++ b/share/templates/asciidoc/index.asciidoc.j2
@@ -65,6 +65,10 @@
 ![jpeg]({{ output.metadata.filenames['image/jpeg'] | path2url }})
 {% endblock data_jpg %}
 
+{% block data_gif %}
+![gif]({{ output.metadata.filenames['image/gif'] | path2url }})
+{% endblock data_gif %}
+
 {% block data_latex %}
 {{ output.data['text/latex'] | convert_pandoc(from_format="latex", to_format="asciidoc")}}
 {% endblock data_latex %}

--- a/share/templates/base/display_priority.j2
+++ b/share/templates/base/display_priority.j2
@@ -23,6 +23,9 @@
         {%- elif type == 'image/jpeg' -%}
             {%- block data_jpg -%}
             {%- endblock -%}
+        {%- elif type == 'image/gif' -%}
+            {%- block data_gif -%}
+            {%- endblock -%}
         {%- elif type == 'text/plain' -%}
             {%- block data_text -%}
             {%- endblock -%}

--- a/share/templates/classic/base.html.j2
+++ b/share/templates/classic/base.html.j2
@@ -225,6 +225,32 @@ alt="{{ alttext | escape_html }}"
 </div>
 {%- endblock data_jpg %}
 
+{% block data_gif scoped %}
+<div class="output_gif output_subarea {{ extra_class }}">
+{%- if 'image/gif' in output.metadata.get('filenames', {}) %}
+<img src="{{ output.metadata.filenames['image/gif'] | posix_path | escape_html }}"
+{%- else %}
+<img src="data:image/gif;base64,{{ output.data['image/gif'] | escape_html }}"
+{%- endif %}
+{%- set width=output | get_metadata('width', 'image/gif') -%}
+{%- if width is not none %}
+width={{ width | escape_html }}
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/gif') -%}
+{%- if height is not none %}
+height={{ height | escape_html }}
+{%- endif %}
+{%- if output | get_metadata('unconfined', 'image/gif') %}
+class="unconfined"
+{%- endif %}
+{%- set alttext=(output | get_metadata('alt', 'image/gif')) or (cell | get_metadata('alt')) -%}
+{%- if alttext is not none %}
+alt="{{ alttext | escape_html }}"
+{%- endif %}
+>
+</div>
+{%- endblock data_gif %}
+
 {% block data_latex scoped %}
 <div class="output_latex output_subarea {{ extra_class }}">
 {{ output.data['text/latex'] | e }}

--- a/share/templates/lab/base.html.j2
+++ b/share/templates/lab/base.html.j2
@@ -262,6 +262,36 @@ jp-needs-dark-background
 </div>
 {%- endblock data_jpg %}
 
+{% block data_gif scoped %}
+<div class="jp-RenderedImage jp-OutputArea-output {{ extra_class }}">
+{%- if 'image/gif' in output.metadata.get('filenames', {}) %}
+<img src="{{ output.metadata.filenames['image/gif'] | posix_path | escape_html }}"
+{%- else %}
+<img src="data:image/gif;base64,{{ output.data['image/gif'] | escape_html }}"
+{%- endif %}
+{%- set width=output | get_metadata('width', 'image/gif') -%}
+{%- if width is not none %}
+width={{ width | escape_html }}
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/gif') -%}
+{%- if height is not none %}
+height={{ height | escape_html }}
+{%- endif %}
+class="
+{%- if output | get_metadata('unconfined', 'image/gif') %}
+unconfined
+{%- endif %}
+{%- if output | get_metadata('needs_background', 'image/gif') == 'light' %}
+jp-needs-light-background
+{%- endif %}
+{%- if output | get_metadata('needs_background', 'image/gif') == 'dark' %}
+jp-needs-dark-background
+{%- endif %}
+"
+>
+</div>
+{%- endblock data_gif %}
+
 {% block data_latex scoped %}
 <div class="jp-RenderedLatex jp-OutputArea-output {{ extra_class }}" data-mime-type="text/latex">
 {{ output.data['text/latex'] | e }}

--- a/share/templates/markdown/index.md.j2
+++ b/share/templates/markdown/index.md.j2
@@ -61,6 +61,14 @@
     {% endif %}
 {% endblock data_jpg %}
 
+{% block data_gif %}
+    {% if "filenames" in output.metadata %}
+![gif]({{ output.metadata.filenames['image/gif'] | path2url }})
+    {% else %}
+![gif](data:image/gif;base64,{{ output.data['image/gif'] }})
+    {% endif %}
+{% endblock data_gif %}
+
 {% block data_latex %}
 {{ output.data['text/latex'] }}
 {% endblock data_latex %}

--- a/share/templates/rst/index.rst.j2
+++ b/share/templates/rst/index.rst.j2
@@ -76,6 +76,18 @@
 {%- endif %}
 {% endblock data_jpg %}
 
+{% block data_gif %}
+.. image:: {{ output.metadata.filenames['image/gif'] | urlencode }}
+{%- set width=output | get_metadata('width', 'image/gif') -%}
+{%- if width is not none %}
+   :width: {{ width }}px
+{%- endif %}
+{%- set height=output | get_metadata('height', 'image/gif') -%}
+{%- if height is not none %}
+   :height: {{ height }}px
+{%- endif %}
+{% endblock data_gif %}
+
 {% block data_markdown %}
 {{ output.data['text/markdown'] | convert_pandoc("markdown", "rst") }}
 {% endblock data_markdown %}

--- a/tests/preprocessors/base.py
+++ b/tests/preprocessors/base.py
@@ -26,6 +26,7 @@ class PreprocessorTestsBase(TestsBase):
             nbformat.new_output("stream", name="stderr", text="f"),
             nbformat.new_output("display_data", data={"image/png": "Zw=="}),  # g
             nbformat.new_output("display_data", data={"application/pdf": "aA=="}),  # h
+            nbformat.new_output("display_data", data={"image/gif": "aQ=="}),  # i
         ]
         if with_json_outputs:
             outputs.extend(

--- a/tests/preprocessors/test_extractoutput.py
+++ b/tests/preprocessors/test_extractoutput.py
@@ -16,7 +16,12 @@ class TestExtractOutput(PreprocessorTestsBase):
     def build_preprocessor(self):
         """Make an instance of a preprocessor"""
         preprocessor = ExtractOutputPreprocessor()
-        preprocessor.extract_output_types = {"text/plain", "image/png", "application/pdf", "image/gif"}
+        preprocessor.extract_output_types = {
+            "text/plain",
+            "image/png",
+            "application/pdf",
+            "image/gif",
+        }
         preprocessor.enabled = True
         return preprocessor
 
@@ -94,4 +99,3 @@ class TestExtractOutput(PreprocessorTestsBase):
 
         # Verify equivalence of extracted outputs.
         self.assertEqual(sorted(outputs), sorted(reference_files))
-

--- a/tests/preprocessors/test_extractoutput.py
+++ b/tests/preprocessors/test_extractoutput.py
@@ -16,7 +16,7 @@ class TestExtractOutput(PreprocessorTestsBase):
     def build_preprocessor(self):
         """Make an instance of a preprocessor"""
         preprocessor = ExtractOutputPreprocessor()
-        preprocessor.extract_output_types = {"text/plain", "image/png", "application/pdf"}
+        preprocessor.extract_output_types = {"text/plain", "image/png", "application/pdf", "image/gif"}
         preprocessor.enabled = True
         return preprocessor
 
@@ -48,6 +48,12 @@ class TestExtractOutput(PreprocessorTestsBase):
         self.assertIn("application/pdf", output.metadata.filenames)
         pdf_filename = output.metadata.filenames["application/pdf"]
 
+        # Check that gif was extracted as binary bytes (base64-decoded), not a string
+        output = nb.cells[0].outputs[8]
+        self.assertIn("filenames", output.metadata)
+        self.assertIn("image/gif", output.metadata.filenames)
+        gif_filename = output.metadata.filenames["image/gif"]
+
         # Verify text output
         self.assertIn(text_filename, res["outputs"])
         self.assertEqual(res["outputs"][text_filename], b"b")
@@ -59,6 +65,10 @@ class TestExtractOutput(PreprocessorTestsBase):
         # Verify pdf output
         self.assertIn(pdf_filename, res["outputs"])
         self.assertEqual(res["outputs"][pdf_filename], b"h")
+
+        # Verify gif output — must be bytes, not a raw base64 string
+        self.assertIn(gif_filename, res["outputs"])
+        self.assertEqual(res["outputs"][gif_filename], b"i")
 
     def test_json_extraction(self):
         nb = self.build_notebook(with_json_outputs=True)
@@ -84,3 +94,4 @@ class TestExtractOutput(PreprocessorTestsBase):
 
         # Verify equivalence of extracted outputs.
         self.assertEqual(sorted(outputs), sorted(reference_files))
+

--- a/tests/preprocessors/test_tagremove.py
+++ b/tests/preprocessors/test_tagremove.py
@@ -85,4 +85,4 @@ class TestTagRemove(PreprocessorTestsBase):
         self.assertEqual(len(nb.cells[-1].outputs), 0)
 
         # checks that we can remove individual outputs
-        self.assertEqual(len(nb.cells[0].outputs), 8)
+        self.assertEqual(len(nb.cells[0].outputs), 9)


### PR DESCRIPTION
# GIF Support Implementation for nbconvert

## Overview
This document describes the implementation of native GIF image support in nbconvert, which eliminates the need for the monkey patch previously required for example in WhipperSnapPy (Deep-MI/WhipperSnapPy#59). See also Issue #2270 .

## Problem Statement
Previously, nbconvert did not support the `image/gif` MIME type for display data outputs. This meant that animated GIFs generated by notebook cells would:
1. Not be extracted from notebook outputs
2. Fall back to text/plain representation
3. Require external monkey patches in dependent projects to work properly

## Solution Overview
The implementation adds native GIF support across three main areas. All changes are additive and existing conversion without gif will not break. 

### 1. Output Extraction (ExtractOutputPreprocessor)
**File:** `nbconvert/preprocessors/extractoutput.py`

**Changes:**
- Added `"image/gif"` to the `extract_output_types` Set (line 52)
- Added `"image/gif"` to the binary MIME types that are base64-decoded (line 92)

**Why:** This ensures that GIF image data is properly extracted from notebook outputs and converted from base64 to binary format, just like PNG and JPEG images.

### 2. Display Priority
**File:** `share/templates/base/display_priority.j2`

**Changes:**
- Added GIF handling to the display priority chain (after JPEG, before plain text)
- Created a `data_gif` block for template inheritance

**Why:** This ensures that GIF outputs are selected and prioritized appropriately in the output rendering pipeline.

### 3. Template Rendering
Templates were updated across multiple export formats to handle GIF rendering:

#### HTML Templates
- **File:** `share/templates/classic/base.html.j2`
  - Added `data_gif` block with full HTML img tag support
  - Supports both file-based and base64 data URIs
  - Includes metadata support (width, height, alt text, etc.)

- **File:** `share/templates/lab/base.html.j2`
  - Added `data_gif` block with JupyterLab-specific CSS classes
  - Full feature parity with PNG/JPEG rendering

#### Markdown Template
- **File:** `share/templates/markdown/index.md.j2`
  - Added `data_gif` block with Markdown image syntax
  - Supports both file references and base64 data URIs

#### ReStructuredText Template
- **File:** `share/templates/rst/index.rst.j2`
  - Added `data_gif` block with RST image directive
  - Includes width/height metadata support

#### AsciiDoc Template
- **File:** `share/templates/asciidoc/index.asciidoc.j2`
  - Added `data_gif` block with AsciiDoc image syntax

### 4. Exporters
- added gif to exporters

### 5. Tests
- added gif to tests
