### PR TITLE
FIX strip ANSI escape codes from Markdown streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/share/templates/markdown/index.md.j2
+++ b/share/templates/markdown/index.md.j2
@@ -34,7 +34,7 @@
 {% endblock execute_result %}
 
 {% block stream %}
-{{ output.text | indent }}
+{{ output.text | indent | strip_ansi }}
 {% endblock stream %}
 
 {% block data_svg %}

--- a/tests/exporters/test_markdown.py
+++ b/tests/exporters/test_markdown.py
@@ -13,6 +13,7 @@
 # -----------------------------------------------------------------------------
 
 from nbconvert.exporters.markdown import MarkdownExporter
+from nbformat import v4
 
 from .base import ExportersTestsBase
 
@@ -39,3 +40,18 @@ class TestMarkdownExporter(ExportersTestsBase):
         """
         (output, _resources) = MarkdownExporter().from_filename(self._get_notebook())
         assert len(output) > 0
+
+    def test_stream_ansi_is_stripped(self):
+        """ANSI escape codes in stream output are not emitted as Markdown."""
+        notebook = v4.new_notebook(
+            cells=[
+                v4.new_code_cell(
+                    outputs=[v4.new_output("stream", text="\x1b[31mred\x1b[0m\n")]
+                )
+            ]
+        )
+
+        output, _resources = MarkdownExporter().from_notebook_node(notebook)
+
+        assert "\x1b[" not in output
+        assert "red" in output

--- a/tests/exporters/test_markdown.py
+++ b/tests/exporters/test_markdown.py
@@ -12,8 +12,9 @@
 # Imports
 # -----------------------------------------------------------------------------
 
-from nbconvert.exporters.markdown import MarkdownExporter
 from nbformat import v4
+
+from nbconvert.exporters.markdown import MarkdownExporter
 
 from .base import ExportersTestsBase
 
@@ -44,11 +45,7 @@ class TestMarkdownExporter(ExportersTestsBase):
     def test_stream_ansi_is_stripped(self):
         """ANSI escape codes in stream output are not emitted as Markdown."""
         notebook = v4.new_notebook(
-            cells=[
-                v4.new_code_cell(
-                    outputs=[v4.new_output("stream", text="\x1b[31mred\x1b[0m\n")]
-                )
-            ]
+            cells=[v4.new_code_cell(outputs=[v4.new_output("stream", text="\x1b[31mred\x1b[0m\n")])]
         )
 
         output, _resources = MarkdownExporter().from_notebook_node(notebook)


### PR DESCRIPTION
Closes #1989

Markdown already strips ANSI escape codes from traceback lines, but stream output still emitted them verbatim. Apply the existing `strip_ansi` filter to Markdown stream output and add a regression test.

Tested with `uv run --extra test pytest -q tests/exporters/test_markdown.py`.