### PR TITLE
Fix codespell and blacken-docs failures in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 
@@ -1704,6 +1704,7 @@ class AttrExporter(TemplateExporter):
 raw template
 {%- endblock in_prompt -%}
     """
+
 
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)


### PR DESCRIPTION
pre-commit.ci runs with `--all-files`, so these two failures currently show up on every open pull request, not just one that touches `CHANGELOG.md`. As of now they red #2290, #2294, #2299 and #2301.

Two fixes, both in `CHANGELOG.md`:

- **codespell** — `configureable` → `configurable` (line 18). That entry is generated from the title of #2250, so the typo can only be corrected here.
- **blacken-docs** — a Python block in the 5.6.1 section was missing the blank line black requires before a top-level statement.

### Verification

Run against the versions pinned in `.pre-commit-config.yaml`, not whatever was newest:

| hook | pinned version | before | after |
|---|---|---|---|
| `codespell` | 2.4.2, `-L sur,nd,assertin` | exit 65 | exit 0 |
| `blacken-docs` | 1.20.0 + `black==23.7.0` | exit 1 | exit 0 |
| `mdformat` | 1.0.0 | clean | clean, file unchanged |

Also checked that the edited lines carry no trailing whitespace and the file still ends in a single newline, so `trailing-whitespace` and `end-of-file-fixer` stay happy.

No code or behaviour changes.