### PR TITLE
fix: preserve extensionless notebook names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -425,7 +425,8 @@ class NbConvertApp(JupyterApp):
         applying `output_base` pattern and stripping extension
         """
         basename = os.path.basename(notebook_filename)
-        notebook_name = basename[: basename.rfind(".")]
+        stem, extension = os.path.splitext(basename)
+        notebook_name = stem if extension else basename
         notebook_name = self.output_base.format(notebook_name=notebook_name)
 
         return notebook_name  # noqa: RET504

--- a/tests/test_nbconvertapp.py
+++ b/tests/test_nbconvertapp.py
@@ -11,6 +11,7 @@ import pytest
 from traitlets.tests.utils import check_help_all_output
 
 from nbconvert.exporters import HTMLExporter
+from nbconvert.nbconvertapp import NbConvertApp
 from nbconvert.postprocessors import PostProcessorBase
 
 from .base import TestsBase
@@ -38,6 +39,12 @@ class TestNbConvertApp(TestsBase):
     def test_help_output(self):
         """ipython nbconvert --help-all works"""
         check_help_all_output("nbconvert")
+
+    def test_notebook_filename_to_name_without_extension(self):
+        app = NbConvertApp()
+
+        assert app._notebook_filename_to_name("test") == "test"
+        assert app._notebook_filename_to_name("report.v1.ipynb") == "report.v1"
 
     def test_glob(self):
         """


### PR DESCRIPTION
Closes #2119

## Summary
- Use `os.path.splitext()` when deriving the notebook basename so files without a suffix keep their final character. Adds direct regression coverage for extensionless and multi-dot names.
- keep the change narrowly scoped to the reported behavior
- add focused regression coverage

## Validation
- checked the reported failure against current `main`
- patch is based on current `main`
- full repository tests should run in CI

<!-- pr-relay-job relay-94-b2a685171ea2f7128009 -->