### PR TITLE
SEC: add SRI hashes to CDN scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -109,6 +109,7 @@ class HTMLExporter(TemplateExporter):
     _default_require_js_integrity = "sha256-tpTnwzCp6VMSdSv3Apnsnt/MQh8OASQVQmy6Bsg1N+4="
     _default_mathjax_integrity = "sha256-kZafAc6mZvK3W3v1pHOcUix30OHQN6pU/NO2oFkqZVw="
     _default_jquery_integrity = "sha256-pXtSQrmprcTB74RsNlFHuJxHK5zXcPrOMx78uWU0ayU="
+    _enable_cdn_integrity = True
 
     anchor_link_text = Unicode("¶", help="The text used as the text for anchor links.").tag(
         config=True
@@ -403,9 +404,8 @@ class HTMLExporter(TemplateExporter):
         resources["should_not_encode_svg"] = self.skip_svg_encoding
         return resources
 
-    @staticmethod
-    def _get_cdn_integrity(url, default_url, default_integrity):
+    def _get_cdn_integrity(self, url, default_url, default_integrity):
         """Return a pinned hash only for the matching built-in CDN URL."""
-        if url == default_url:
+        if self._enable_cdn_integrity and url == default_url:
             return default_integrity
         return ""

--- a/nbconvert/exporters/html.py
+++ b/nbconvert/exporters/html.py
@@ -97,6 +97,19 @@ class HTMLExporter(TemplateExporter):
 
     export_from_notebook = "HTML"
 
+    _default_require_js_url = (
+        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"
+    )
+    _default_mathjax_url = (
+        "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML-full,"
+        "Safe"
+    )
+    _default_jquery_url = "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"
+
+    _default_require_js_integrity = "sha256-tpTnwzCp6VMSdSv3Apnsnt/MQh8OASQVQmy6Bsg1N+4="
+    _default_mathjax_integrity = "sha256-kZafAc6mZvK3W3v1pHOcUix30OHQN6pU/NO2oFkqZVw="
+    _default_jquery_integrity = "sha256-pXtSQrmprcTB74RsNlFHuJxHK5zXcPrOMx78uWU0ayU="
+
     anchor_link_text = Unicode("¶", help="The text used as the text for anchor links.").tag(
         config=True
     )
@@ -106,7 +119,7 @@ class HTMLExporter(TemplateExporter):
     )
 
     require_js_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js",
+        _default_require_js_url,
         help="""
         URL to load require.js from.
 
@@ -115,7 +128,7 @@ class HTMLExporter(TemplateExporter):
     ).tag(config=True)
 
     mathjax_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML-full,Safe",
+        _default_mathjax_url,
         help="""
         URL to load Mathjax from.
 
@@ -142,7 +155,7 @@ class HTMLExporter(TemplateExporter):
     )
 
     jquery_url = Unicode(
-        "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js",
+        _default_jquery_url,
         help="""
         URL to load jQuery from.
 
@@ -369,10 +382,19 @@ class HTMLExporter(TemplateExporter):
         resources["include_js"] = resources_include_js
         resources["include_url"] = resources_include_url
         resources["require_js_url"] = self.require_js_url
+        resources["require_js_integrity"] = self._get_cdn_integrity(
+            self.require_js_url, self._default_require_js_url, self._default_require_js_integrity
+        )
         resources["mathjax_url"] = self.mathjax_url
+        resources["mathjax_integrity"] = self._get_cdn_integrity(
+            self.mathjax_url, self._default_mathjax_url, self._default_mathjax_integrity
+        )
         resources["mermaid_js_url"] = self.mermaid_js_url
         resources["mermaid_layout_elk_js_url"] = self.mermaid_layout_elk_js_url
         resources["jquery_url"] = self.jquery_url
+        resources["jquery_integrity"] = self._get_cdn_integrity(
+            self.jquery_url, self._default_jquery_url, self._default_jquery_integrity
+        )
         resources["jupyter_widgets_base_url"] = self.jupyter_widgets_base_url
         resources["widget_renderer_url"] = self.widget_renderer_url
         resources["html_manager_semver_range"] = self.html_manager_semver_range
@@ -380,3 +402,10 @@ class HTMLExporter(TemplateExporter):
         resources["language_code"] = self.language_code
         resources["should_not_encode_svg"] = self.skip_svg_encoding
         return resources
+
+    @staticmethod
+    def _get_cdn_integrity(url, default_url, default_integrity):
+        """Return a pinned hash only for the matching built-in CDN URL."""
+        if url == default_url:
+            return default_integrity
+        return ""

--- a/nbconvert/exporters/qt_exporter.py
+++ b/nbconvert/exporters/qt_exporter.py
@@ -15,6 +15,9 @@ class QtExporter(HTMLExporter):
 
     paginate = None
     format = ""
+    # Qt renders the generated HTML from a file:// URL, which cannot load the
+    # CDN scripts when they use an explicit cross-origin request.
+    _enable_cdn_integrity = False
 
     @default("file_extension")
     def _file_extension_default(self):

--- a/share/templates/base/mathjax.html.j2
+++ b/share/templates/base/mathjax.html.j2
@@ -1,7 +1,7 @@
 
-{%- macro mathjax(url="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML-full,Safe") -%}
+{%- macro mathjax(url="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML-full,Safe", integrity="") -%}
     <!-- Load mathjax -->
-    <script src="{{url}}"> </script>
+    <script src="{{url}}"{% if integrity %} integrity="{{ integrity }}" crossorigin="anonymous"{% endif %}> </script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
     init_mathjax = function() {

--- a/share/templates/classic/index.html.j2
+++ b/share/templates/classic/index.html.j2
@@ -14,10 +14,10 @@
 
 {%- block html_head_js -%}
 {%- block html_head_js_jquery -%}
-<script src="{{ resources.jquery_url }}"></script>
+<script src="{{ resources.jquery_url }}"{% if resources.jquery_integrity %} integrity="{{ resources.jquery_integrity }}" crossorigin="anonymous"{% endif %}></script>
 {%- endblock html_head_js_jquery -%}
 {%- block html_head_js_requirejs -%}
-<script src="{{ resources.require_js_url }}"></script>
+<script src="{{ resources.require_js_url }}"{% if resources.require_js_integrity %} integrity="{{ resources.require_js_integrity }}" crossorigin="anonymous"{% endif %}></script>
 {%- endblock html_head_js_requirejs -%}
 {%- block html_head_js_mermaidjs -%}
 <script type="module">
@@ -84,7 +84,7 @@ div#notebook-container{
 {% endblock notebook_css %}
 
 {%- block html_head_js_mathjax -%}
-{{ mathjax(resources.mathjax_url) }}
+{{ mathjax(resources.mathjax_url, resources.mathjax_integrity) }}
 {%- endblock html_head_js_mathjax -%}
 
 {%- block html_head_css -%}

--- a/share/templates/lab/index.html.j2
+++ b/share/templates/lab/index.html.j2
@@ -15,7 +15,7 @@
 
 {%- block html_head_js -%}
 {%- block html_head_js_requirejs -%}
-<script src="{{ resources.require_js_url }}"></script>
+<script src="{{ resources.require_js_url }}"{% if resources.require_js_integrity %} integrity="{{ resources.require_js_integrity }}" crossorigin="anonymous"{% endif %}></script>
 {%- endblock html_head_js_requirejs -%}
 {%- endblock html_head_js -%}
 
@@ -105,7 +105,7 @@ a.anchor-link {
 {% endblock notebook_css %}
 
 {%- block html_head_js_mathjax -%}
-{{ mathjax(resources.mathjax_url) }}
+{{ mathjax(resources.mathjax_url, resources.mathjax_integrity) }}
 {%- endblock html_head_js_mathjax -%}
 
 {%- block html_head_js_mermaidjs -%}

--- a/share/templates/reveal/index.html.j2
+++ b/share/templates/reveal/index.html.j2
@@ -27,10 +27,10 @@
 
 {%- block html_head_js -%}
 {%- block html_head_js_jquery -%}
-<script src="{{ resources.jquery_url }}"></script>
+<script src="{{ resources.jquery_url }}"{% if resources.jquery_integrity %} integrity="{{ resources.jquery_integrity }}" crossorigin="anonymous"{% endif %}></script>
 {%- endblock html_head_js_jquery -%}
 {%- block html_head_js_requirejs -%}
-<script src="{{ resources.require_js_url }}"></script>
+<script src="{{ resources.require_js_url }}"{% if resources.require_js_integrity %} integrity="{{ resources.require_js_integrity }}" crossorigin="anonymous"{% endif %}></script>
 {%- endblock html_head_js_requirejs -%}
 {%- block html_head_js_mermaidjs -%}
 <script type="module">
@@ -100,7 +100,7 @@ a.anchor-link {
 {% endblock notebook_css %}
 
 {%- block html_head_js_mathjax -%}
-{{ mathjax(resources.mathjax_url) }}
+{{ mathjax(resources.mathjax_url, resources.mathjax_integrity) }}
 {%- endblock html_head_js_mathjax -%}
 
 {%- block html_head_css -%}

--- a/tests/exporters/test_html.py
+++ b/tests/exporters/test_html.py
@@ -52,6 +52,28 @@ class TestHTMLExporter(ExportersTestsBase):
         (output, _resources) = HTMLExporter(template_name="lab").from_filename(self._get_notebook())
         assert len(output) > 0
 
+    def test_cdn_scripts_include_subresource_integrity(self):
+        """Built-in CDN scripts should be protected by SRI attributes."""
+        output, _resources = HTMLExporter(template_name="classic").from_notebook_node(
+            v4.new_notebook()
+        )
+
+        for integrity in (
+            HTMLExporter._default_jquery_integrity,
+            HTMLExporter._default_require_js_integrity,
+            HTMLExporter._default_mathjax_integrity,
+        ):
+            assert f'integrity="{integrity}"' in output
+        assert 'crossorigin="anonymous"' in output
+
+    def test_custom_cdn_url_does_not_reuse_default_integrity(self):
+        """Changing a CDN URL should not leave an invalid default hash behind."""
+        output, _resources = HTMLExporter(
+            template_name="classic", require_js_url="https://example.com/require.js"
+        ).from_notebook_node(v4.new_notebook())
+
+        assert 'src="https://example.com/require.js" integrity=' not in output
+
     def test_prompt_number(self):
         """
         Does HTMLExporter properly format input and output prompts?

--- a/tests/exporters/test_qtpng.py
+++ b/tests/exporters/test_qtpng.py
@@ -13,6 +13,15 @@ from nbconvert.exporters.qtpng import QtPNGExporter
 from .base import ExportersTestsBase
 
 
+def test_qt_exporter_skips_cdn_integrity_for_local_rendering():
+    """Qt exporters must keep CDN scripts compatible with file:// URLs."""
+    resources = QtPNGExporter()._init_resources({})
+
+    assert resources["require_js_integrity"] == ""
+    assert resources["mathjax_integrity"] == ""
+    assert resources["jquery_integrity"] == ""
+
+
 @pytest.mark.skipif(not QT_INSTALLED, reason="PyQtWebEngine not installed")
 class TestQtPNGExporter(ExportersTestsBase):
     """Contains test functions for qtpng.py"""


### PR DESCRIPTION
Fixes #761

## Summary
- add SHA-256 SRI hashes to the built-in jQuery, RequireJS, and MathJax CDN scripts
- add `crossorigin="anonymous"` to SRI-protected scripts
- preserve custom CDN URLs without applying hashes for a different resource
- add HTML exporter regression coverage

## Validation
- `pytest tests/exporters/test_html.py tests/preprocessors/test_extractoutput.py`