### PR TITLE
fix: normalize RST image paths on Windows 🤖🍆 (#765)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/share/templates/rst/index.rst.j2
+++ b/share/templates/rst/index.rst.j2
@@ -49,11 +49,11 @@
 {% endblock data_native %}
 
 {% block data_svg %}
-.. image:: {{ output.metadata.filenames['image/svg+xml'] | urlencode }}
+.. image:: {{ output.metadata.filenames['image/svg+xml'] | posix_path | urlencode }}
 {% endblock data_svg %}
 
 {% block data_png %}
-.. image:: {{ output.metadata.filenames['image/png'] | urlencode }}
+.. image:: {{ output.metadata.filenames['image/png'] | posix_path | urlencode }}
 {%- set width=output | get_metadata('width', 'image/png') -%}
 {%- if width is not none %}
    :width: {{ width }}px
@@ -65,7 +65,7 @@
 {% endblock data_png %}
 
 {% block data_jpg %}
-.. image:: {{ output.metadata.filenames['image/jpeg'] | urlencode }}
+.. image:: {{ output.metadata.filenames['image/jpeg'] | posix_path | urlencode }}
 {%- set width=output | get_metadata('width', 'image/jpeg') -%}
 {%- if width is not none %}
    :width: {{ width }}px

--- a/tests/filters/test_strings.py
+++ b/tests/filters/test_strings.py
@@ -15,6 +15,7 @@ Module with tests for Strings
 # -----------------------------------------------------------------------------
 import os
 import re
+from unittest import mock
 
 from nbconvert.filters.strings import (
     add_anchor,
@@ -175,6 +176,11 @@ class TestStrings(TestsBase):
         native = os.path.join(*path_list)
         filtered = posix_path(native)
         self.assertEqual(filtered, expected)
+
+    def test_posix_path_windows(self):
+        """posix_path converts Windows separators when running on any platform"""
+        with mock.patch.object(os.path, "sep", "\\"):
+            self.assertEqual(posix_path(r"foo\bar"), "foo/bar")
 
     def test_add_prompts(self):
         """add_prompts test"""


### PR DESCRIPTION
🤖🍆

## Summary

- Normalize Windows path separators before URL encoding RST image references.
- Add a regression test for Windows-style separators.

Closes #765