### PR TITLE
BUG: count only code cells for extracted outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/docs/source/nbconvert_library.ipynb
+++ b/docs/source/nbconvert_library.ipynb
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that base64 images are not embedded, but instead there are filename-like strings, such as `output_3_0.png`.  The strings actually are (configurable) keys that map to the binary data in the resources dict.\n",
+    "Notice that base64 images are not embedded, but instead there are filename-like strings, such as `output_0_0.png`.  The strings actually are (configurable) keys that map to the binary data in the resources dict.\n",
     "\n",
     "Note, if you write an RST Plugin, you are responsible for writing all the files to the disk (or uploading, etc...) in the right location.  Of course, the naming scheme is configurable.\n",
     "\n",
@@ -240,7 +240,7 @@
    "source": [
     "from IPython.display import Image\n",
     "\n",
-    "Image(data=resources[\"outputs\"][\"output_3_0.png\"], format=\"png\")"
+    "Image(data=resources[\"outputs\"][\"output_0_0.png\"], format=\"png\")"
    ]
   },
   {

--- a/nbconvert/preprocessors/extractoutput.py
+++ b/nbconvert/preprocessors/extractoutput.py
@@ -53,6 +53,16 @@ class ExtractOutputPreprocessor(Preprocessor):
         config=True
     )
 
+    def preprocess(self, nb, resources):
+        """Extract outputs using the code-cell index in generated filenames."""
+        code_cell_index = 0
+        for index, cell in enumerate(nb.cells):
+            cell_index = code_cell_index if cell.cell_type == "code" else index
+            nb.cells[index], resources = self.preprocess_cell(cell, resources, cell_index)
+            if cell.cell_type == "code":
+                code_cell_index += 1
+        return nb, resources
+
     def preprocess_cell(self, cell, resources, cell_index):
         """
         Apply a transformation on each cell,

--- a/tests/preprocessors/test_extractoutput.py
+++ b/tests/preprocessors/test_extractoutput.py
@@ -5,6 +5,8 @@
 
 import json
 
+from nbformat import v4 as nbformat
+
 from nbconvert.preprocessors.extractoutput import ExtractOutputPreprocessor
 
 from .base import PreprocessorTestsBase
@@ -84,3 +86,24 @@ class TestExtractOutput(PreprocessorTestsBase):
 
         # Verify equivalence of extracted outputs.
         self.assertEqual(sorted(outputs), sorted(reference_files))
+
+    def test_output_filename_uses_code_cell_index(self):
+        """Markdown cells should not change extracted output numbering."""
+        image = nbformat.new_output("display_data", data={"image/png": "Zw=="})
+        nb = nbformat.new_notebook(
+            cells=[
+                nbformat.new_markdown_cell(source="intro"),
+                nbformat.new_code_cell(outputs=[image]),
+                nbformat.new_markdown_cell(source="between"),
+                nbformat.new_code_cell(
+                    outputs=[nbformat.new_output("display_data", data={"image/png": "Zw=="})]
+                ),
+            ]
+        )
+        res = self.build_resources()
+        preprocessor = self.build_preprocessor()
+        nb, res = preprocessor(nb, res)
+
+        self.assertEqual(nb.cells[1].outputs[0].metadata.filenames["image/png"], "output_0_0.png")
+        self.assertEqual(nb.cells[3].outputs[0].metadata.filenames["image/png"], "output_1_0.png")
+        self.assertEqual(sorted(res["outputs"]), ["output_0_0.png", "output_1_0.png"])


### PR DESCRIPTION
Fixes #1316

## Summary
- count only code cells when assigning extracted output filenames
- keep markdown and raw cells from creating gaps in output names
- add a regression test for mixed cell types

## Validation
- `pytest tests/preprocessors/test_extractoutput.py`