### PR TITLE
fix: preserve explicit exporter with inplace 🤖🍆 (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -383,10 +383,8 @@ class NbConvertApp(JupyterApp):
     def _export_format_was_explicit(argv):
         """Return whether command-line arguments explicitly select a format."""
         return any(
-            argument == "--to"
-            or argument.startswith("--to=")
-            or argument == "--NbConvertApp.export_format"
-            or argument.startswith("--NbConvertApp.export_format=")
+            argument in ("--to", "--NbConvertApp.export_format")
+            or argument.startswith(("--to=", "--NbConvertApp.export_format="))
             for argument in argv
         )
 

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -99,12 +99,12 @@ nbconvert_flags.update(
             {
                 "NbConvertApp": {
                     "use_output_suffix": False,
-                    "export_format": "notebook",
+                    "inplace": True,
                 },
                 "FilesWriter": {"build_directory": ""},
             },
-            """Run nbconvert in place, overwriting the existing notebook (only
-        relevant when converting to notebook format)""",
+            """Run nbconvert in place, overwriting the existing notebook when
+        converting to notebook format""",
         ),
         "clear-output": (
             {
@@ -349,6 +349,11 @@ class NbConvertApp(JupyterApp):
                      Filenames passed positionally will be added to the list.
                      """,
     ).tag(config=True)
+
+    inplace = Bool(
+        False,
+        help="Run nbconvert in place, overwriting the existing notebook.",
+    ).tag(config=True)
     from_stdin = Bool(False, help="read a single notebook from stdin.").tag(config=True)
     recursive_glob = Bool(
         False, help="set the 'recursive' option for glob for searching wildcards."
@@ -361,13 +366,29 @@ class NbConvertApp(JupyterApp):
         if sys.platform.startswith("win"):
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
+        if argv is None:
+            argv = sys.argv[1:]
+
         self.init_syspath()
         super().initialize(argv)
         if hasattr(self, "load_config_environ"):
             self.load_config_environ()
+        if self.inplace and not self._export_format_was_explicit(argv):
+            self.export_format = "notebook"
         self.init_notebooks()
         self.init_writer()
         self.init_postprocessor()
+
+    @staticmethod
+    def _export_format_was_explicit(argv):
+        """Return whether command-line arguments explicitly select a format."""
+        return any(
+            argument == "--to"
+            or argument.startswith("--to=")
+            or argument == "--NbConvertApp.export_format"
+            or argument.startswith("--NbConvertApp.export_format=")
+            for argument in argv
+        )
 
     def init_syspath(self):
         """Add the cwd to the sys.path ($PYTHONPATH)"""

--- a/tests/fake_exporters.py
+++ b/tests/fake_exporters.py
@@ -6,6 +6,7 @@ nbconvert with full qualified name
 from traitlets import default
 
 from nbconvert.exporters.html import HTMLExporter
+from nbconvert.exporters.notebook import NotebookExporter
 
 
 class MyExporter(HTMLExporter):
@@ -23,3 +24,11 @@ class MyExporter(HTMLExporter):
     @default("template_extension")
     def _template_extension_default(self):
         return ".html.j2"
+
+
+class MyNotebookExporter(NotebookExporter):
+    """A notebook exporter that marks output to verify exporter selection."""
+
+    def from_notebook_node(self, nb, resources=None, **kw):
+        nb.metadata["custom_exporter"] = True
+        return super().from_notebook_node(nb, resources, **kw)

--- a/tests/test_nbconvertapp.py
+++ b/tests/test_nbconvertapp.py
@@ -328,6 +328,18 @@ class TestNbConvertApp(TestsBase):
             assert not os.path.isfile("empty.nbconvert.ipynb")
             assert not os.path.isfile("empty.html")
 
+    def test_inplace_respects_explicit_exporter(self):
+        """Verify that --inplace does not override an explicit --to option."""
+        with self.create_temp_cwd():
+            self.create_empty_notebook("empty.ipynb")
+            self.copy_files_to(["../fake_exporters.py"], "tests")
+            self.nbconvert(
+                "empty.ipynb --inplace --to tests.fake_exporters.MyNotebookExporter"
+            )
+            with open("empty.ipynb", encoding="utf-8") as f:
+                notebook = nbformat.read(f, 4)
+            assert notebook.metadata["custom_exporter"]
+
     def test_no_prompt(self):
         """
         Verify that the html has no prompts when given --no-prompt.

--- a/tests/test_nbconvertapp.py
+++ b/tests/test_nbconvertapp.py
@@ -333,9 +333,7 @@ class TestNbConvertApp(TestsBase):
         with self.create_temp_cwd():
             self.create_empty_notebook("empty.ipynb")
             self.copy_files_to(["../fake_exporters.py"], "tests")
-            self.nbconvert(
-                "empty.ipynb --inplace --to tests.fake_exporters.MyNotebookExporter"
-            )
+            self.nbconvert("empty.ipynb --inplace --to tests.fake_exporters.MyNotebookExporter")
             with open("empty.ipynb", encoding="utf-8") as f:
                 notebook = nbformat.read(f, 4)
             assert notebook.metadata["custom_exporter"]


### PR DESCRIPTION
🤖🍆

## Summary

- Keep `--inplace`'s notebook default only when no output format is selected.
- Add a regression test for a custom notebook exporter.

Closes #257