### PR TITLE
fix: avoid duplicating output subdirs for support files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -447,12 +447,17 @@ class NbConvertApp(JupyterApp):
         notebook_name = self._notebook_filename_to_name(notebook_filename)
         self.log.debug("Notebook name is '%s'", notebook_name)
 
+        output_dir = os.path.dirname(notebook_name)
+        output_basename = os.path.basename(notebook_name)
+
         # first initialize the resources we want to use
         resources = {}
         resources["config_dir"] = self.config_dir
-        resources["unique_key"] = notebook_name
+        resources["unique_key"] = output_basename
 
-        output_files_dir = self.output_files_dir.format(notebook_name=notebook_name)
+        output_files_dir = self.output_files_dir.format(notebook_name=output_basename)
+        if output_dir:
+            output_files_dir = os.path.join(output_dir, output_files_dir)
 
         resources["output_files_dir"] = output_files_dir
 

--- a/tests/test_nbconvertapp.py
+++ b/tests/test_nbconvertapp.py
@@ -68,7 +68,6 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile("notebook1.py")
             assert os.path.isfile("notebook2.py")
 
-
     def test_output_in_subdir_support_files_path(self):
         """Support files for an output path in a subdirectory should not duplicate the subdirectory name."""
         with self.create_temp_cwd(["notebook4_jpeg.ipynb", "containerized_deployments.jpeg"]):
@@ -78,9 +77,7 @@ class TestNbConvertApp(TestsBase):
             )
             assert os.path.isfile("test.md")
             assert os.path.isdir(os.path.join("another_folder", "test_files"))
-            assert not os.path.isdir(
-                os.path.join("another_folder", "test_files", "another_folder")
-            )
+            assert not os.path.isdir(os.path.join("another_folder", "test_files", "another_folder"))
             assert os.listdir(os.path.join("another_folder", "test_files"))
 
     def test_convert_full_qualified_name(self):

--- a/tests/test_nbconvertapp.py
+++ b/tests/test_nbconvertapp.py
@@ -68,6 +68,21 @@ class TestNbConvertApp(TestsBase):
             assert os.path.isfile("notebook1.py")
             assert os.path.isfile("notebook2.py")
 
+
+    def test_output_in_subdir_support_files_path(self):
+        """Support files for an output path in a subdirectory should not duplicate the subdirectory name."""
+        with self.create_temp_cwd(["notebook4_jpeg.ipynb", "containerized_deployments.jpeg"]):
+            os.mkdir("another_folder")
+            self.nbconvert(
+                "--to markdown --log-level 0 --output another_folder/test.md notebook4_jpeg.ipynb"
+            )
+            assert os.path.isfile("test.md")
+            assert os.path.isdir(os.path.join("another_folder", "test_files"))
+            assert not os.path.isdir(
+                os.path.join("another_folder", "test_files", "another_folder")
+            )
+            assert os.listdir(os.path.join("another_folder", "test_files"))
+
     def test_convert_full_qualified_name(self):
         """
         Test that nbconvert can convert file using a full qualified name for a


### PR DESCRIPTION
## Summary
- avoid duplicating subdirectory segments in support-file paths when `--output` points to a subdirectory
- keep extracted output filenames keyed off the output basename instead of the full output path
- add a regression test covering markdown export with `--output another_folder/test.md`

## Problem
Issue #1164 reports support files being written under an incorrect nested path when converting to markdown and sending the output to a file outside the current directory.

## Root cause
`NbConvertApp` was using the full path-like notebook output name as both the `unique_key` for extracted asset filenames and the `{notebook_name}` placeholder for `output_files_dir`. When `--output` included a subdirectory, that path information leaked into both places and could be duplicated.

## Fix
Split the output name into:
- a basename used for `unique_key` and filename templating
- an optional directory prefix that is re-applied only once to `output_files_dir`

## Test Plan
- `python3 -m pytest -q tests/test_nbconvertapp.py -k output_in_subdir_support_files_path`
- `python3 -m pytest -q tests/test_nbconvertapp.py -k 'write_figures_to_custom_path or output_in_subdir_support_files_path'`

Closes #1164
