### PR TITLE
Do not copy an unrecognized code fence language into the rendered output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/nbconvert/filters/markdown_mistune.py
+++ b/nbconvert/filters/markdown_mistune.py
@@ -323,7 +323,9 @@ class IPythonRenderer(HTMLRenderer):
                     lang = info.strip().split(maxsplit=1)[0]
                     lexer = get_lexer_by_name(lang, **self.lexer_options)
             except ClassNotFound:
-                code = f"{lang}\n{code}"
+                # Pygments has no lexer for this info string. Fall back to an
+                # unhighlighted block; mistune keeps the info string in the
+                # ``language-`` class, so it must not be added to the code.
                 lang = None
 
         if not lang:

--- a/tests/filters/test_markdown.py
+++ b/tests/filters/test_markdown.py
@@ -253,6 +253,14 @@ i.e. the $i^{th}$""",
 
         self._try_markdown(markdown2html, case, output_check)
 
+    def test_markdown2html_unknown_language(self):
+        """An info string Pygments cannot resolve is not copied into the code"""
+        for info in ["plaintext", "{python}", "unknownlang extra"]:
+            case = f"```{info}\nx = 1\n```"
+            results = markdown2html(case)
+            self.assertIn("<code", results)
+            self.assertIn(">x = 1\n</code>", results)
+
     def _try_markdown(self, method, test, tokens):
         results = method(test)
         if isinstance(tokens, (str,)):


### PR DESCRIPTION
A fenced code block in a markdown cell whose info string is not a Pygments lexer name has that info string prepended to the code as an extra first line.

```plaintext
hello world
```

renders as `<pre><code class="language-plaintext">plaintext\nhello world\n</code></pre>`. The word `plaintext` shows up twice: once in the class, once as the first line of the code. `jsonc` and Quarto's `{python}` and `{r}` hit the same path.

`IPythonRenderer.block_code` does `code = f"{lang}\n{code}"` when `get_lexer_by_name` raises `ClassNotFound`. That dates back to the first mistune renderer, when the fallback called `super().block_code(code, None)` and the info string was dropped. Since the mistune v3 port it passes `info=info` through, and mistune 2 and 3 both put the info string in the `language-` class, so the code no longer has to carry it. `_pygments_highlight` already handles the same `ClassNotFound` by falling back to plain text without touching the source.

One line removed, plus a regression test.

🤖🤖