### PR TITLE
Define LaTeX counter none for pandoc captionless tables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,6 +1705,7 @@ raw template
 {%- endblock in_prompt -%}
     """
 
+
 exporter_attr = AttrExporter()
 output_attr, _ = exporter_attr.from_notebook_node(nb)
 assert "raw template" in output_attr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a security release, fixing two CVEs:
 
 ### Enhancements made
 
-- Allow configureable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
+- Allow configurable WebPDF JavaScript processing timeout [#2250](https://github.com/jupyter/nbconvert/pull/2250) ([@timkpaine](https://github.com/timkpaine), [@Carreau](https://github.com/Carreau))
 
 ### Bugs fixed
 

--- a/share/templates/latex/base.tex.j2
+++ b/share/templates/latex/base.tex.j2
@@ -88,6 +88,7 @@ override this.-=))
     \usepackage{booktabs}  % table support for pandoc > 1.12.2
     \usepackage{array}     % table support for pandoc >= 2.11.3
     \usepackage{calc}      % table minipage width calculation for pandoc >= 2.11.1
+    \newcounter{none} % for pandoc unnumbered longtables (\LTcaptype{none})
     \usepackage[inline]{enumitem} % IRkernel/repr support (it uses the enumerate* environment)
     \usepackage[normalem]{ulem} % ulem is needed to support strikethroughs (\sout)
                                 % normalem makes italics be italics, not underlines

--- a/tests/exporters/test_latex.py
+++ b/tests/exporters/test_latex.py
@@ -41,6 +41,24 @@ class TestLatexExporter(ExportersTestsBase):
         assert len(output) > 0
 
     @onlyif_cmds_exist("pandoc")
+    def test_captionless_markdown_table_defines_none_counter(self):
+        """
+        Pandoc emits \\def\\LTcaptype{none} for captionless tables. The latex
+        template must define that counter (same as pandoc's common.latex).
+        """
+        table = textwrap.dedent(
+            """\
+            | Name | Value |
+            | --- | --- |
+            | a | 1 |
+            """
+        )
+        nb = v4.new_notebook(cells=[v4.new_markdown_cell(source=table)])
+        (output, _resources) = LatexExporter().from_notebook_node(nb)
+        assert r"\newcounter{none}" in output
+        assert r"\LTcaptype{none}" in output
+
+    @onlyif_cmds_exist("pandoc")
     def test_export_book(self):
         """
         Can a LatexExporter export using 'report' template?

--- a/tests/exporters/test_pdf.py
+++ b/tests/exporters/test_pdf.py
@@ -5,7 +5,10 @@
 
 import os
 import shutil
+import textwrap
 from tempfile import TemporaryDirectory
+
+from nbformat import v4, write
 
 from nbconvert.exporters.pdf import PDFExporter
 from nbconvert.utils import _contextlib_chdir
@@ -41,6 +44,32 @@ class TestPDF(ExportersTestsBase):
             assert len(output) > 0
             # all temporary file should be cleaned up
             assert {file_name} == set(os.listdir(td))
+
+    @onlyif_cmds_exist("xelatex", "pandoc")
+    def test_captionless_markdown_table(self):
+        """
+        Captionless Markdown tables must PDF-build with modern pandoc/longtable.
+
+        Pandoc sets \\LTcaptype to none; without \\newcounter{none} in the
+        template, xelatex fails with ``No counter 'none' defined``.
+        """
+        table = textwrap.dedent(
+            """\
+            | Name | Value |
+            | --- | --- |
+            | a | 1 |
+            """
+        )
+        nb = v4.new_notebook(cells=[v4.new_markdown_cell(source=table)])
+        with TemporaryDirectory() as td:
+            nbfile = os.path.join(td, "captionless_table.ipynb")
+            with open(nbfile, "w", encoding="utf-8") as f:
+                write(nb, f, 4)
+            (output, _resources) = self.exporter_class(latex_count=1).from_filename(  # type:ignore
+                nbfile
+            )
+            self.assertIsInstance(output, bytes)
+            assert len(output) > 0
 
     @onlyif_cmds_exist("xelatex", "pandoc")
     def test_texinputs(self):


### PR DESCRIPTION
I asked Cursor to write this PR, but I've checked it, and it's very short, it looks reasonable to me, and I don't think it could reasonably raise copyright concerns.

Cursor's text follows:

Pandoc >= 3.8.2.1 emits \def\LTcaptype{none} for unnumbered longtables and
defines \newcounter{none} in its default template. Without the same line,
nbconvert PDF export fails with "No counter 'none' defined".

Fixes jupyter/nbconvert#2254
Fixes jupyter/nbconvert#2243

Assisted-by: Cursor:Composer
