### PR TITLE
fix: handle empty anchor link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -123,6 +123,8 @@ def add_anchor(html, anchor_link_text="¶"):
         return html
     link = _convert_header_id(html2text(h))
     h.set("id", link)
+    if anchor_link_text == "":
+        return ElementTree.tostring(h).decode(encoding="utf-8")
     a = Element("a", {"class": "anchor-link", "href": "#" + link})
     try:
         # Test if the anchor link text is HTML (e.g. an image)

--- a/tests/filters/test_strings.py
+++ b/tests/filters/test_strings.py
@@ -67,6 +67,11 @@ class TestStrings(TestsBase):
         assert "<b" in results
         assert "</b>" in results
 
+    def test_add_anchor_with_empty_link_text(self):
+        """add_anchor keeps the heading visible when the link text is empty"""
+        results = add_anchor("<h1>header</h1>", anchor_link_text="")
+        self.assertEqual(results, '<h1 id="header">header</h1>')
+
     def test_add_anchor_fail(self):
         """add_anchor does nothing when it fails"""
         html = "<h1>Hello <br>World!</h1>"


### PR DESCRIPTION
## Summary
- avoid emitting an empty self-closing anchor when `HTMLExporter.anchor_link_text` is set to an empty string
- preserve the heading id so downstream links still work
- add a regression test covering the empty-string case

## Problem
`add_anchor()` currently serializes an empty anchor as `<a ... />` when `anchor_link_text=""`.
That produces invalid HTML for `<a>` tags and can hide the following content in converted output.

## Fix
Return the heading with its generated `id` unchanged when `anchor_link_text` is an empty string, instead of appending an empty anchor element.

## Test Plan
- `python3 -m pytest tests/filters/test_strings.py -k empty_link_text -q`
- `python3 -m pytest tests/filters/test_strings.py tests/filters/test_markdown.py -q`

Closes #935
