### PR TITLE
Fix WebPDF Playwright event loop on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/exporters/webpdf.py
+++ b/nbconvert/exporters/webpdf.py
@@ -19,6 +19,17 @@ PLAYWRIGHT_INSTALLED = importlib_util.find_spec("playwright") is not None
 IS_WINDOWS = os.name == "nt"
 
 
+def _run_coroutine(coro):
+    """Run a coroutine on an event loop compatible with Playwright."""
+    if IS_WINDOWS and hasattr(asyncio, "ProactorEventLoop"):
+        loop = asyncio.ProactorEventLoop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+    return asyncio.run(coro)
+
+
 class WebPDFExporter(HTMLExporter):
     """Writer designed to write to PDF files.
 
@@ -179,7 +190,7 @@ class WebPDFExporter(HTMLExporter):
         with temp_file:
             temp_file.write(html.encode("utf-8"))
         try:
-            pdf_data = pool.submit(asyncio.run, main(temp_file)).result()
+            pdf_data = pool.submit(_run_coroutine, main(temp_file)).result()
         finally:
             # Ensure the file is deleted even if playwright raises an exception
             os.unlink(temp_file.name)

--- a/tests/exporters/test_webpdf.py
+++ b/tests/exporters/test_webpdf.py
@@ -4,12 +4,16 @@
 # Distributed under the terms of the Modified BSD License.
 
 import builtins
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from nbconvert.exporters.exporter import Exporter
-from nbconvert.exporters.webpdf import PLAYWRIGHT_INSTALLED, WebPDFExporter
+from nbconvert.exporters.webpdf import (
+    PLAYWRIGHT_INSTALLED,
+    WebPDFExporter,
+    _run_coroutine,
+)
 
 from .base import ExportersTestsBase
 
@@ -18,6 +22,33 @@ real_import = builtins.__import__
 
 class FakeBrowser:
     executable_path: str = ""
+
+
+def test_run_coroutine_uses_asyncio_run_off_windows():
+    coro = object()
+    with (
+        patch("nbconvert.exporters.webpdf.IS_WINDOWS", False),
+        patch("nbconvert.exporters.webpdf.asyncio.run", return_value="done") as run,
+    ):
+        assert _run_coroutine(coro) == "done"
+        run.assert_called_once_with(coro)
+
+
+def test_run_coroutine_uses_proactor_loop_on_windows():
+    coro = object()
+    loop = Mock()
+    loop.run_until_complete.return_value = "done"
+    with (
+        patch("nbconvert.exporters.webpdf.IS_WINDOWS", True),
+        patch(
+            "nbconvert.exporters.webpdf.asyncio.ProactorEventLoop",
+            return_value=loop,
+            create=True,
+        ),
+    ):
+        assert _run_coroutine(coro) == "done"
+        loop.run_until_complete.assert_called_once_with(coro)
+        loop.close.assert_called_once_with()
 
 
 def monkey_import_notfound(name, globals_ctx=None, locals_ctx=None, fromlist=(), level=0):


### PR DESCRIPTION
Fixes #2287

## Summary
- use a Proactor event loop for WebPDF's Playwright coroutine on Windows
- keep asyncio.run on other platforms
- add unit coverage for both loop paths

## Testing
Not run locally; draft PR for CI validation.

<!-- pr-relay-job relay-84-8dd2cfdcbcbf4f40adcb -->