### PR TITLE
fix: avoid overwriting duplicate markdown attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/nbconvert/preprocessors/extractattachments.py
+++ b/nbconvert/preprocessors/extractattachments.py
@@ -43,6 +43,16 @@ class ExtractAttachmentsPreprocessor(Preprocessor):
             "attachments"  # Here as a default, in case someone doesn't want to call preprocess
         )
 
+    def _unique_filename(self, resources, safe_fname):
+        """Return a unique output filename for an attachment."""
+        base, ext = os.path.splitext(safe_fname)
+        candidate = safe_fname
+        counter = 1
+        while os.path.join(self.path_name, candidate) in resources[self.resources_item_key]:
+            candidate = f"{base}_{counter}{ext}"
+            counter += 1
+        return candidate
+
     # Add condition and configurability here
     def preprocess(self, nb, resources):
         """
@@ -109,13 +119,14 @@ class ExtractAttachmentsPreprocessor(Preprocessor):
                     break
 
                 # FilesWriter wants path to be in attachment filename here
-                new_filename = os.path.join(self.path_name, safe_fname)
-                if new_filename in resources[self.resources_item_key]:
+                unique_fname = self._unique_filename(resources, safe_fname)
+                new_filename = os.path.join(self.path_name, unique_fname)
+                if unique_fname != safe_fname:
                     self.log.warning(
-                        "Attachment filename '%s' (from '%s') overwrites a previous "
-                        "attachment with the same name",
+                        "Attachment filename '%s' (from '%s') already existed; using '%s' instead",
                         safe_fname,
                         fname,
+                        unique_fname,
                     )
                 resources[self.resources_item_key][new_filename] = decoded
 

--- a/tests/preprocessors/test_extractattachments.py
+++ b/tests/preprocessors/test_extractattachments.py
@@ -151,6 +151,58 @@ class TestExtractAttachments(PreprocessorTestsBase):
         # Cell source must reference the safe, flattened filename
         self.assertEqual(nb.cells[0].source, "![file](test1)")
 
+    def test_attachment_duplicate_filenames_are_made_unique_per_cell(self):
+        """Attachments with the same filename in different cells should not overwrite.
+
+        Markdown export writes attachments to disk, so filenames must be unique
+        across cells even though notebook attachments are only scoped per cell.
+        """
+        first = b64encode(b"first image").decode("utf-8")
+        second = b64encode(b"second image").decode("utf-8")
+        first_cell = nbformat.new_markdown_cell(
+            source="![first](attachment:image.png)",
+            attachments={"image.png": {"image/png": first}},
+        )
+        second_cell = nbformat.new_markdown_cell(
+            source="![second](attachment:image.png)",
+            attachments={"image.png": {"image/png": second}},
+        )
+        nb = nbformat.new_notebook(cells=[first_cell, second_cell])
+        res = self.build_resources()
+        res["output_files_dir"] = "outputs"
+        preprocessor = self.build_preprocessor()
+
+        nb, res = preprocessor(nb, res)
+
+        self.assertEqual(res["outputs"][os.path.join("outputs", "image.png")], b"first image")
+        self.assertEqual(res["outputs"][os.path.join("outputs", "image_1.png")], b"second image")
+        self.assertEqual(nb.cells[0].source, "![first](outputs/image.png)")
+        self.assertEqual(nb.cells[1].source, "![second](outputs/image_1.png)")
+
+    def test_attachment_sanitized_name_collisions_are_made_unique(self):
+        """Sanitized basenames should still be uniquified across cells."""
+        nested = b64encode(b"nested image").decode("utf-8")
+        flat = b64encode(b"flat image").decode("utf-8")
+        first_cell = nbformat.new_markdown_cell(
+            source="![first](attachment:dir/image.png)",
+            attachments={"dir/image.png": {"image/png": nested}},
+        )
+        second_cell = nbformat.new_markdown_cell(
+            source="![second](attachment:image.png)",
+            attachments={"image.png": {"image/png": flat}},
+        )
+        nb = nbformat.new_notebook(cells=[first_cell, second_cell])
+        res = self.build_resources()
+        res["output_files_dir"] = "outputs"
+        preprocessor = self.build_preprocessor()
+
+        nb, res = preprocessor(nb, res)
+
+        self.assertEqual(res["outputs"][os.path.join("outputs", "image.png")], b"nested image")
+        self.assertEqual(res["outputs"][os.path.join("outputs", "image_1.png")], b"flat image")
+        self.assertEqual(nb.cells[0].source, "![first](outputs/image.png)")
+        self.assertEqual(nb.cells[1].source, "![second](outputs/image_1.png)")
+
     def test_attachment_empty_basename_skipped(self):
         """Test that filenames resolving to an empty basename are skipped.
 


### PR DESCRIPTION
## Summary
- avoid overwriting extracted markdown attachments when different cells reuse the same attachment filename
- keep the first attachment path unchanged and suffix later collisions deterministically
- add regression coverage for both direct duplicate names and collisions introduced by filename sanitization

## Problem
`ExtractAttachmentsPreprocessor` flattens attachment filenames into a shared output directory during markdown export. If two cells both reference `attachment:image.png`, the later extraction overwrites the earlier file and both markdown references end up pointing at the same image.

## Fix
Generate a unique output filename when the sanitized attachment basename already exists in the current resources map, then rewrite that cell's attachment reference to the uniquified path.

## Test Plan
- `python3 -m pytest tests/preprocessors/test_extractattachments.py -q`
- `python3 -m pytest tests/test_nbconvertapp.py -k "output_in_subdir_support_files_path or same_filename_different_dir" -q`
- manual reproduction with `jupyter nbconvert --to markdown` on a notebook containing two cells with distinct `attachment:image.png` payloads now produces `image.png` and `image_1.png`

Closes #2163
