### PR TITLE
Fix XSS for text/vnd.mermaid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/share/templates/lab/base.html.j2
+++ b/share/templates/lab/base.html.j2
@@ -176,7 +176,7 @@ unknown type  {{ cell.type }}
 {% block data_mermaid scoped -%}
 <div class="jp-Mermaid">
 <pre class="mermaid">
-{{ output.data['text/vnd.mermaid'].strip() }}
+{{ output.data['text/vnd.mermaid'].strip() | clean_html }}
 </pre>
 </div>
 {%- endblock data_mermaid %}


### PR DESCRIPTION
This patch sanitizes the content of 'text/vnd.mermaid' on rendering to avoid XSS

See https://www.cve.org/CVERecord?id=CVE-2026-6658