### PR TITLE
Add --embed-images support to Markdown exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/nbconvert/exporters/markdown.py
+++ b/nbconvert/exporters/markdown.py
@@ -3,7 +3,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from traitlets import default
+from traitlets import Bool, default
 from traitlets.config import Config
 
 from .templateexporter import TemplateExporter
@@ -26,9 +26,20 @@ class MarkdownExporter(TemplateExporter):
 
     output_mimetype = "text/markdown"
 
+    embed_images = Bool(
+        False, help="Whether or not to embed images as base64 in Markdown output."
+    ).tag(config=True)
+
     @default("raw_mimetypes")
     def _raw_mimetypes_default(self):
         return ["text/markdown", "text/html", ""]
+
+    def from_notebook_node(self, nb, resources=None, **kw):
+        """Convert a notebook, optionally embedding extracted images."""
+        if resources is None:
+            resources = {}
+        resources["embed_images"] = self.embed_images
+        return super().from_notebook_node(nb, resources, **kw)
 
     @property
     def default_config(self):

--- a/nbconvert/nbconvertapp.py
+++ b/nbconvert/nbconvertapp.py
@@ -174,9 +174,12 @@ nbconvert_flags.update(
             {
                 "HTMLExporter": {
                     "embed_images": True,
-                }
+                },
+                "MarkdownExporter": {
+                    "embed_images": True,
+                },
             },
-            """Embed the images as base64 dataurls in the output. This flag is only useful for the HTML/WebPDF/Slides exports.""",
+            """Embed the images as base64 dataurls in the output. This flag is only useful for the HTML/Markdown/WebPDF/Slides exports.""",
         ),
         "sanitize-html": (
             {

--- a/share/templates/markdown/index.md.j2
+++ b/share/templates/markdown/index.md.j2
@@ -38,15 +38,15 @@
 {% endblock stream %}
 
 {% block data_svg %}
-    {% if "filenames" in output.metadata %}
+    {% if "filenames" in output.metadata and not resources.get("embed_images", False) %}
 ![svg]({{ output.metadata.filenames['image/svg+xml'] | path2url }})
     {% else %}
-![svg](data:image/svg;base64,{{ output.data['image/svg+xml'] }})
+![svg](data:image/svg+xml;base64,{{ output.data['image/svg+xml'] | text_base64 }})
     {% endif %}
 {% endblock data_svg %}
 
 {% block data_png %}
-    {% if "filenames" in output.metadata %}
+    {% if "filenames" in output.metadata and not resources.get("embed_images", False) %}
 ![png]({{ output.metadata.filenames['image/png'] | path2url }})
     {% else %}
 ![png](data:image/png;base64,{{ output.data['image/png'] }})
@@ -54,7 +54,7 @@
 {% endblock data_png %}
 
 {% block data_jpg %}
-    {% if "filenames" in output.metadata %}
+    {% if "filenames" in output.metadata and not resources.get("embed_images", False) %}
 ![jpeg]({{ output.metadata.filenames['image/jpeg'] | path2url }})
     {% else %}
 ![jpeg](data:image/jpeg;base64,{{ output.data['image/jpeg'] }})

--- a/tests/exporters/test_markdown.py
+++ b/tests/exporters/test_markdown.py
@@ -47,6 +47,7 @@ class TestMarkdownExporter(ExportersTestsBase):
     def test_embed_images(self):
         """Embed extracted image outputs when requested."""
         image = base64.b64encode(b"test image").decode("ascii")
+        svg = "<svg xmlns='http://www.w3.org/2000/svg'><rect width='1' height='1'/></svg>"
         notebook = v4.new_notebook(
             cells=[
                 v4.new_code_cell(
@@ -56,12 +57,22 @@ class TestMarkdownExporter(ExportersTestsBase):
                             data={"image/png": image},
                         )
                     ]
-                )
+                ),
+                v4.new_code_cell(
+                    outputs=[
+                        v4.new_output(
+                            "display_data",
+                            data={"image/svg+xml": svg},
+                        )
+                    ]
+                ),
             ]
         )
 
         output, resources = MarkdownExporter(embed_images=True).from_notebook_node(notebook)
 
         assert "![png](data:image/png;base64," + image + ")" in output
+        svg64 = base64.b64encode(svg.encode("utf-8")).decode("ascii")
+        assert "![svg](data:image/svg+xml;base64," + svg64 + ")" in output
         assert resources["embed_images"] is True
         assert "output_0_0.png" not in output

--- a/tests/exporters/test_markdown.py
+++ b/tests/exporters/test_markdown.py
@@ -12,6 +12,10 @@
 # Imports
 # -----------------------------------------------------------------------------
 
+import base64
+
+from nbformat import v4
+
 from nbconvert.exporters.markdown import MarkdownExporter
 
 from .base import ExportersTestsBase
@@ -39,3 +43,25 @@ class TestMarkdownExporter(ExportersTestsBase):
         """
         (output, _resources) = MarkdownExporter().from_filename(self._get_notebook())
         assert len(output) > 0
+
+    def test_embed_images(self):
+        """Embed extracted image outputs when requested."""
+        image = base64.b64encode(b"test image").decode("ascii")
+        notebook = v4.new_notebook(
+            cells=[
+                v4.new_code_cell(
+                    outputs=[
+                        v4.new_output(
+                            "display_data",
+                            data={"image/png": image},
+                        )
+                    ]
+                )
+            ]
+        )
+
+        output, resources = MarkdownExporter(embed_images=True).from_notebook_node(notebook)
+
+        assert "![png](data:image/png;base64," + image + ")" in output
+        assert resources["embed_images"] is True
+        assert "output_0_0.png" not in output


### PR DESCRIPTION
## Summary

- add `MarkdownExporter.embed_images` support for display image outputs
- wire `--embed-images` to Markdown exports
- keep extracted image paths for the default output while emitting PNG, JPEG, and SVG data URLs when embedding is enabled

Fixes #2314

## Validation

- `python -m pytest -q tests/exporters/test_markdown.py tests/test_nbconvertapp.py -k "embed_images or MarkdownExporter" --disable-warnings`
- `pre-commit run --files nbconvert/exporters/markdown.py nbconvert/nbconvertapp.py share/templates/markdown/index.md.j2 tests/exporters/test_markdown.py`
- smoke-tested `jupyter nbconvert --to markdown --embed-images` with a notebook containing a PNG display output