### PR TITLE
preprocessors: refresh inferred kernel per notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -47,6 +47,10 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
             nb = NotebookNode()
         Preprocessor.__init__(self, nb=nb, **kw)
         NotebookClient.__init__(self, nb, **kw)
+        # NotebookClient infers and stores the kernel name from the first
+        # notebook it executes. Keep the configured value so that inference is
+        # repeated for each notebook in a batch.
+        self._configured_kernel_name = self.kernel_name
 
     def _check_assign_resources(self, resources):
         if resources or not hasattr(self, "resources"):
@@ -90,6 +94,7 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         resources : dictionary
             Additional resources used in the conversion process.
         """
+        self.kernel_name = self._configured_kernel_name
         NotebookClient.__init__(self, nb, km)
         self.reset_execution_trackers()
         self._check_assign_resources(resources)

--- a/tests/preprocessors/test_execute.py
+++ b/tests/preprocessors/test_execute.py
@@ -6,10 +6,12 @@ Module with tests for the execute preprocessor.
 # Distributed under the terms of the Modified BSD License.
 import os
 import re
+from contextlib import contextmanager
 from copy import deepcopy
 
 import nbformat
 import pytest
+from jupyter_client.manager import KernelManager
 
 from nbconvert.preprocessors.execute import ExecutePreprocessor, executenb
 
@@ -103,3 +105,49 @@ def test_preprocess_cell():
         for output in cell.outputs:
             output.text = "Ignored\n"
     assert_notebooks_equal(expected_nb, output_nb)
+
+
+def test_batch_execution_uses_each_notebook_kernel():
+    """Kernel inference must be refreshed for every notebook in a batch."""
+
+    class RecordingKernelManager(KernelManager):
+        requested_kernel_names = []
+
+        def __init__(self, *args, **kwargs):
+            self.requested_kernel_names.append(kwargs.get("kernel_name"))
+            super().__init__(*args, **kwargs)
+
+    class RecordingKernelClient:
+        def kernel_info(self):
+            return "kernel-info"
+
+    class RecordingExecutePreprocessor(ExecutePreprocessor):
+        @contextmanager
+        def setup_kernel(self):
+            self.create_kernel_manager()
+            self.kc = RecordingKernelClient()
+            yield
+            self.kc = None
+
+        def wait_for_reply(self, *args, **kwargs):
+            return {"content": {"language_info": {}}}
+
+        def preprocess_cell(self, cell, resources, index):
+            return cell, resources
+
+        def set_widgets_metadata(self):
+            pass
+
+    preprocessor = RecordingExecutePreprocessor()
+    preprocessor.kernel_manager_class = RecordingKernelManager
+    resources = {"metadata": {"path": ""}}
+
+    for kernel_name in ("python3", "julia"):
+        notebook = nbformat.v4.new_notebook(
+            metadata={
+                "kernelspec": {"name": kernel_name, "display_name": kernel_name},
+            }
+        )
+        preprocessor.preprocess(notebook, resources=resources)
+
+    assert RecordingKernelManager.requested_kernel_names == ["python3", "julia"]


### PR DESCRIPTION
## Summary

When --execute converts multiple notebooks, the shared ExecutePreprocessor can retain the first notebook’s inferred kernel name. Reset the kernel name to the value configured at construction before each preprocessing run so kernel inference follows each notebook’s kernelspec.

Adds a regression test that runs two notebooks with different kernelspec names and verifies both kernel managers receive the correct name.

Fixes #1235

## Validation

- uv run pytest tests/preprocessors/test_execute.py -q — 6 passed
- uv run pytest tests/test_nbconvertapp.py::TestNbConvertApp::test_execute_multiple_notebooks -q — passed
- uv run ruff check nbconvert/preprocessors/execute.py tests/preprocessors/test_execute.py
- uv run ruff format --check nbconvert/preprocessors/execute.py tests/preprocessors/test_execute.py
- git diff --check

The repository pre-commit hook could not finish locally because its Prettier environment hit npm EALLOWGIT; the direct Ruff and test checks above passed.

This contribution was prepared with Codex (GPT-5) assistance and reviewed before publication.