### PR TITLE
Drop bleach dependency in favor of nh3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/nbconvert/filters/strings.py
+++ b/nbconvert/filters/strings.py
@@ -15,12 +15,15 @@ import warnings
 from urllib.parse import quote
 from xml.etree.ElementTree import Element
 
-import bleach
-
 # defusedxml does safe(r) parsing of untrusted XML data
 from defusedxml import ElementTree
 
-from nbconvert.preprocessors.sanitize import _get_default_css_sanitizer
+from nbconvert.preprocessors.sanitize import (
+    ALLOWED_ATTRIBUTES,
+    ALLOWED_STYLES,
+    ALLOWED_TAGS,
+    sanitize_html,
+)
 
 __all__ = [
     "add_anchor",
@@ -83,18 +86,16 @@ def html2text(element):
 def clean_html(element):
     """Clean an html element."""
     element = element.decode() if isinstance(element, bytes) else str(element)
-    kwargs = {}
-    css_sanitizer = _get_default_css_sanitizer()
-    if css_sanitizer:
-        kwargs["css_sanitizer"] = css_sanitizer
-    return bleach.clean(
+    return sanitize_html(
         element,
-        tags=[*bleach.ALLOWED_TAGS, "div", "pre", "code", "span", "table", "tr", "td"],
+        tags=[*ALLOWED_TAGS, "div", "pre", "code", "span", "table", "tr", "td"],
         attributes={
-            **bleach.ALLOWED_ATTRIBUTES,
+            **ALLOWED_ATTRIBUTES,
             "*": ["class", "id"],
         },
-        **kwargs,
+        styles=ALLOWED_STYLES,
+        strip=False,
+        strip_comments=True,
     )
 
 

--- a/nbconvert/preprocessors/sanitize.py
+++ b/nbconvert/preprocessors/sanitize.py
@@ -5,8 +5,15 @@ NBConvert Preprocessor for sanitizing HTML rendering of notebooks.
 from collections.abc import Mapping
 from html import escape
 from html.parser import HTMLParser
+from importlib import import_module
+from typing import Any as TypingAny
 
-import nh3
+nh3: TypingAny = None
+try:  # pragma: no cover - the fallback is only possible in partial tooling environments
+    nh3 = import_module("nh3")
+except ModuleNotFoundError:
+    pass
+
 from traitlets import Any, Bool, List, Set, Unicode
 
 from .base import Preprocessor
@@ -150,7 +157,7 @@ def _attribute_configuration(attributes):
             if callable(allowed):
                 # nh3 needs a candidate allowlist before it invokes the
                 # callback.  Its default set covers the standard HTML attrs.
-                normalized[tag] = set(nh3.ALLOWED_ATTRIBUTES.get(tag, set()))
+                normalized[tag] = set(ALLOWED_ATTRIBUTES.get(tag, ()))
             elif isinstance(allowed, str):
                 normalized[tag] = {allowed}
             else:
@@ -165,14 +172,15 @@ def _attribute_configuration(attributes):
                 candidates.append(attributes["*"])
             if tag in attributes:
                 candidates.append(attributes[tag])
-            for allowed in candidates:
-                if callable(allowed):
-                    if allowed(tag, attr, value):
+            for allowed_value in candidates:
+                if callable(allowed_value):
+                    if allowed_value(tag, attr, value):
                         return value
                 else:
-                    if isinstance(allowed, str):
-                        allowed = {allowed}
-                    if attr in (allowed or ()):
+                    allowed_attrs = (
+                        {allowed_value} if isinstance(allowed_value, str) else allowed_value
+                    )
+                    if attr in (allowed_attrs or ()):
                         return value
             return None
 
@@ -183,6 +191,10 @@ def _attribute_configuration(attributes):
 
 def sanitize_html(html_str, *, tags, attributes, styles, strip, strip_comments):
     """Sanitize HTML with nh3 while retaining nbconvert's Bleach semantics."""
+    if nh3 is None:
+        msg = "nbconvert's HTML sanitizer requires the nh3 dependency"
+        raise ImportError(msg)
+
     if not strip:
         html_str = _escape_disallowed_tags(html_str, tags)
 
@@ -212,13 +224,13 @@ class SanitizeHTML(Preprocessor):
     tags = List(
         Unicode(),
         config=True,
-        default_value=ALLOWED_TAGS,  # type:ignore[arg-type]
+        default_value=ALLOWED_TAGS,
         help="List of HTML tags to allow",
     )
     styles = List(
         Unicode(),
         config=True,
-        default_value=ALLOWED_STYLES,  # type:ignore[arg-type]
+        default_value=ALLOWED_STYLES,
         help="Allowed CSS styles if <style> tag is allowed",
     )
     strip = Bool(

--- a/nbconvert/preprocessors/sanitize.py
+++ b/nbconvert/preprocessors/sanitize.py
@@ -8,15 +8,15 @@ from html.parser import HTMLParser
 from importlib import import_module
 from typing import Any as TypingAny
 
+from traitlets import Any, Bool, List, Set, Unicode
+
+from .base import Preprocessor
+
 nh3: TypingAny = None
 try:  # pragma: no cover - the fallback is only possible in partial tooling environments
     nh3 = import_module("nh3")
 except ModuleNotFoundError:
     pass
-
-from traitlets import Any, Bool, List, Set, Unicode
-
-from .base import Preprocessor
 
 # Keep the public defaults compatible with Bleach while using nh3 for the
 # actual sanitization.  nh3's defaults are intentionally broader than

--- a/nbconvert/preprocessors/sanitize.py
+++ b/nbconvert/preprocessors/sanitize.py
@@ -2,47 +2,202 @@
 NBConvert Preprocessor for sanitizing HTML rendering of notebooks.
 """
 
-import warnings
+from collections.abc import Mapping
+from html import escape
+from html.parser import HTMLParser
 
-from bleach import ALLOWED_ATTRIBUTES, ALLOWED_TAGS, clean
+import nh3
 from traitlets import Any, Bool, List, Set, Unicode
 
 from .base import Preprocessor
 
-_USE_BLEACH_CSS_SANITIZER = False
-_USE_BLEACH_STYLES = False
-
-
-try:
-    # bleach[css] >=5.0
-    from bleach.css_sanitizer import ALLOWED_CSS_PROPERTIES as ALLOWED_STYLES
-    from bleach.css_sanitizer import CSSSanitizer
-
-    _USE_BLEACH_CSS_SANITIZER = True
-    _USE_BLEACH_STYLES = False
-except ImportError:
-    try:
-        # bleach <5
-        from bleach import ALLOWED_STYLES  # type:ignore[attr-defined, no-redef]
-
-        _USE_BLEACH_CSS_SANITIZER = False
-        _USE_BLEACH_STYLES = True
-        warnings.warn(
-            "Support for bleach <5 will be removed in a future version of nbconvert",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    except ImportError:
-        warnings.warn(
-            "The installed bleach/tinycss2 do not provide CSS sanitization, "
-            "please upgrade to bleach >=5",
-            UserWarning,
-            stacklevel=2,
-        )
+# Keep the public defaults compatible with Bleach while using nh3 for the
+# actual sanitization.  nh3's defaults are intentionally broader than
+# Bleach's, so relying on them would silently change the HTML allowlist.
+ALLOWED_TAGS = {
+    "a",
+    "abbr",
+    "acronym",
+    "b",
+    "blockquote",
+    "code",
+    "em",
+    "i",
+    "li",
+    "ol",
+    "strong",
+    "ul",
+}
+ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title"],
+    "abbr": ["title"],
+    "acronym": ["title"],
+}
+ALLOWED_STYLES = {
+    "azimuth",
+    "background-color",
+    "border-bottom-color",
+    "border-collapse",
+    "border-color",
+    "border-left-color",
+    "border-right-color",
+    "border-top-color",
+    "clear",
+    "color",
+    "cursor",
+    "direction",
+    "display",
+    "elevation",
+    "float",
+    "font",
+    "font-family",
+    "font-size",
+    "font-style",
+    "font-variant",
+    "font-weight",
+    "height",
+    "letter-spacing",
+    "line-height",
+    "overflow",
+    "pause",
+    "pause-after",
+    "pause-before",
+    "pitch",
+    "pitch-range",
+    "richness",
+    "speak",
+    "speak-header",
+    "speak-numeral",
+    "speak-punctuation",
+    "speech-rate",
+    "stress",
+    "text-align",
+    "text-decoration",
+    "text-indent",
+    "vertical-align",
+    "voice-family",
+    "volume",
+    "white-space",
+    "width",
+    "unicode-bidi",
+}
 
 
 __all__ = ["SanitizeHTML"]
+
+
+class _TagEscaper(HTMLParser):
+    """Escape disallowed tags so nh3 can reproduce Bleach's strip=False mode."""
+
+    def __init__(self, allowed_tags):
+        super().__init__(convert_charrefs=False)
+        self.allowed_tags = {tag.lower() for tag in allowed_tags}
+        self.parts = []
+
+    def handle_starttag(self, tag, attrs):
+        source = self.get_starttag_text() or f"<{tag}>"
+        self.parts.append(source if tag.lower() in self.allowed_tags else escape(source))
+
+    def handle_startendtag(self, tag, attrs):
+        source = self.get_starttag_text() or f"<{tag} />"
+        self.parts.append(source if tag.lower() in self.allowed_tags else escape(source))
+
+    def handle_endtag(self, tag):
+        source = f"</{tag}>"
+        self.parts.append(source if tag.lower() in self.allowed_tags else escape(source))
+
+    def handle_data(self, data):
+        self.parts.append(data)
+
+    def handle_entityref(self, name):
+        self.parts.append(f"&{name};")
+
+    def handle_charref(self, name):
+        self.parts.append(f"&#{name};")
+
+    def handle_comment(self, data):
+        self.parts.append(f"<!--{data}-->")
+
+    def handle_decl(self, decl):
+        self.parts.append(escape(f"<!{decl}>"))
+
+    def unknown_decl(self, data):
+        self.parts.append(escape(f"<![{data}]>"))
+
+    def handle_pi(self, data):
+        self.parts.append(escape(f"<?{data}>"))
+
+    def result(self):
+        return "".join(self.parts)
+
+
+def _escape_disallowed_tags(html_str, tags):
+    parser = _TagEscaper(tags)
+    parser.feed(html_str)
+    parser.close()
+    return parser.result()
+
+
+def _attribute_configuration(attributes):
+    """Convert Bleach's flexible attribute config to nh3's callback API."""
+
+    if callable(attributes):
+        return None, lambda tag, attr, value: value if attributes(tag, attr, value) else None
+
+    if isinstance(attributes, Mapping):
+        normalized = {}
+        for tag, allowed in attributes.items():
+            if callable(allowed):
+                # nh3 needs a candidate allowlist before it invokes the
+                # callback.  Its default set covers the standard HTML attrs.
+                normalized[tag] = set(nh3.ALLOWED_ATTRIBUTES.get(tag, set()))
+            elif isinstance(allowed, str):
+                normalized[tag] = {allowed}
+            else:
+                normalized[tag] = set(allowed or ())
+    else:
+        normalized = {"*": set(attributes or ())}
+
+    def filter_mapping(tag, attr, value):
+        if isinstance(attributes, Mapping):
+            candidates = []
+            if "*" in attributes:
+                candidates.append(attributes["*"])
+            if tag in attributes:
+                candidates.append(attributes[tag])
+            for allowed in candidates:
+                if callable(allowed):
+                    if allowed(tag, attr, value):
+                        return value
+                else:
+                    if isinstance(allowed, str):
+                        allowed = {allowed}
+                    if attr in (allowed or ()):
+                        return value
+            return None
+
+        return value if attr in normalized["*"] else None
+
+    return normalized, filter_mapping
+
+
+def sanitize_html(html_str, *, tags, attributes, styles, strip, strip_comments):
+    """Sanitize HTML with nh3 while retaining nbconvert's Bleach semantics."""
+    if not strip:
+        html_str = _escape_disallowed_tags(html_str, tags)
+
+    attribute_config, attribute_filter = _attribute_configuration(attributes)
+    return nh3.clean(
+        html_str,
+        tags=set(tags),
+        # Bleach strips unsafe tags but keeps their contents in both modes.
+        clean_content_tags=set(),
+        attributes=attribute_config,
+        attribute_filter=attribute_filter,
+        strip_comments=strip_comments,
+        link_rel=None,
+        filter_style_properties=set(styles),
+    )
 
 
 class SanitizeHTML(Preprocessor):
@@ -96,7 +251,7 @@ class SanitizeHTML(Preprocessor):
             "text/html",
             "text/markdown",
         },
-        help="Cell output types to display after escaping with Bleach.",
+        help="Cell output types to display after sanitizing with nh3.",
     )
 
     def preprocess_cell(self, cell, resources, cell_index):
@@ -157,23 +312,15 @@ class SanitizeHTML(Preprocessor):
         """
         Sanitize a string containing raw HTML tags.
         """
-        kwargs = {
-            "tags": self.tags,
-            "attributes": self.attributes,
-            "strip": self.strip,
-            "strip_comments": self.strip_comments,
-        }
-
-        if _USE_BLEACH_CSS_SANITIZER:
-            css_sanitizer = CSSSanitizer(allowed_css_properties=self.styles)
-            kwargs.update(css_sanitizer=css_sanitizer)
-        elif _USE_BLEACH_STYLES:
-            kwargs.update(styles=self.styles)
-
-        return clean(html_str, **kwargs)
+        return sanitize_html(
+            html_str,
+            tags=self.tags,
+            attributes=self.attributes,
+            styles=self.styles,
+            strip=self.strip,
+            strip_comments=self.strip_comments,
+        )
 
 
 def _get_default_css_sanitizer():
-    if _USE_BLEACH_CSS_SANITIZER:
-        return CSSSanitizer(allowed_css_properties=ALLOWED_STYLES)
-    return None
+    return set(ALLOWED_STYLES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ urls = {Homepage = "https://jupyter.org"}
 requires-python = ">=3.9"
 dependencies = [
     "beautifulsoup4",
-    "bleach[css]!=5.0.0",
+    "nh3>=0.3.0",
     "defusedxml",
     "importlib_metadata>=3.6;python_version<\"3.10\"",
     "jinja2>=3.0",

--- a/tests/preprocessors/test_sanitize.py
+++ b/tests/preprocessors/test_sanitize.py
@@ -126,7 +126,7 @@ class TestSanitizer(PreprocessorTestsBase):
                 "few</em> <script>tags</script>",
                 preprocessor,
             ),
-            '_A_ <em style="color: blue;">few</em> &lt;script&gt;tags&lt;/script&gt;',
+            '_A_ <em style="color:blue">few</em> &lt;script&gt;tags&lt;/script&gt;',
         )
 
     def test_tag_passthrough(self):


### PR DESCRIPTION
Closes #2289

## Summary
- replace the archived `bleach[css]` runtime dependency with `nh3>=0.3.0`
- preserve nbconvert's explicit Bleach tag, attribute, CSS-property, comment, and strip-mode configuration while delegating sanitization to nh3
- keep `clean_html` on the same shared sanitizer path and cover the nh3 CSS serialization in the existing sanitizer test

## Validation
- `uv run --python 3.9 --with 'nh3>=0.3.0' --with pytest --with ipython python3 -m pytest -q tests/preprocessors/test_sanitize.py tests/filters/test_strings.py` — **23 passed**
- `uv run --with ruff ruff check nbconvert/preprocessors/sanitize.py` — **All checks passed**
- `uv run --with ruff ruff format --check nbconvert/preprocessors/sanitize.py nbconvert/filters/strings.py tests/preprocessors/test_sanitize.py` — **formatted**
- `git diff --check` — **passed**

The full repository suite was not used as the acceptance gate because a source-checkout run lacks the packaged template data and fails before these changes are exercised; the focused sanitizer/filter suite passes on the project's minimum Python version.