### PR TITLE
fix: separate leading block quotes in rst export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/share/templates/rst/index.rst.j2
+++ b/share/templates/rst/index.rst.j2
@@ -99,7 +99,12 @@
 {% endblock data_html %}
 
 {% block markdowncell scoped %}
-{{ cell.source | convert_pandoc("markdown", "rst") }}
+{% set rst_source = cell.source | convert_pandoc("markdown", "rst") -%}
+{%- if rst_source.startswith(" ") -%}
+..
+
+{% endif -%}
+{{ rst_source }}
 {% endblock markdowncell %}
 
 {%- block rawcell scoped -%}

--- a/tests/exporters/test_rst.py
+++ b/tests/exporters/test_rst.py
@@ -70,7 +70,6 @@ class TestRSTExporter(ExportersTestsBase):
         assert ":height:" in attr_string
         assert "px" in attr_string
 
-
     @onlyif_cmds_exist("pandoc")
     def test_markdown_cell_starting_with_block_quote_after_image(self):
         """A leading block quote in one cell must not extend a prior directive."""
@@ -86,9 +85,7 @@ class TestRSTExporter(ExportersTestsBase):
         output, _resources = RSTExporter(config=config).from_notebook_node(nb)
 
         assert (
-            ".. image:: https://jupyter.org/assets/main-logo.svg\n\n"
-            "..\n\n"
-            "   starting with a quote"
+            ".. image:: https://jupyter.org/assets/main-logo.svg\n\n..\n\n   starting with a quote"
         ) in output
 
     def test_rst_output(self):

--- a/tests/exporters/test_rst.py
+++ b/tests/exporters/test_rst.py
@@ -7,6 +7,7 @@ import re
 
 import nbformat
 from nbformat import v4
+from traitlets.config import Config
 
 from nbconvert.exporters.rst import RSTExporter
 from tests.testutils import onlyif_cmds_exist
@@ -68,6 +69,27 @@ class TestRSTExporter(ExportersTestsBase):
         assert ":width:" in attr_string
         assert ":height:" in attr_string
         assert "px" in attr_string
+
+
+    @onlyif_cmds_exist("pandoc")
+    def test_markdown_cell_starting_with_block_quote_after_image(self):
+        """A leading block quote in one cell must not extend a prior directive."""
+        nb = v4.new_notebook(
+            cells=[
+                v4.new_markdown_cell("![](https://jupyter.org/assets/main-logo.svg)"),
+                v4.new_markdown_cell("> starting with a quote"),
+            ]
+        )
+
+        config = Config()
+        config.TemplateExporter.extra_template_basedirs = ["share/templates"]
+        output, _resources = RSTExporter(config=config).from_notebook_node(nb)
+
+        assert (
+            ".. image:: https://jupyter.org/assets/main-logo.svg\n\n"
+            "..\n\n"
+            "   starting with a quote"
+        ) in output
 
     def test_rst_output(self):
         """


### PR DESCRIPTION
## Summary
- prevent an RST markdown cell that starts with a block quote from being parsed as part of the previous directive
- add a regression test for an image-only markdown cell followed by a leading block quote cell

## Problem
Issue #1245 shows that when RST export emits a directive at the end of one markdown cell, a following markdown cell that starts with `>` is converted by pandoc to an indented block quote. In reStructuredText that indentation can be interpreted as directive content, so the quote is swallowed by the previous image directive and the output is invalid.

## Fix
When a markdown cell's converted RST starts with indentation, insert an empty RST comment before it. That gives the previous directive an explicit boundary while preserving the rendered block quote text.

## Test Plan
- `PYTHONPATH=. python3 -m pytest tests/exporters/test_rst.py -q`
- `PYTHONPATH=. python3 -m pytest tests/exporters/test_rst.py -k "block_quote or empty_code_cell or png_metadata" -q`

Closes #1245.
