### PR TITLE
fix: preserve explicit output file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -519,6 +519,10 @@ class NbConvertApp(JupyterApp):
         notebook_name = resources["unique_key"]
         if self.use_output_suffix and self.output_base == "{notebook_name}":
             notebook_name += resources.get("output_suffix", "")
+        if os.path.splitext(self.output_base)[1]:
+            # An explicit output suffix is already part of notebook_name.
+            resources = resources.copy()
+            resources["output_extension"] = ""
 
         if not self.writer:
             msg = "No writer object defined!"

--- a/tests/test_nbconvertapp.py
+++ b/tests/test_nbconvertapp.py
@@ -226,6 +226,16 @@ class TestNbConvertApp(TestsBase):
             self.nbconvert("--log-level 0 --to python notebook1.ipynb --output nb2")
             assert os.path.exists("nb2.py")
 
+    def test_output_ext_script_exporter(self):
+        """Explicit --output extensions are not duplicated by ScriptExporter."""
+        with self.create_temp_cwd(["notebook1.ipynb"]):
+            self.nbconvert("--log-level 0 --to script notebook1.ipynb --output nb.py")
+            assert os.path.exists("nb.py")
+            assert not os.path.exists("nb.py.py")
+
+            self.nbconvert("--log-level 0 --to script notebook1.ipynb --output nb.txt")
+            assert os.path.exists("nb.txt")
+
     def test_glob_explicit(self):
         """
         Can a search pattern be used along with matching explicit notebook names?


### PR DESCRIPTION
Fixes #1629

Treats an explicit --output filename with an extension as complete, including dynamically determined ScriptExporter extensions, while preserving extension inference for extensionless output names.

Tests: focused pytest regression (2 passed); changed Python module compiles cleanly.

<!-- pr-relay-job relay-106-48bdaf92bb2f3314cb18 -->