### PR TITLE
Handle missing widget state metadata in WidgetsDataTypeFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/filters/widgetsdatatypefilter.py
+++ b/nbconvert/filters/widgetsdatatypefilter.py
@@ -54,11 +54,8 @@ class WidgetsDataTypeFilter(NbConvertBase):
 
         """
         metadata = self.metadata.get(self.notebook_path, {})
-        widgets_state = (
-            metadata["widgets"][WIDGET_STATE_MIMETYPE]["state"]
-            if metadata.get("widgets") is not None
-            else {}
-        )
+        widgets_metadata = (metadata.get("widgets") or {}).get(WIDGET_STATE_MIMETYPE) or {}
+        widgets_state = widgets_metadata.get("state", {})
         for fmt in self.display_data_priority:
             if fmt in output:
                 # If there is no widget state available, we skip this mimetype

--- a/tests/filters/test_widgetsdatatypefilter.py
+++ b/tests/filters/test_widgetsdatatypefilter.py
@@ -1,0 +1,56 @@
+"""Tests for the widget-aware data type filter."""
+
+from nbconvert.filters.widgetsdatatypefilter import (
+    WIDGET_STATE_MIMETYPE,
+    WIDGET_VIEW_MIMETYPE,
+    WidgetsDataTypeFilter,
+)
+
+
+def test_widget_metadata_without_state_falls_back_to_plain_text():
+    """Missing widget state should behave like unavailable widget state."""
+    filter_ = WidgetsDataTypeFilter(
+        notebook_metadata={
+            "": {
+                "widgets": {
+                    WIDGET_STATE_MIMETYPE: {
+                        "version_major": 2,
+                        "version_minor": 0,
+                    }
+                }
+            }
+        }
+    )
+    filter_.display_data_priority = [WIDGET_VIEW_MIMETYPE, "text/plain"]
+
+    assert filter_(
+        {
+            WIDGET_VIEW_MIMETYPE: {"model_id": "missing-widget-model"},
+            "text/plain": "widget fallback",
+        }
+    ) == ["text/plain"]
+
+
+def test_widget_metadata_with_matching_state_prefers_widget_view():
+    """Available widget state should still allow the widget view mimetype."""
+    filter_ = WidgetsDataTypeFilter(
+        notebook_metadata={
+            "": {
+                "widgets": {
+                    WIDGET_STATE_MIMETYPE: {
+                        "state": {
+                            "available-widget-model": {},
+                        },
+                    }
+                }
+            }
+        }
+    )
+    filter_.display_data_priority = [WIDGET_VIEW_MIMETYPE, "text/plain"]
+
+    assert filter_(
+        {
+            WIDGET_VIEW_MIMETYPE: {"model_id": "available-widget-model"},
+            "text/plain": "widget fallback",
+        }
+    ) == [WIDGET_VIEW_MIMETYPE]


### PR DESCRIPTION
## Summary

This fixes a `KeyError` when notebook metadata contains the widget-state mimetype object but that object does not include a nested `"state"` key.

## Reproducer shape

```python
metadata = {
    "widgets": {
        "application/vnd.jupyter.widget-state+json": {
            "version_major": 2,
            "version_minor": 0,
        }
    }
}
```

When an output includes `application/vnd.jupyter.widget-view+json`, `WidgetsDataTypeFilter` currently indexes:

```python
metadata["widgets"][WIDGET_STATE_MIMETYPE]["state"]
```

and raises:

```text
KeyError: "state"
```

## Fix

This change treats missing `"state"` the same as unavailable widget state. The filter skips the widget-view mimetype and falls back to the next available display format, such as `text/plain`.

## Tests

Tests added:

* widget metadata without `"state"` falls back to `text/plain`
* widget metadata with matching state still prefers widget-view

Tested locally:

* `tests/filters/test_widgetsdatatypefilter.py tests/filters/test_datatypefilter.py`: `5 passed`
* `tests/filters`: `54 passed, 5 skipped`
* full suite: `290 passed, 41 skipped`

## Related issues

* Fixes #1731
* Related to #2127

## Debugging / reproduction note

We reproduced this failure using Retrace, our Python record/replay debugger, to inspect the runtime state at the failing call site.

The replay showed that the notebook metadata contained the widget-state mimetype object, but that object only had `version_major` and `version_minor`; the nested `"state"` key was absent. That is the shape covered by the new test.

The fix and tests above do not depend on Retrace, but the replay was useful for confirming the exact runtime metadata shape behind the `KeyError`.

For context, we documented the replay/debugging workflow here:
https://github.com/retracesoftware/retracesoftware/tree/main/open-source-debugging/examples/001-nbconvert-1731
