### PR TITLE
Add opt-in show_output trait to stream cell output during execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/preprocessors/execute.py
+++ b/nbconvert/preprocessors/execute.py
@@ -6,6 +6,7 @@ and updates outputs"""
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from warnings import warn
 
@@ -16,6 +17,7 @@ from nbclient.client import execute as _execute
 # Backwards compatibility for imported name
 from nbclient.exceptions import CellExecutionError  # noqa: F401
 from nbformat import NotebookNode
+from traitlets import Bool
 
 from .base import Preprocessor
 
@@ -39,6 +41,12 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
     """
     Executes all the cells in a notebook
     """
+
+    show_output = Bool(
+        False,
+        help="If True, stream each cell's stdout/stderr to the console as it executes, "
+        "in addition to storing it in the notebook.",
+    ).tag(config=True)
 
     def __init__(self, **kw):
         """Initialize the preprocessor."""
@@ -123,3 +131,11 @@ class ExecutePreprocessor(Preprocessor, NotebookClient):
         self._check_assign_resources(resources)
         cell = self.execute_cell(cell, index, store_history=True)
         return cell, self.resources
+
+    def output(self, outs, msg, display_id, cell_index):
+        """Handle a cell output, streaming it live when ``show_output`` is set."""
+        out = super().output(outs, msg, display_id, cell_index)
+        if self.show_output and out is not None and out.get("output_type") == "stream":
+            stream = sys.stderr if out.get("name") == "stderr" else sys.stdout
+            print(out.get("text", ""), end="", file=stream, flush=True)
+        return out

--- a/tests/preprocessors/test_execute.py
+++ b/tests/preprocessors/test_execute.py
@@ -86,6 +86,24 @@ def test_populate_language_info():
     assert "language_info" in nb.metadata  # See that a basic attribute is filled in
 
 
+def test_show_output_streams_to_console(capsys):
+    preprocessor = ExecutePreprocessor(show_output=True)
+    fname = os.path.join(os.path.dirname(__file__), "files", "HelloWorld.ipynb")
+    with open(fname) as f:
+        input_nb = nbformat.read(f, 4)
+        preprocessor.preprocess(deepcopy(input_nb))
+    assert "Hello World" in capsys.readouterr().out
+
+
+def test_show_output_disabled_by_default(capsys):
+    preprocessor = ExecutePreprocessor()
+    fname = os.path.join(os.path.dirname(__file__), "files", "HelloWorld.ipynb")
+    with open(fname) as f:
+        input_nb = nbformat.read(f, 4)
+        preprocessor.preprocess(deepcopy(input_nb))
+    assert "Hello World" not in capsys.readouterr().out
+
+
 def test_preprocess_cell():
     class CellReplacer(ExecutePreprocessor):
         def preprocess_cell(self, cell, resources, index, **kwargs):


### PR DESCRIPTION
Refs #2212.

## Problem

`nbconvert --execute` (and `ExecutePreprocessor` generally) swallows all cell stdout/stderr, so a long-running notebook looks hung with no way to see progress. papermill's `--log-output` shows this is doable via nbclient's output hook.

## Change

Add a Bool trait `ExecutePreprocessor.show_output` (default `False`, no behavior change). When set, each stream output is printed live to `sys.stdout`/`sys.stderr` as cells run, by overriding nbclient's `output()` hook.

## Tests

`tests/preprocessors/test_execute.py`:
- `test_show_output_streams_to_console`: with `show_output=True`, a cell's stream output is printed live.
- `test_show_output_disabled_by_default`: default is silent (no behavior change).

Both pass; the first fails on `main` (no such trait). Opt-in only, so existing behavior is unchanged.