### PR TITLE
fix: accept Pandoc image alt metadata in LaTeX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/share/templates/latex/base.tex.j2
+++ b/share/templates/latex/base.tex.j2
@@ -18,6 +18,10 @@ override this.-=))
     % Basic figure setup, for now with no caption control since it's done
     % automatically by Pandoc (which extracts ![](path) syntax from Markdown).
     \usepackage{graphicx}
+    % Pandoc may emit alt={...} for images. Treat it as metadata so graphicx
+    % and adjustbox do not reject otherwise valid images.
+    \makeatletter\define@key{Gin}{alt}{}\makeatother
+
     % Keep aspect ratio if custom image width or height is specified
     \setkeys{Gin}{keepaspectratio}
     % Maintain compatibility with old templates. Remove in nbconvert 6.0

--- a/tests/exporters/test_latex.py
+++ b/tests/exporters/test_latex.py
@@ -50,6 +50,12 @@ class TestLatexExporter(ExportersTestsBase):
         )
         assert len(output) > 0
 
+    def test_graphics_alt_key_is_defined(self):
+        """Pandoc image alt metadata should be accepted by the LaTeX preamble."""
+        output, _resources = LatexExporter().from_notebook_node(v4.new_notebook())
+
+        assert r"\define@key{Gin}{alt}{}" in output
+
     @onlyif_cmds_exist("pandoc")
     def test_very_long_cells(self):
         """


### PR DESCRIPTION
Closes #2275

## Summary
- Define a no-op `Gin` `alt` key so Pandoc-generated `alt={...}` image metadata is accepted by graphicx/adjustbox instead of failing PDF compilation. Adds a template regression check; the shim was also sanity-compiled with pdflatex.
- keep the change narrowly scoped to the reported behavior
- add focused regression coverage

## Validation
- checked the reported failure against current `main`
- patch is based on current `main`
- full repository tests should run in CI

<!-- pr-relay-job relay-95-90e6e371e66b566ee262 -->