### PR TITLE
fix: handle non-string LaTeX date metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/share/templates/latex/base.tex.j2
+++ b/share/templates/latex/base.tex.j2
@@ -203,7 +203,7 @@ override this.-=))
     ((*- endblock title *))
     ((* block date *))
     ((* if 'date' in nb.metadata *))
-    \date{((( nb.metadata.date | escape_latex )))}
+    \date{((( nb.metadata.date | string | escape_latex )))}
     ((* endif *))
     ((* endblock date *))
     ((* block author *))

--- a/tests/exporters/test_latex.py
+++ b/tests/exporters/test_latex.py
@@ -50,6 +50,13 @@ class TestLatexExporter(ExportersTestsBase):
         )
         assert len(output) > 0
 
+    def test_numeric_date_metadata(self):
+        """Numeric date metadata should be rendered rather than crashing."""
+        nb = v4.new_notebook(metadata={"date": 1.23})
+        output, _resources = LatexExporter().from_notebook_node(nb)
+
+        assert r"\date{1.23}" in output
+
     @onlyif_cmds_exist("pandoc")
     def test_very_long_cells(self):
         """


### PR DESCRIPTION
Fixes #2109

Coerces notebook date metadata to a string before LaTeX escaping so numeric dates no longer crash export.

Tests: focused pytest regression (2 passed).

<!-- pr-relay-job relay-109-65189f2bcb56db72fc52 -->