### PR TITLE
fix (security): Sanitize output filenames in ExtractOutputPreprocessor to prevent path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/preprocessors/extractoutput.py
+++ b/nbconvert/preprocessors/extractoutput.py
@@ -114,8 +114,32 @@ class ExtractOutputPreprocessor(Preprocessor):
                     if ext is None:
                         ext = "." + mime_type.rsplit("/")[-1]
                     if out.metadata.get("filename", ""):
-                        filename = out.metadata["filename"]
-                        if not filename.endswith(ext):
+                        # Sanitize: use only the basename to prevent path traversal.
+                        # A crafted filename (an absolute path or a '../' sequence)
+                        # must not be able to redirect the extracted output outside
+                        # the output directory when it is later written to disk.
+                        raw_filename = out.metadata["filename"]
+                        filename = os.path.basename(raw_filename)
+                        if filename != raw_filename:
+                            self.log.warning(
+                                "Output filename '%s' contained path components, "
+                                "using basename '%s'",
+                                raw_filename,
+                                filename,
+                            )
+                        if not filename:
+                            self.log.warning(
+                                "Output filename '%s' is invalid (empty basename), "
+                                "using a generated filename",
+                                raw_filename,
+                            )
+                            filename = self.output_filename_template.format(
+                                unique_key=unique_key,
+                                cell_index=cell_index,
+                                index=index,
+                                extension=ext,
+                            )
+                        elif not filename.endswith(ext):
                             filename += ext
                     else:
                         filename = self.output_filename_template.format(

--- a/tests/preprocessors/test_extractoutput.py
+++ b/tests/preprocessors/test_extractoutput.py
@@ -4,6 +4,9 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+import os
+
+from nbformat import v4 as nbformat
 
 from nbconvert.preprocessors.extractoutput import ExtractOutputPreprocessor
 
@@ -84,3 +87,50 @@ class TestExtractOutput(PreprocessorTestsBase):
 
         # Verify equivalence of extracted outputs.
         self.assertEqual(sorted(outputs), sorted(reference_files))
+
+    def _extract_with_output_filename(self, filename):
+        """Run the preprocessor on a notebook whose single image output carries an
+        attacker-controlled ``metadata.filename``; return the resources dict."""
+        output = nbformat.new_output(
+            "display_data",
+            data={"image/png": "Zw=="},
+            metadata={"filename": filename},
+        )
+        nb = nbformat.new_notebook(
+            cells=[nbformat.new_code_cell(source="", execution_count=1, outputs=[output])]
+        )
+        res = self.build_resources()
+        preprocessor = self.build_preprocessor()
+        _, res = preprocessor(nb, res)
+        return res
+
+    def test_output_filename_path_traversal_sanitised(self):
+        """A '../' traversal in output metadata.filename must not escape the output
+        directory; only the basename is used as the resource key."""
+        malicious = "../../../../../../tmp/nbconvert_traversal/evil.png"
+        res = self._extract_with_output_filename(malicious)
+        self.assertIn("evil.png", res["outputs"])
+        self.assertEqual(res["outputs"]["evil.png"], b"g")
+        for key in res["outputs"]:
+            self.assertNotIn("..", key)
+            self.assertFalse(os.path.isabs(key))
+
+    def test_output_filename_absolute_path_sanitised(self):
+        """An absolute output metadata.filename must be reduced to its basename so
+        os.path.join cannot redirect the write to an absolute location."""
+        res = self._extract_with_output_filename("/tmp/absolute/evil.png")
+        self.assertIn("evil.png", res["outputs"])
+        self.assertNotIn("/tmp/absolute/evil.png", res["outputs"])
+        self.assertEqual(res["outputs"]["evil.png"], b"g")
+        for key in res["outputs"]:
+            self.assertFalse(os.path.isabs(key))
+
+    def test_output_filename_empty_basename_fallback(self):
+        """A filename whose basename is empty (e.g. '../') must fall back to a
+        generated filename rather than being used verbatim."""
+        res = self._extract_with_output_filename("../../../tmp/")
+        self.assertEqual(len(res["outputs"]), 1)
+        for key in res["outputs"]:
+            self.assertNotIn("..", key)
+            self.assertFalse(os.path.isabs(key))
+            self.assertTrue(key.endswith(".png"))


### PR DESCRIPTION
## Summary

`ExtractOutputPreprocessor` uses the notebook-provided `output.metadata.filename` as the on-disk filename for extracted outputs without sanitizing it. A crafted notebook can therefore cause extracted output files to be written **outside** the conversion output directory — both an absolute path and a `../` traversal escape — and for `image/svg+xml` outputs the written bytes are fully controlled by the notebook.

## Details

```python
# nbconvert/preprocessors/extractoutput.py (before)
if out.metadata.get("filename", ""):
    filename = out.metadata["filename"]                    # taken verbatim from the notebook
    ...
if output_files_dir is not None:
    filename = os.path.join(output_files_dir, filename)    # an absolute path discards the prefix
...
resources["outputs"][filename] = data
```

The default writer then writes each item without checking that the destination stays inside the build directory:

```python
# nbconvert/writers/files.py
dest = os.path.join(build_dir, filename)   # an absolute path or a ../ sequence escapes build_dir
...
with open(dest, "wb") as f:
    f.write(data)
```

`ExtractOutputPreprocessor` is a default preprocessor for the `rst`, `markdown`, `asciidoc`, and `latex`/`pdf` exporters and `FilesWriter` is the default writer, so this code path is reached by an ordinary `jupyter nbconvert` invocation. The notebook does not need to be executed — the payload lives in static `outputs`.

## Reproduction (before this change)

A notebook whose display output carries `metadata.filename = "../../../../../../tmp/x/evil.svg"` (or an absolute path) together with `data["image/svg+xml"]`:

```console
$ jupyter nbconvert --to rst --output-dir build evil.ipynb
...
$ ls /tmp/x        # written OUTSIDE build/, with attacker-controlled contents
evil.svg
```

## Fix

Reduce the output filename to its basename before use, and fall back to the generated `output_filename_template` when the basename is empty, so extracted outputs always stay inside the output directory. A warning is logged when a filename contained path components.

## Tests

Adds regression tests covering `../` traversal, absolute paths, and empty-basename filenames in `tests/preprocessors/test_extractoutput.py`. The existing extractoutput tests continue to pass.
