### PR TITLE
Improve invalid template config errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -68,6 +68,7 @@ data = data.replace("`cell`", "``cell``")
 data = data.replace("`cell_index`", "``cell_index``")
 data = data.replace("`cell_allows_errors`", "``cell_allows_errors``")
 data = data.replace("`notebook`", "``notebook``")
+data = data.replace("`asctime`", "``asctime``")
 
 with open(destination, "w") as f:
     f.write(data)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -24,7 +24,7 @@ Nbconvert is packaged for both pip and conda, so you can install it with::
 
     conda install nbconvert
 
-The `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ and `Miniforge <https://github.com/conda-forge/miniforge/>`_ distributions both provide a minimal conda installation.
+The `Miniconda <https://www.anaconda.com/docs/getting-started/miniconda/main>`_ and `Miniforge <https://github.com/conda-forge/miniforge/>`_ distributions both provide a minimal conda installation.
 
 .. important::
 

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -109,7 +109,7 @@ def _load_template_conf(conf_path):
         with open(conf_path) as f:
             return json.load(f)
     except json.JSONDecodeError as err:
-        msg = f"Failed to parse template configuration file {conf_path!r}: {err}"
+        msg = f"Failed to parse template configuration file {conf_path}: {err}"
         raise ValueError(msg) from err
 
 

--- a/nbconvert/exporters/templateexporter.py
+++ b/nbconvert/exporters/templateexporter.py
@@ -102,6 +102,17 @@ def recursive_update(target, new):
     return target  # return for convenience
 
 
+def _load_template_conf(conf_path):
+    """Load a template conf.json file."""
+    conf_path = os.fspath(conf_path)
+    try:
+        with open(conf_path) as f:
+            return json.load(f)
+    except json.JSONDecodeError as err:
+        msg = f"Failed to parse template configuration file {conf_path!r}: {err}"
+        raise ValueError(msg) from err
+
+
 # define function at the top level to avoid pickle errors
 def deprecated(msg):
     """Emit a deprecation warning."""
@@ -564,8 +575,7 @@ class TemplateExporter(Exporter):
                 pass
             else:
                 if conf_path_exists:
-                    with conf_path.open() as f:
-                        conf = recursive_update(conf, json.load(f))
+                    conf = recursive_update(conf, _load_template_conf(conf_path))
         return conf
 
     @default("template_paths")
@@ -635,16 +645,14 @@ class TemplateExporter(Exporter):
                     found_at_least_one = True
                 conf_file = os.path.join(template_dir, "conf.json")
                 if os.path.exists(conf_file):
-                    with open(conf_file) as f:
-                        conf = recursive_update(json.load(f), conf)
+                    conf = recursive_update(_load_template_conf(conf_file), conf)
             for root_dir in root_dirs:
                 template_dir = os.path.join(root_dir, "nbconvert", "templates", base_template)
                 if os.path.exists(template_dir):
                     found_at_least_one = True
                 conf_file = os.path.join(template_dir, "conf.json")
                 if os.path.exists(conf_file):
-                    with open(conf_file) as f:
-                        conf = recursive_update(json.load(f), conf)
+                    conf = recursive_update(_load_template_conf(conf_file), conf)
             if not found_at_least_one:
                 # Check for backwards compatibility template names
                 for root_dir in root_dirs:

--- a/tests/exporters/test_templateexporter.py
+++ b/tests/exporters/test_templateexporter.py
@@ -273,6 +273,30 @@ class TestExporter(ExportersTestsBase):
             assert exporter.template_name == template
             assert os.path.join(td, template) in exporter.template_paths
 
+    def test_invalid_template_conf_json_error_includes_path(self):
+        with TemporaryDirectory() as td:
+            template = "mytemplate"
+            template_dir = os.path.join(td, template)
+            template_file = os.path.join(template_dir, "index.py.j2")
+            template_conf = os.path.join(template_dir, "conf.json")
+            os.mkdir(template_dir)
+            with open(template_file, "w") as f:
+                f.write("content")
+            with open(template_conf, "w") as f:
+                f.write("{")
+
+            config = Config()
+            config.TemplateExporter.template_name = template
+            config.TemplateExporter.extra_template_basedirs = [td]
+
+            with pytest.raises(
+                ValueError, match="Failed to parse template configuration file"
+            ) as exc_info:
+                self._make_exporter(config=config)
+
+            assert "Failed to parse template configuration file" in str(exc_info.value)
+            assert template_conf in str(exc_info.value)
+
     def test_local_template_dir(self):
         with TemporaryDirectory() as td, _contextlib_chdir.chdir(td):  # noqa
             with patch("os.getcwd", return_value=os.path.abspath(td)):


### PR DESCRIPTION
## Summary

- add a shared loader for template `conf.json` files
- report the template configuration file path when JSON parsing fails
- add a regression test for invalid template config JSON

## Why

When a template `conf.json` is invalid, `json.load()` raises a `JSONDecodeError` without showing which template file caused the failure. That is hard to diagnose when multiple template paths are configured.

Fixes #2149.

## Testing

- `.venv/bin/python -m pytest -q tests/exporters/test_templateexporter.py::TestExporter::test_invalid_template_conf_json_error_includes_path`
- `.venv/bin/python -m pytest -q tests/exporters/test_templateexporter.py`
- `.venv/bin/python -m ruff check --fix --show-fixes nbconvert/exporters/templateexporter.py tests/exporters/test_templateexporter.py`
- `.venv/bin/python -m ruff format nbconvert/exporters/templateexporter.py tests/exporters/test_templateexporter.py`
- `git diff --check`
- manual smoke test confirming the raised error includes the invalid `conf.json` path
